### PR TITLE
Fix R2 pull refresh and startup restore

### DIFF
--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -13553,8 +13553,10 @@
             const intervalMinutes = parseInt(config.syncInterval) || 15;
             const intervalMs = intervalMinutes * 60 * 1000;
             
-            r2AutoSyncTimer = setInterval(async () => {
-                await performAutoSync();
+            r2AutoSyncTimer = setInterval(() => {
+                performAutoSync().catch(err => {
+                    console.warn('R2 定时同步失败:', err);
+                });
             }, intervalMs);
             
             console.log('R2 自动同步已启动，间隔: ' + intervalMinutes + ' 分钟');
@@ -13586,6 +13588,8 @@
                     const metadataStr = await r2GetObject('metadata.json');
                     if (metadataStr) {
                         const metadata = JSON.parse(metadataStr);
+                        const localR2Config = appData.settings.r2Config;
+                        const localApiSettings = pickApiSettingsFrom(appData.settings);
                         const localBooks = appData.books || [];
                         const localPapers = appData.papers || [];
                         const cloudBooks = metadata.books || [];
@@ -13613,6 +13617,14 @@
                             appData.books = mergeDocsPreferringLocalProgress(cloudBooks, localBooks, cloudSyncedAtMs);
                             appData.papers = mergeDocsPreferringLocalProgress(cloudPapers, localPapers, cloudSyncedAtMs);
                         }
+
+                        // 与启动同步保持一致：下拉刷新也要接收书架之外的云端元数据。
+                        // API 与 R2 凭据仍只保留本地值，绝不从 metadata 覆盖。
+                        appData.notes = mergePreferNonEmpty(metadata.notes, appData.notes);
+                        appData.archived = (metadata.archived && metadata.archived.length > 0)
+                            ? metadata.archived : (appData.archived || []);
+                        appData.lectures = mergePreferNonEmpty(metadata.lectures, appData.lectures);
+                        appData.drafts = mergePreferNonEmpty(metadata.drafts, appData.drafts);
 
                         // 合并 classroom 数据，避免覆盖另一设备新增的素材和笔记；
                         // 云端课堂索引为空而本地非空时保留本地（防止被清空的云端抹掉本地）
@@ -13765,12 +13777,17 @@
                             }
                         }
 
+                        appData.settings = {
+                            ...metadata.settings,
+                            ...localApiSettings,
+                            r2Config: localR2Config
+                        };
                         saveData();
                         refreshAllUIFromAppData();
                     }
                 } catch (e) {
                     console.warn('定时同步：拉取合并失败，跳过本次推送', e);
-                    return;
+                    throw e;
                 }
 
                 // 所有课堂正文先于 metadata 提交，避免其它设备看见悬空索引。
