### PR TITLE
Fix cloud sync not triggering on file operations

### DIFF
--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -13424,7 +13424,8 @@
         async function resumePendingClassroomSync() {
             await r2StartupMetadataReady.catch(() => {});
             const config = appData.settings?.r2Config;
-            if (!config?.accessKeyId || !config.autoSyncOnChange) return;
+            if (!config?.accessKeyId ||
+                (!config.autoSyncEnabled && !config.autoSyncOnChange)) return;
             const tasks = [];
             const seen = new Set();
             const add = (fileId, action) => {
@@ -14473,7 +14474,7 @@
             const next = previous.catch(() => {}).then(async () => {
                 const config = appData.settings && appData.settings.r2Config;
                 if (!appDataLoaded || !notebookId || !config || !config.accessKeyId ||
-                    !config.autoSyncOnChange) return;
+                    (!config.autoSyncEnabled && !config.autoSyncOnChange)) return;
                 let nb = (appData.notebooks?.items || []).find(item => item && item.id === notebookId);
                 if (!nb || !nb.lastOpenedPageId || !r2NotebookPositionTimestamp(nb)) return;
 
@@ -14516,10 +14517,11 @@
                 return;
             }
             const config = appData.settings.r2Config;
-            if (!config || !config.accessKeyId || !config.autoSyncOnChange) {
+            if (!config || !config.accessKeyId ||
+                (!config.autoSyncEnabled && !config.autoSyncOnChange)) {
                 return;
             }
-            
+
             if (r2SyncInProgress) {
                 // 有同步正在进行，排队等待，完成后自动执行（去重）
                 if (!r2PendingSyncQueue.some(t => t.fileId === fileId && t.action === action)) {
@@ -14703,7 +14705,7 @@
                 const retryableClassroomAction = ['recording_upload', 'classroom_upload',
                     'classroom_note_upload', 'classroom_delete', 'classroom_note_delete',
                     'recording_delete', 'classroom_folder_delete'].includes(action);
-                if (retryableClassroomAction && config.autoSyncOnChange && Number(attempt || 0) < 8) {
+                if (retryableClassroomAction && (config.autoSyncEnabled || config.autoSyncOnChange) && Number(attempt || 0) < 8) {
                     const key = action + ':' + fileId;
                     if (!r2ClassroomRetryTimers.has(key)) {
                         const nextAttempt = Number(attempt || 0) + 1;
@@ -27352,11 +27354,11 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 const cfg = appData.settings && appData.settings.r2Config;
                 for (const pg of (nb.pages || [])) {
                     try { await deleteFileData('nbpage_' + pg.id); } catch (e) {}
-                    if (cfg && cfg.accessKeyId && cfg.autoSyncOnChange) {
+                    if (cfg && cfg.accessKeyId && (cfg.autoSyncEnabled || cfg.autoSyncOnChange)) {
                         try { await r2DeleteObject('notebooks/pages/nbpage_' + pg.id); } catch (e) {}
                     }
                 }
-                if (cfg && cfg.accessKeyId && cfg.autoSyncOnChange) {
+                if (cfg && cfg.accessKeyId && (cfg.autoSyncEnabled || cfg.autoSyncOnChange)) {
                     try { await r2DeleteObject(r2NotebookPositionKey(nbId)); } catch (e) {}
                 }
             })();

--- a/docs/index.html
+++ b/docs/index.html
@@ -13424,7 +13424,8 @@
         async function resumePendingClassroomSync() {
             await r2StartupMetadataReady.catch(() => {});
             const config = appData.settings?.r2Config;
-            if (!config?.accessKeyId || !config.autoSyncOnChange) return;
+            if (!config?.accessKeyId ||
+                (!config.autoSyncEnabled && !config.autoSyncOnChange)) return;
             const tasks = [];
             const seen = new Set();
             const add = (fileId, action) => {
@@ -14473,7 +14474,7 @@
             const next = previous.catch(() => {}).then(async () => {
                 const config = appData.settings && appData.settings.r2Config;
                 if (!appDataLoaded || !notebookId || !config || !config.accessKeyId ||
-                    !config.autoSyncOnChange) return;
+                    (!config.autoSyncEnabled && !config.autoSyncOnChange)) return;
                 let nb = (appData.notebooks?.items || []).find(item => item && item.id === notebookId);
                 if (!nb || !nb.lastOpenedPageId || !r2NotebookPositionTimestamp(nb)) return;
 
@@ -14516,10 +14517,11 @@
                 return;
             }
             const config = appData.settings.r2Config;
-            if (!config || !config.accessKeyId || !config.autoSyncOnChange) {
+            if (!config || !config.accessKeyId ||
+                (!config.autoSyncEnabled && !config.autoSyncOnChange)) {
                 return;
             }
-            
+
             if (r2SyncInProgress) {
                 // 有同步正在进行，排队等待，完成后自动执行（去重）
                 if (!r2PendingSyncQueue.some(t => t.fileId === fileId && t.action === action)) {
@@ -14703,7 +14705,7 @@
                 const retryableClassroomAction = ['recording_upload', 'classroom_upload',
                     'classroom_note_upload', 'classroom_delete', 'classroom_note_delete',
                     'recording_delete', 'classroom_folder_delete'].includes(action);
-                if (retryableClassroomAction && config.autoSyncOnChange && Number(attempt || 0) < 8) {
+                if (retryableClassroomAction && (config.autoSyncEnabled || config.autoSyncOnChange) && Number(attempt || 0) < 8) {
                     const key = action + ':' + fileId;
                     if (!r2ClassroomRetryTimers.has(key)) {
                         const nextAttempt = Number(attempt || 0) + 1;
@@ -27352,11 +27354,11 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 const cfg = appData.settings && appData.settings.r2Config;
                 for (const pg of (nb.pages || [])) {
                     try { await deleteFileData('nbpage_' + pg.id); } catch (e) {}
-                    if (cfg && cfg.accessKeyId && cfg.autoSyncOnChange) {
+                    if (cfg && cfg.accessKeyId && (cfg.autoSyncEnabled || cfg.autoSyncOnChange)) {
                         try { await r2DeleteObject('notebooks/pages/nbpage_' + pg.id); } catch (e) {}
                     }
                 }
-                if (cfg && cfg.accessKeyId && cfg.autoSyncOnChange) {
+                if (cfg && cfg.accessKeyId && (cfg.autoSyncEnabled || cfg.autoSyncOnChange)) {
                     try { await r2DeleteObject(r2NotebookPositionKey(nbId)); } catch (e) {}
                 }
             })();


### PR DESCRIPTION
## Summary

- `triggerSyncOnFileChange` (the function that fires cloud sync on book upload, lecture generation, file deletion, etc.) only checked `autoSyncOnChange`, silently skipping sync when the user had `autoSyncEnabled` (periodic sync) turned on but `autoSyncOnChange` off
- Fixed all 6 inconsistent sync guard checks to accept **either** toggle, matching the existing behavior of `autoSyncFromR2OnStartup` and `r2FetchNotebookPosition` which already accepted both
- Affected functions: `triggerSyncOnFileChange`, `resumePendingClassroomSync`, `r2SyncNotebookPosition`, retry logic, and notebook cloud deletion

## What changed

| Location | Before | After |
|---|---|---|
| `triggerSyncOnFileChange` guard | `!config.autoSyncOnChange` | `!config.autoSyncEnabled && !config.autoSyncOnChange` |
| `resumePendingClassroomSync` guard | `!config.autoSyncOnChange` | `!config.autoSyncEnabled && !config.autoSyncOnChange` |
| `r2SyncNotebookPosition` guard | `!config.autoSyncOnChange` | `!config.autoSyncEnabled && !config.autoSyncOnChange` |
| Classroom retry condition | `config.autoSyncOnChange` | `config.autoSyncEnabled \|\| config.autoSyncOnChange` |
| Notebook page cloud delete | `cfg.autoSyncOnChange` | `cfg.autoSyncEnabled \|\| cfg.autoSyncOnChange` |
| Notebook position cloud delete | `cfg.autoSyncOnChange` | `cfg.autoSyncEnabled \|\| cfg.autoSyncOnChange` |

## Test plan

- [ ] Enable only "自动同步" (autoSyncEnabled), leave "文件变更时自动同步" (autoSyncOnChange) off
- [ ] Upload a book → should trigger cloud sync immediately
- [ ] Generate a lecture → should trigger cloud sync immediately
- [ ] Delete a file → should trigger cloud sync immediately
- [ ] Enable only autoSyncOnChange → verify sync still works as before
- [ ] Disable both toggles → verify no sync fires

---
_Generated by [Claude Code](https://claude.ai/code/session_01S1VpU2ygZ45P6qaECKRY35)_