### PR TITLE
Defer cloud sync while lectures generate

### DIFF
--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -13316,6 +13316,7 @@
         let r2LastSyncTime = null;
         let r2SyncInProgress = false;
         let r2PendingSyncQueue = []; // 排队等待的文件变更同步任务队列
+        let activeLectureGenerationCount = 0;
         const r2ClassroomRetryTimers = new Map();
         let r2StartupMetadataReady = Promise.resolve();
         let _resolveR2StartupMetadataReady = null;
@@ -13565,6 +13566,10 @@
         async function performAutoSync() {
             if (!appDataLoaded) {
                 console.warn('[sync] 数据未加载完成，跳过定时同步');
+                return;
+            }
+            if (activeLectureGenerationCount > 0) {
+                console.log('[sync] 讲义仍在生成，延后定时同步');
                 return;
             }
             const config = appData.settings.r2Config;
@@ -14550,6 +14555,13 @@
             }
             const config = appData.settings.r2Config;
             if (!config || !config.accessKeyId || !config.autoSyncOnChange) {
+                return;
+            }
+
+            if (activeLectureGenerationCount > 0) {
+                if (!r2PendingSyncQueue.some(t => t.fileId === fileId && t.action === action)) {
+                    r2PendingSyncQueue.push({ fileId, action, attempt });
+                }
                 return;
             }
             
@@ -18807,6 +18819,7 @@ ${i18n('prompt_outline_gen')}`;
             book.bookmarksUpdatedAt = Date.now();
             lectureData.status = 'ready';
             saveData();
+            debouncedChatSync();
             showToast(i18n('toast_outline_loaded', lectureData.chapters.length));
             renderNotesPage();
 
@@ -18833,6 +18846,7 @@ ${i18n('prompt_outline_gen')}`;
                 displayLectureContent();
             }
 
+            activeLectureGenerationCount++;
             try {
                 const systemPrompt = i18n('prompt_lecture_sys');
 
@@ -18889,6 +18903,16 @@ ${i18n('prompt_lecture_gen')}`;
                     displayLectureContent();
                 }
                 renderNotesPage();
+            } finally {
+                activeLectureGenerationCount = Math.max(0, activeLectureGenerationCount - 1);
+                if (activeLectureGenerationCount === 0 && !r2SyncInProgress && r2PendingSyncQueue.length > 0) {
+                    const lectureUploadIndex = r2PendingSyncQueue.findIndex(item =>
+                        item.action === 'lecture_upload');
+                    const pending = lectureUploadIndex >= 0
+                        ? r2PendingSyncQueue.splice(lectureUploadIndex, 1)[0]
+                        : r2PendingSyncQueue.shift();
+                    triggerSyncOnFileChange(pending.fileId, pending.action, pending.attempt || 0);
+                }
             }
         }
 

--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -18807,7 +18807,6 @@ ${i18n('prompt_outline_gen')}`;
             book.bookmarksUpdatedAt = Date.now();
             lectureData.status = 'ready';
             saveData();
-            debouncedChatSync();
             showToast(i18n('toast_outline_loaded', lectureData.chapters.length));
             renderNotesPage();
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -13316,6 +13316,7 @@
         let r2LastSyncTime = null;
         let r2SyncInProgress = false;
         let r2PendingSyncQueue = []; // 排队等待的文件变更同步任务队列
+        let activeLectureGenerationCount = 0;
         const r2ClassroomRetryTimers = new Map();
         let r2StartupMetadataReady = Promise.resolve();
         let _resolveR2StartupMetadataReady = null;
@@ -13565,6 +13566,10 @@
         async function performAutoSync() {
             if (!appDataLoaded) {
                 console.warn('[sync] 数据未加载完成，跳过定时同步');
+                return;
+            }
+            if (activeLectureGenerationCount > 0) {
+                console.log('[sync] 讲义仍在生成，延后定时同步');
                 return;
             }
             const config = appData.settings.r2Config;
@@ -14550,6 +14555,13 @@
             }
             const config = appData.settings.r2Config;
             if (!config || !config.accessKeyId || !config.autoSyncOnChange) {
+                return;
+            }
+
+            if (activeLectureGenerationCount > 0) {
+                if (!r2PendingSyncQueue.some(t => t.fileId === fileId && t.action === action)) {
+                    r2PendingSyncQueue.push({ fileId, action, attempt });
+                }
                 return;
             }
             
@@ -18807,6 +18819,7 @@ ${i18n('prompt_outline_gen')}`;
             book.bookmarksUpdatedAt = Date.now();
             lectureData.status = 'ready';
             saveData();
+            debouncedChatSync();
             showToast(i18n('toast_outline_loaded', lectureData.chapters.length));
             renderNotesPage();
 
@@ -18833,6 +18846,7 @@ ${i18n('prompt_outline_gen')}`;
                 displayLectureContent();
             }
 
+            activeLectureGenerationCount++;
             try {
                 const systemPrompt = i18n('prompt_lecture_sys');
 
@@ -18889,6 +18903,16 @@ ${i18n('prompt_lecture_gen')}`;
                     displayLectureContent();
                 }
                 renderNotesPage();
+            } finally {
+                activeLectureGenerationCount = Math.max(0, activeLectureGenerationCount - 1);
+                if (activeLectureGenerationCount === 0 && !r2SyncInProgress && r2PendingSyncQueue.length > 0) {
+                    const lectureUploadIndex = r2PendingSyncQueue.findIndex(item =>
+                        item.action === 'lecture_upload');
+                    const pending = lectureUploadIndex >= 0
+                        ? r2PendingSyncQueue.splice(lectureUploadIndex, 1)[0]
+                        : r2PendingSyncQueue.shift();
+                    triggerSyncOnFileChange(pending.fileId, pending.action, pending.attempt || 0);
+                }
             }
         }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -18807,7 +18807,6 @@ ${i18n('prompt_outline_gen')}`;
             book.bookmarksUpdatedAt = Date.now();
             lectureData.status = 'ready';
             saveData();
-            debouncedChatSync();
             showToast(i18n('toast_outline_loaded', lectureData.chapters.length));
             renderNotesPage();
 


### PR DESCRIPTION
## Summary
- keep the existing lecture metadata sync trigger
- defer scheduled and change-triggered cloud sync while any lecture generation task is active
- release queued sync only after all active lecture generation tasks finish, prioritizing lecture content upload