@@ -13942,6 +13959,7 @@
                 console.log('R2 自动同步完成: ' + config.lastSyncTime);
             } catch (err) {
                 console.error('R2 自动同步失败:', err);
+                throw err;
             } finally {
                 r2SyncInProgress = false;
                 // 检查是否有排队的文件变更同步任务
@@ -15971,8 +15989,7 @@
 
         async function autoSyncFromR2OnStartup() {
             const config = appData.settings && appData.settings.r2Config;
-            if (!config || !config.accessKeyId ||
-                (!config.autoSyncEnabled && !config.autoSyncOnChange)) {
+            if (!config || !config.accessKeyId) {
                 finishR2StartupMetadataSync();
                 return;
             }

--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -15981,6 +15981,7 @@
                 return;
             }
             r2SyncInProgress = true;
+            let ownsR2SyncLock = true;
             try {
                 const metadataStr = await r2GetObjectWithTimeout('metadata.json', 5000);
                 if (!metadataStr) {
@@ -16127,6 +16128,15 @@
                     r2LastSyncTime = metadata.syncedAt || config.lastSyncTime;
                 }
                 finishR2StartupMetadataSync();
+
+                // 元数据合并完成后立即释放同步锁。后续资源恢复在后台继续，
+                // 不能阻塞上传书籍、生成讲义等变更同步及其成功提示。
+                r2SyncInProgress = false;
+                ownsR2SyncLock = false;
+                if (r2PendingSyncQueue.length > 0) {
+                    const pending = r2PendingSyncQueue.shift();
+                    triggerSyncOnFileChange(pending.fileId, pending.action, pending.attempt || 0);
+                }
 
                 // 后台拉取本地缺失的资源文件（只拉本地没有的）
                 let pulledMaterials = 0;
@@ -16303,10 +16313,12 @@
                 console.warn('Startup auto-sync failed:', err);
             } finally {
                 finishR2StartupMetadataSync();
-                r2SyncInProgress = false;
-                if (r2PendingSyncQueue.length > 0) {
-                    const pending = r2PendingSyncQueue.shift();
-                    triggerSyncOnFileChange(pending.fileId, pending.action, pending.attempt || 0);
+                if (ownsR2SyncLock) {
+                    r2SyncInProgress = false;
+                    if (r2PendingSyncQueue.length > 0) {
+                        const pending = r2PendingSyncQueue.shift();
+                        triggerSyncOnFileChange(pending.fileId, pending.action, pending.attempt || 0);
+                    }
                 }
             }
         }

--- a/docs/index.html
+++ b/docs/index.html
@@ -13553,8 +13553,10 @@
             const intervalMinutes = parseInt(config.syncInterval) || 15;
             const intervalMs = intervalMinutes * 60 * 1000;
             
-            r2AutoSyncTimer = setInterval(async () => {
-                await performAutoSync();
+            r2AutoSyncTimer = setInterval(() => {
+                performAutoSync().catch(err => {
+                    console.warn('R2 定时同步失败:', err);
+                });
             }, intervalMs);
             
             console.log('R2 自动同步已启动，间隔: ' + intervalMinutes + ' 分钟');
@@ -13586,6 +13588,8 @@
                     const metadataStr = await r2GetObject('metadata.json');
                     if (metadataStr) {
                         const metadata = JSON.parse(metadataStr);
+                        const localR2Config = appData.settings.r2Config;
+                        const localApiSettings = pickApiSettingsFrom(appData.settings);
                         const localBooks = appData.books || [];
                         const localPapers = appData.papers || [];
                         const cloudBooks = metadata.books || [];
@@ -13613,6 +13617,14 @@
                             appData.books = mergeDocsPreferringLocalProgress(cloudBooks, localBooks, cloudSyncedAtMs);
                             appData.papers = mergeDocsPreferringLocalProgress(cloudPapers, localPapers, cloudSyncedAtMs);
                         }
+
+                        // 与启动同步保持一致：下拉刷新也要接收书架之外的云端元数据。
+                        // API 与 R2 凭据仍只保留本地值，绝不从 metadata 覆盖。
+                        appData.notes = mergePreferNonEmpty(metadata.notes, appData.notes);
+                        appData.archived = (metadata.archived && metadata.archived.length > 0)
+                            ? metadata.archived : (appData.archived || []);
+                        appData.lectures = mergePreferNonEmpty(metadata.lectures, appData.lectures);
+                        appData.drafts = mergePreferNonEmpty(metadata.drafts, appData.drafts);
 
                         // 合并 classroom 数据，避免覆盖另一设备新增的素材和笔记；
                         // 云端课堂索引为空而本地非空时保留本地（防止被清空的云端抹掉本地）
@@ -13765,12 +13777,17 @@
                             }
                         }
 
+                        appData.settings = {
+                            ...metadata.settings,
+                            ...localApiSettings,
+                            r2Config: localR2Config
+                        };
                         saveData();
                         refreshAllUIFromAppData();
                     }
                 } catch (e) {
                     console.warn('定时同步：拉取合并失败，跳过本次推送', e);
-                    return;
+                    throw e;
                 }
 
                 // 所有课堂正文先于 metadata 提交，避免其它设备看见悬空索引。
