### PR TITLE
Default fresh installs to English

### DIFF
--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -6915,7 +6915,7 @@
                 restored_parts:'Restauré : ',
             }
         };
-        let currentLang = 'zh';
+        let currentLang = 'en';
         function i18n(key, ...args) {
             const dict = I18N[currentLang] || I18N.zh;
             let text = dict[key] || I18N.zh[key] || key;


### PR DESCRIPTION
## Summary

- Default the interface language to English when `mathreader_lang` is absent or invalid.
- Continue honoring existing valid stored language preferences.

## Why

Fresh installs currently start from the hard-coded Chinese default before the local storage override runs. English should be the fallback when no language preference exists.

## Validation

- Targeted language bootstrap check: missing or invalid storage resolves to English; stored Chinese and French preferences remain unchanged.
- Targeted inline application script parse test passed.
- `git diff --check` passed.