@@ -13942,6 +13959,7 @@
                 console.log('R2 自动同步完成: ' + config.lastSyncTime);
             } catch (err) {
                 console.error('R2 自动同步失败:', err);
+                throw err;
             } finally {
                 r2SyncInProgress = false;
                 // 检查是否有排队的文件变更同步任务
@@ -15971,8 +15989,7 @@
 
         async function autoSyncFromR2OnStartup() {
             const config = appData.settings && appData.settings.r2Config;
-            if (!config || !config.accessKeyId ||
-                (!config.autoSyncEnabled && !config.autoSyncOnChange)) {
+            if (!config || !config.accessKeyId) {
                 finishR2StartupMetadataSync();
                 return;
             }

--- a/docs/index.html
+++ b/docs/index.html
@@ -15981,6 +15981,7 @@
                 return;
             }
             r2SyncInProgress = true;
+            let ownsR2SyncLock = true;
             try {
                 const metadataStr = await r2GetObjectWithTimeout('metadata.json', 5000);
                 if (!metadataStr) {
@@ -16127,6 +16128,15 @@
                     r2LastSyncTime = metadata.syncedAt || config.lastSyncTime;
                 }
                 finishR2StartupMetadataSync();
+
+                // 元数据合并完成后立即释放同步锁。后续资源恢复在后台继续，
+                // 不能阻塞上传书籍、生成讲义等变更同步及其成功提示。
+                r2SyncInProgress = false;
+                ownsR2SyncLock = false;
+                if (r2PendingSyncQueue.length > 0) {
+                    const pending = r2PendingSyncQueue.shift();
+                    triggerSyncOnFileChange(pending.fileId, pending.action, pending.attempt || 0);
+                }
 
                 // 后台拉取本地缺失的资源文件（只拉本地没有的）
                 let pulledMaterials = 0;
@@ -16303,10 +16313,12 @@
                 console.warn('Startup auto-sync failed:', err);
             } finally {
                 finishR2StartupMetadataSync();
-                r2SyncInProgress = false;
-                if (r2PendingSyncQueue.length > 0) {
-                    const pending = r2PendingSyncQueue.shift();
-                    triggerSyncOnFileChange(pending.fileId, pending.action, pending.attempt || 0);
+                if (ownsR2SyncLock) {
+                    r2SyncInProgress = false;
+                    if (r2PendingSyncQueue.length > 0) {
+                        const pending = r2PendingSyncQueue.shift();
+                        triggerSyncOnFileChange(pending.fileId, pending.action, pending.attempt || 0);
+                    }
                 }
             }
         }


### PR DESCRIPTION
## 改动

- R2 已配置时，PWA 每次启动都会拉取云端元数据，不再依赖两个自动同步开关。
- 启动元数据合并并刷新界面后立即释放全局 R2 同步锁；讲义、习题、课堂素材和笔记资源继续在后台恢复。
- 书架/讲义下拉刷新现在也合并云端 `notes`、`archived`、`lectures`、`drafts` 和设置，同时保留仅限本地的 API 配置与 R2 凭据。
- 下拉同步失败会传递到现有错误提示，不再吞掉异常后误报“同步成功”。
- 定时同步显式捕获并记录异常，避免未处理的 Promise rejection。

## 根因

设置页的 `syncFromR2()` 会完整采用云端元数据并下载资源；书架与讲义页下拉使用的 `performAutoSync()` 只合并了书籍、论文、课堂、习题和笔记本数据，随后还会把缺少云端讲义状态的本地元数据重新上传。启动路径又受自动同步开关限制，并在所有资源下载完成前一直占用同步锁，因此重新打开 PWA 或紧接着下拉都可能看不到更新。

## 范围

仅修改以下两个保持一致的文件：

- `docs/index.html`
- `app/src/main/assets/www/index.html`

未修改存储格式、R2 请求签名、数据模型、测试、构建配置或其他文件。

## 验证

- PWA 与 APK 两份 `index.html` 字节一致。
- 两份 HTML 的内联 JavaScript 语法解析通过。
- `git diff --check` 通过。
- 已检查实际差异仅限上述两个文件。
- 按仓库规则未运行全量测试或构建。