### PR TITLE
Fix notebook page insertion, first course creation, and large PDF outlines

### DIFF
--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -18827,7 +18827,7 @@
             let uri = fileObj.uri;
             const processingDeadline = Date.now() + 5 * 60 * 1000;
             let pollDelay = 1500;
-            while (fileObj.state && fileObj.state !== 'ACTIVE') {
+            while (fileObj.state !== 'ACTIVE') {
                 if (fileObj.state === 'FAILED') {
                     const detail = fileObj.error?.message || '';
                     throw new Error(i18n('files_api_processing_failed') + (detail ? ': ' + detail : ''));

--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -6953,7 +6953,7 @@
             chat_history_filename:'聊天记录', select_books:'选择书籍', select_papers:'选择论文', progress_label:'进度 {0}%', book_file_missing:'书籍文件不存在', bookmark_page_suffix:'（第 {0} 页）', no_chapter_bookmarks:'暂无章节书签', chapter_bookmarks_hint:'长按书籍可生成讲义与章节书签', page_label:'第 {0} 页', lecture_progress_suffix:' · 讲义 {0}%',
             generating_lecture_content:'正在生成讲义内容…', first_generation_time:'首次生成可能需要几分钟', generation_failed:'生成失败', network_api_retry:'请检查网络或 API 设置后重试', content_load_failed:'内容加载失败', lecture_content_not_found:'未找到讲义内容', lecture_not_generated:'讲义尚未生成', cannot_load_lecture:'无法加载讲义', download_lecture:'下载讲义',
             fetch_models_http_error:'拉取模型失败（HTTP {0}）：{1}', fetch_models_failed:'拉取模型失败', all_apis_failed:'所有 API 均调用失败', configure_api_first:'请先配置 API', api_error:'API 错误（HTTP {0}）：{1}', claude_api_error:'Claude API 错误（HTTP {0}）：{1}', api_url_empty:'API URL 不能为空', select_model_required:'请选择模型', large_recording_requires_gemini:'长录音需要使用 Gemini 模型',
-            files_api_start_failed:'Files API 启动失败', files_api_no_upload_url:'Files API 未返回上传地址', files_api_upload_failed:'Files API 上传失败', files_api_processing_failed:'Files API 处理失败', pdf_text_extraction_failed:'PDF 文本提取失败', attached_pdf_text:'附件 PDF 文本：\n{0}',
+            files_api_start_failed:'Files API 启动失败', files_api_no_upload_url:'Files API 未返回上传地址', files_api_upload_failed:'Files API 上传失败', files_api_processing_failed:'Files API 处理失败', files_api_processing_timeout:'Files API 处理超时', pdf_text_extraction_failed:'PDF 文本提取失败', attached_pdf_text:'附件 PDF 文本：\n{0}',
             data_not_loaded_upload_blocked:'数据尚未安全加载，已阻止上传', cloud_metadata_busy:'云端元数据正在同步，请稍后重试', cloud_metadata_corrupt:'云端元数据损坏', empty_local_cloud_nonempty_blocked:'本地数据为空但云端非空，已阻止覆盖', r2_not_configured:'尚未配置 R2', r2_read_verification_failed:'R2 写入后读取校验失败', cloud_notebook_position_invalid:'云端笔记本位置数据无效', recording_not_committed:'录音尚未完整提交', cloud_metadata_not_committed:'云端元数据未成功提交',
             local_class_material_missing:'本地课堂素材缺失：{0}', class_material_index_changed:'课堂素材索引已变化：{0}', class_note_content_missing:'课堂讲义内容缺失：{0}', class_note_index_changed:'课堂讲义索引已变化：{0}', delete_cloud_class_material_failed:'删除云端课堂素材失败：{0}', delete_cloud_class_note_failed:'删除云端课堂讲义失败：{0}',
             notification_lecture_sync_title:'讲义同步完成', notification_lecture_sync_body:'讲义已同步到云端', notification_abstract_sync_title:'摘要同步完成', notification_abstract_sync_body:'摘要已同步到云端', network_endpoint_cors_error:'网络、Endpoint 或 CORS 配置错误', permission_key_error:'权限或密钥错误', bucket_not_found:'未找到存储桶',
@@ -6972,7 +6972,7 @@
             chat_history_filename:'chat-history', select_books:'Select books', select_papers:'Select papers', progress_label:'Progress {0}%', book_file_missing:'The book file is missing', bookmark_page_suffix:' (page {0})', no_chapter_bookmarks:'No chapter bookmarks', chapter_bookmarks_hint:'Long-press a book to generate lectures and chapter bookmarks', page_label:'Page {0}', lecture_progress_suffix:' · Lecture {0}%',
             generating_lecture_content:'Generating lecture content…', first_generation_time:'The first generation may take a few minutes', generation_failed:'Generation failed', network_api_retry:'Check your network or API settings and try again', content_load_failed:'Failed to load content', lecture_content_not_found:'Lecture content was not found', lecture_not_generated:'This lecture has not been generated', cannot_load_lecture:'Unable to load the lecture', download_lecture:'Download lecture',
             fetch_models_http_error:'Failed to fetch models (HTTP {0}): {1}', fetch_models_failed:'Failed to fetch models', all_apis_failed:'All API attempts failed', configure_api_first:'Configure an API first', api_error:'API error (HTTP {0}): {1}', claude_api_error:'Claude API error (HTTP {0}): {1}', api_url_empty:'API URL cannot be empty', select_model_required:'Select a model', large_recording_requires_gemini:'Long recordings require a Gemini model',
-            files_api_start_failed:'Failed to start the Files API upload', files_api_no_upload_url:'The Files API did not return an upload URL', files_api_upload_failed:'Files API upload failed', files_api_processing_failed:'Files API processing failed', pdf_text_extraction_failed:'Failed to extract PDF text', attached_pdf_text:'Attached PDF text:\n{0}',
+            files_api_start_failed:'Failed to start the Files API upload', files_api_no_upload_url:'The Files API did not return an upload URL', files_api_upload_failed:'Files API upload failed', files_api_processing_failed:'Files API processing failed', files_api_processing_timeout:'Files API processing timed out', pdf_text_extraction_failed:'Failed to extract PDF text', attached_pdf_text:'Attached PDF text:\n{0}',
             data_not_loaded_upload_blocked:'Data has not loaded safely; upload was blocked', cloud_metadata_busy:'Cloud metadata is syncing; try again shortly', cloud_metadata_corrupt:'Cloud metadata is corrupted', empty_local_cloud_nonempty_blocked:'Local data is empty while cloud data is not; overwrite was blocked', r2_not_configured:'R2 is not configured', r2_read_verification_failed:'R2 read-after-write verification failed', cloud_notebook_position_invalid:'Cloud notebook position data is invalid', recording_not_committed:'The recording has not been fully committed', cloud_metadata_not_committed:'Cloud metadata was not committed',
             local_class_material_missing:'Local class material is missing: {0}', class_material_index_changed:'The class material index changed: {0}', class_note_content_missing:'Class lecture content is missing: {0}', class_note_index_changed:'The class lecture index changed: {0}', delete_cloud_class_material_failed:'Failed to delete cloud class material: {0}', delete_cloud_class_note_failed:'Failed to delete cloud class lecture: {0}',
             notification_lecture_sync_title:'Lecture sync complete', notification_lecture_sync_body:'The lecture was synced to the cloud', notification_abstract_sync_title:'Abstract sync complete', notification_abstract_sync_body:'The abstract was synced to the cloud', network_endpoint_cors_error:'Network, endpoint, or CORS configuration error', permission_key_error:'Permission or credential error', bucket_not_found:'Bucket not found',
@@ -6991,7 +6991,7 @@
             chat_history_filename:'historique-discussion', select_books:'Sélectionner des livres', select_papers:'Sélectionner des articles', progress_label:'Progression {0} %', book_file_missing:'Le fichier du livre est introuvable', bookmark_page_suffix:' (page {0})', no_chapter_bookmarks:'Aucun signet de chapitre', chapter_bookmarks_hint:'Appuyez longuement sur un livre pour générer les cours et les signets', page_label:'Page {0}', lecture_progress_suffix:' · Cours {0} %',
             generating_lecture_content:'Génération du cours…', first_generation_time:'La première génération peut prendre quelques minutes', generation_failed:'Échec de la génération', network_api_retry:'Vérifiez le réseau ou les réglages API, puis réessayez', content_load_failed:'Échec du chargement du contenu', lecture_content_not_found:'Contenu du cours introuvable', lecture_not_generated:'Ce cours n’a pas encore été généré', cannot_load_lecture:'Impossible de charger le cours', download_lecture:'Télécharger le cours',
             fetch_models_http_error:'Échec de récupération des modèles (HTTP {0}) : {1}', fetch_models_failed:'Échec de récupération des modèles', all_apis_failed:'Toutes les tentatives API ont échoué', configure_api_first:'Configurez d’abord une API', api_error:'Erreur API (HTTP {0}) : {1}', claude_api_error:'Erreur de l’API Claude (HTTP {0}) : {1}', api_url_empty:"L’URL de l’API ne peut pas être vide", select_model_required:'Sélectionnez un modèle', large_recording_requires_gemini:'Les enregistrements longs nécessitent un modèle Gemini',
-            files_api_start_failed:'Impossible de démarrer le téléversement Files API', files_api_no_upload_url:'Files API n’a renvoyé aucune URL de téléversement', files_api_upload_failed:'Échec du téléversement Files API', files_api_processing_failed:'Échec du traitement Files API', pdf_text_extraction_failed:"Échec de l’extraction du texte du PDF", attached_pdf_text:'Texte du PDF joint :\n{0}',
+            files_api_start_failed:'Impossible de démarrer le téléversement Files API', files_api_no_upload_url:'Files API n’a renvoyé aucune URL de téléversement', files_api_upload_failed:'Échec du téléversement Files API', files_api_processing_failed:'Échec du traitement Files API', files_api_processing_timeout:'Délai de traitement Files API dépassé', pdf_text_extraction_failed:"Échec de l’extraction du texte du PDF", attached_pdf_text:'Texte du PDF joint :\n{0}',
             data_not_loaded_upload_blocked:"Les données ne sont pas chargées de façon sûre ; l’envoi a été bloqué", cloud_metadata_busy:'Les métadonnées cloud sont en cours de synchronisation ; réessayez bientôt', cloud_metadata_corrupt:'Les métadonnées cloud sont corrompues', empty_local_cloud_nonempty_blocked:'Les données locales sont vides mais celles du cloud ne le sont pas ; remplacement bloqué', r2_not_configured:'R2 n’est pas configuré', r2_read_verification_failed:'Échec de la vérification R2 après écriture', cloud_notebook_position_invalid:'La position cloud du carnet est invalide', recording_not_committed:"L’enregistrement n’est pas entièrement validé", cloud_metadata_not_committed:'Les métadonnées cloud n’ont pas été validées',
             local_class_material_missing:'Support de cours local manquant : {0}', class_material_index_changed:"L’index des supports de cours a changé : {0}", class_note_content_missing:'Contenu du cours manquant : {0}', class_note_index_changed:"L’index des cours a changé : {0}", delete_cloud_class_material_failed:'Échec de suppression du support cloud : {0}', delete_cloud_class_note_failed:'Échec de suppression du cours cloud : {0}',
             notification_lecture_sync_title:'Synchronisation du cours terminée', notification_lecture_sync_body:'Le cours a été synchronisé dans le cloud', notification_abstract_sync_title:'Synchronisation du résumé terminée', notification_abstract_sync_body:'Le résumé a été synchronisé dans le cloud', network_endpoint_cors_error:'Erreur de réseau, d’endpoint ou de configuration CORS', permission_key_error:'Erreur d’autorisation ou d’identifiants', bucket_not_found:'Bucket introuvable',
@@ -18748,13 +18748,17 @@
             return null;
         }
 
-        // 构造 Gemini contents，带 PDF。超过 18MB 走 Files API。
+        // 构造 Gemini contents，带 PDF。官方 Gemini 的大文件走 Files API；
+        // 自定义 Gemini 兼容端点通常没有 Files API，50MB 内改用 inline_data。
         async function buildGeminiContentsWithPdf(base, key, messages, pdfAttachment) {
             const bytes = pdfAttachment.bytes;
             const inlineThreshold = 18 * 1024 * 1024; // 18 MB
+            const inlinePdfLimit = 45 * 1024 * 1024; // 给 PDF 50 MB 上限及提示词留余量
+            const officialGeminiEndpoint = /^https:\/\/generativelanguage\.googleapis\.com(?:\/|$)/i.test(base);
             let fileRef = null; // { file_uri, mime_type } for Files API
             let inlineBase64 = null;
-            if (bytes.length <= inlineThreshold) {
+            if (bytes.length <= inlineThreshold ||
+                (!officialGeminiEndpoint && bytes.length <= inlinePdfLimit)) {
                 inlineBase64 = pdfAttachment.base64 || uint8ToBase64(bytes);
             } else {
                 fileRef = await geminiUploadFile(base, key, bytes, 'application/pdf', pdfAttachment.name || 'book.pdf');
@@ -18816,23 +18820,35 @@
                 throw new Error(i18n('files_api_upload_failed', putResp.status, t));
             }
             const info = await putResp.json();
-            // 上传后文件有个 ACTIVE 状态过程，通常 PDF 立即可用，但保险起见轮询一次
-            const fileObj = info.file || info;
+            // 扫描版 PDF 的服务端处理可能明显超过 20 秒；只有 ACTIVE 才能用于推理。
+            let fileObj = info.file || info;
             const name = fileObj.name;
             const mime = fileObj.mimeType || mimeType;
             let uri = fileObj.uri;
-            // 轮询直到 state=ACTIVE
-            if (fileObj.state && fileObj.state !== 'ACTIVE') {
-                for (let i = 0; i < 20; i++) {
-                    await new Promise(r => setTimeout(r, 1000));
-                    const poll = await fetch(base + '/' + name + '?key=' + encodeURIComponent(key));
-                    if (!poll.ok) break;
-                    const pd = await poll.json();
-                    if (pd.state === 'ACTIVE') { uri = pd.uri; break; }
-                    if (pd.state === 'FAILED') throw new Error(i18n('files_api_processing_failed'));
+            const processingDeadline = Date.now() + 5 * 60 * 1000;
+            let pollDelay = 1500;
+            while (fileObj.state && fileObj.state !== 'ACTIVE') {
+                if (fileObj.state === 'FAILED') {
+                    const detail = fileObj.error?.message || '';
+                    throw new Error(i18n('files_api_processing_failed') + (detail ? ': ' + detail : ''));
                 }
+                if (Date.now() >= processingDeadline) {
+                    throw new Error(i18n('files_api_processing_timeout'));
+                }
+                await new Promise(r => setTimeout(r, pollDelay));
+                const poll = await fetch(base + '/' + name + '?key=' + encodeURIComponent(key));
+                if (!poll.ok) {
+                    const detail = await poll.text().catch(() => '');
+                    throw new Error(i18n('files_api_processing_failed') +
+                        ` (${poll.status})` + (detail ? ': ' + detail : ''));
+                }
+                const polled = await poll.json();
+                fileObj = polled.file || polled;
+                uri = fileObj.uri || uri;
+                pollDelay = Math.min(5000, Math.round(pollDelay * 1.35));
             }
-            return { file_uri: uri, mime_type: mime };
+            if (!uri) throw new Error(i18n('files_api_processing_failed'));
+            return { file_uri: uri, mime_type: fileObj.mimeType || mime };
         }
 
         // OpenAI-compatible API call with message history (保留兼容)
@@ -21818,6 +21834,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         // ==================== Classroom ====================
         let currentClassroomFolder = null;   // { type: 'course'|'seminar', folderId }
         let currentClassroomSession = null;  // { type, folderId, sessionId }
+        let classroomFolderCreatePending = false;
 
         function renderClassroomPage() {
             currentClassroomFolder = null;
@@ -21869,21 +21886,29 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             }
         }
 
-        function onClassroomColumnClick(e, type) {
+        async function onClassroomColumnClick(e, type) {
             if (e.target.closest('.classroom-folder')) return;
-            const name = prompt(i18n(type === 'course' ? 'new_course_name_prompt' : 'new_seminar_name_prompt'));
-            if (!name || !name.trim()) return;
-            if (!appData.classroom) appData.classroom = { courses: [], seminars: [] };
-            const list = type === 'course' ? appData.classroom.courses : appData.classroom.seminars;
-            list.push({
-                id: 'cls_' + Date.now() + '_' + Math.random().toString(36).slice(2, 6),
-                name: name.trim(),
-                createdAt: new Date().toISOString(),
-                sessions: []
-            });
-            saveData();
-            debouncedChatSync();
-            renderClassroomPage();
+            if (classroomFolderCreatePending) return;
+            classroomFolderCreatePending = true;
+            try {
+                // 启动云同步会替换课堂 metadata；等合并完成后再落创建操作，避免首次创建被覆盖。
+                await r2StartupMetadataReady.catch(() => {});
+                const name = prompt(i18n(type === 'course' ? 'new_course_name_prompt' : 'new_seminar_name_prompt'));
+                if (!name || !name.trim()) return;
+                if (!appData.classroom) appData.classroom = { courses: [], seminars: [] };
+                const list = type === 'course' ? appData.classroom.courses : appData.classroom.seminars;
+                list.push({
+                    id: 'cls_' + Date.now() + '_' + Math.random().toString(36).slice(2, 6),
+                    name: name.trim(),
+                    createdAt: new Date().toISOString(),
+                    sessions: []
+                });
+                saveData();
+                debouncedChatSync();
+                renderClassroomPage();
+            } finally {
+                classroomFolderCreatePending = false;
+            }
         }
 
         function getClassroomFolder(type, folderId) {
@@ -29295,14 +29320,23 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 </div>`;
         }
         async function nbInsertPage(after) {
-            const nb = nbCurrentNotebook();
-            if (!nb) return;
+            const notebookId = nbState.notebookId;
+            const anchorPageId = nbCurrentPage()?.id;
+            if (!notebookId || !anchorPageId) return;
             await nbSavePageNow();
+            const nb = nbGetNotebook(notebookId);
+            if (!nb || nbState.notebookId !== notebookId) return;
+            const anchorIndex = (nb.pages || []).findIndex(page => page?.id === anchorPageId);
+            if (anchorIndex < 0) {
+                showToast(i18n('page_deleted'));
+                return;
+            }
             const sel = document.getElementById('nbNewPageTpl');
-            const tpl = (!sel || sel.value === '__cur__') ? (nbCurrentPage().template || 'blank') : sel.value;
+            const anchorPage = nb.pages[anchorIndex];
+            const tpl = (!sel || sel.value === '__cur__') ? (anchorPage.template || 'blank') : sel.value;
             const now = new Date().toISOString();
             const page = { id: nbUid('nbp'), template: tpl, createdAt: now, updatedAt: now };
-            const at = nbState.pageIndex + (after ? 1 : 0);
+            const at = anchorIndex + (after ? 1 : 0);
             nb.pages.splice(at, 0, page);
             nbTouch(nb);
             saveData();

--- a/docs/index.html
+++ b/docs/index.html
@@ -18827,7 +18827,7 @@
             let uri = fileObj.uri;
             const processingDeadline = Date.now() + 5 * 60 * 1000;
             let pollDelay = 1500;
-            while (fileObj.state && fileObj.state !== 'ACTIVE') {
+            while (fileObj.state !== 'ACTIVE') {
                 if (fileObj.state === 'FAILED') {
                     const detail = fileObj.error?.message || '';
                     throw new Error(i18n('files_api_processing_failed') + (detail ? ': ' + detail : ''));

--- a/docs/index.html
+++ b/docs/index.html
@@ -6953,7 +6953,7 @@
             chat_history_filename:'聊天记录', select_books:'选择书籍', select_papers:'选择论文', progress_label:'进度 {0}%', book_file_missing:'书籍文件不存在', bookmark_page_suffix:'（第 {0} 页）', no_chapter_bookmarks:'暂无章节书签', chapter_bookmarks_hint:'长按书籍可生成讲义与章节书签', page_label:'第 {0} 页', lecture_progress_suffix:' · 讲义 {0}%',
             generating_lecture_content:'正在生成讲义内容…', first_generation_time:'首次生成可能需要几分钟', generation_failed:'生成失败', network_api_retry:'请检查网络或 API 设置后重试', content_load_failed:'内容加载失败', lecture_content_not_found:'未找到讲义内容', lecture_not_generated:'讲义尚未生成', cannot_load_lecture:'无法加载讲义', download_lecture:'下载讲义',
             fetch_models_http_error:'拉取模型失败（HTTP {0}）：{1}', fetch_models_failed:'拉取模型失败', all_apis_failed:'所有 API 均调用失败', configure_api_first:'请先配置 API', api_error:'API 错误（HTTP {0}）：{1}', claude_api_error:'Claude API 错误（HTTP {0}）：{1}', api_url_empty:'API URL 不能为空', select_model_required:'请选择模型', large_recording_requires_gemini:'长录音需要使用 Gemini 模型',
-            files_api_start_failed:'Files API 启动失败', files_api_no_upload_url:'Files API 未返回上传地址', files_api_upload_failed:'Files API 上传失败', files_api_processing_failed:'Files API 处理失败', pdf_text_extraction_failed:'PDF 文本提取失败', attached_pdf_text:'附件 PDF 文本：\n{0}',
+            files_api_start_failed:'Files API 启动失败', files_api_no_upload_url:'Files API 未返回上传地址', files_api_upload_failed:'Files API 上传失败', files_api_processing_failed:'Files API 处理失败', files_api_processing_timeout:'Files API 处理超时', pdf_text_extraction_failed:'PDF 文本提取失败', attached_pdf_text:'附件 PDF 文本：\n{0}',
             data_not_loaded_upload_blocked:'数据尚未安全加载，已阻止上传', cloud_metadata_busy:'云端元数据正在同步，请稍后重试', cloud_metadata_corrupt:'云端元数据损坏', empty_local_cloud_nonempty_blocked:'本地数据为空但云端非空，已阻止覆盖', r2_not_configured:'尚未配置 R2', r2_read_verification_failed:'R2 写入后读取校验失败', cloud_notebook_position_invalid:'云端笔记本位置数据无效', recording_not_committed:'录音尚未完整提交', cloud_metadata_not_committed:'云端元数据未成功提交',
             local_class_material_missing:'本地课堂素材缺失：{0}', class_material_index_changed:'课堂素材索引已变化：{0}', class_note_content_missing:'课堂讲义内容缺失：{0}', class_note_index_changed:'课堂讲义索引已变化：{0}', delete_cloud_class_material_failed:'删除云端课堂素材失败：{0}', delete_cloud_class_note_failed:'删除云端课堂讲义失败：{0}',
             notification_lecture_sync_title:'讲义同步完成', notification_lecture_sync_body:'讲义已同步到云端', notification_abstract_sync_title:'摘要同步完成', notification_abstract_sync_body:'摘要已同步到云端', network_endpoint_cors_error:'网络、Endpoint 或 CORS 配置错误', permission_key_error:'权限或密钥错误', bucket_not_found:'未找到存储桶',
@@ -6972,7 +6972,7 @@
             chat_history_filename:'chat-history', select_books:'Select books', select_papers:'Select papers', progress_label:'Progress {0}%', book_file_missing:'The book file is missing', bookmark_page_suffix:' (page {0})', no_chapter_bookmarks:'No chapter bookmarks', chapter_bookmarks_hint:'Long-press a book to generate lectures and chapter bookmarks', page_label:'Page {0}', lecture_progress_suffix:' · Lecture {0}%',
             generating_lecture_content:'Generating lecture content…', first_generation_time:'The first generation may take a few minutes', generation_failed:'Generation failed', network_api_retry:'Check your network or API settings and try again', content_load_failed:'Failed to load content', lecture_content_not_found:'Lecture content was not found', lecture_not_generated:'This lecture has not been generated', cannot_load_lecture:'Unable to load the lecture', download_lecture:'Download lecture',
             fetch_models_http_error:'Failed to fetch models (HTTP {0}): {1}', fetch_models_failed:'Failed to fetch models', all_apis_failed:'All API attempts failed', configure_api_first:'Configure an API first', api_error:'API error (HTTP {0}): {1}', claude_api_error:'Claude API error (HTTP {0}): {1}', api_url_empty:'API URL cannot be empty', select_model_required:'Select a model', large_recording_requires_gemini:'Long recordings require a Gemini model',
-            files_api_start_failed:'Failed to start the Files API upload', files_api_no_upload_url:'The Files API did not return an upload URL', files_api_upload_failed:'Files API upload failed', files_api_processing_failed:'Files API processing failed', pdf_text_extraction_failed:'Failed to extract PDF text', attached_pdf_text:'Attached PDF text:\n{0}',
+            files_api_start_failed:'Failed to start the Files API upload', files_api_no_upload_url:'The Files API did not return an upload URL', files_api_upload_failed:'Files API upload failed', files_api_processing_failed:'Files API processing failed', files_api_processing_timeout:'Files API processing timed out', pdf_text_extraction_failed:'Failed to extract PDF text', attached_pdf_text:'Attached PDF text:\n{0}',
             data_not_loaded_upload_blocked:'Data has not loaded safely; upload was blocked', cloud_metadata_busy:'Cloud metadata is syncing; try again shortly', cloud_metadata_corrupt:'Cloud metadata is corrupted', empty_local_cloud_nonempty_blocked:'Local data is empty while cloud data is not; overwrite was blocked', r2_not_configured:'R2 is not configured', r2_read_verification_failed:'R2 read-after-write verification failed', cloud_notebook_position_invalid:'Cloud notebook position data is invalid', recording_not_committed:'The recording has not been fully committed', cloud_metadata_not_committed:'Cloud metadata was not committed',
             local_class_material_missing:'Local class material is missing: {0}', class_material_index_changed:'The class material index changed: {0}', class_note_content_missing:'Class lecture content is missing: {0}', class_note_index_changed:'The class lecture index changed: {0}', delete_cloud_class_material_failed:'Failed to delete cloud class material: {0}', delete_cloud_class_note_failed:'Failed to delete cloud class lecture: {0}',
             notification_lecture_sync_title:'Lecture sync complete', notification_lecture_sync_body:'The lecture was synced to the cloud', notification_abstract_sync_title:'Abstract sync complete', notification_abstract_sync_body:'The abstract was synced to the cloud', network_endpoint_cors_error:'Network, endpoint, or CORS configuration error', permission_key_error:'Permission or credential error', bucket_not_found:'Bucket not found',
@@ -6991,7 +6991,7 @@
             chat_history_filename:'historique-discussion', select_books:'Sélectionner des livres', select_papers:'Sélectionner des articles', progress_label:'Progression {0} %', book_file_missing:'Le fichier du livre est introuvable', bookmark_page_suffix:' (page {0})', no_chapter_bookmarks:'Aucun signet de chapitre', chapter_bookmarks_hint:'Appuyez longuement sur un livre pour générer les cours et les signets', page_label:'Page {0}', lecture_progress_suffix:' · Cours {0} %',
             generating_lecture_content:'Génération du cours…', first_generation_time:'La première génération peut prendre quelques minutes', generation_failed:'Échec de la génération', network_api_retry:'Vérifiez le réseau ou les réglages API, puis réessayez', content_load_failed:'Échec du chargement du contenu', lecture_content_not_found:'Contenu du cours introuvable', lecture_not_generated:'Ce cours n’a pas encore été généré', cannot_load_lecture:'Impossible de charger le cours', download_lecture:'Télécharger le cours',
             fetch_models_http_error:'Échec de récupération des modèles (HTTP {0}) : {1}', fetch_models_failed:'Échec de récupération des modèles', all_apis_failed:'Toutes les tentatives API ont échoué', configure_api_first:'Configurez d’abord une API', api_error:'Erreur API (HTTP {0}) : {1}', claude_api_error:'Erreur de l’API Claude (HTTP {0}) : {1}', api_url_empty:"L’URL de l’API ne peut pas être vide", select_model_required:'Sélectionnez un modèle', large_recording_requires_gemini:'Les enregistrements longs nécessitent un modèle Gemini',
-            files_api_start_failed:'Impossible de démarrer le téléversement Files API', files_api_no_upload_url:'Files API n’a renvoyé aucune URL de téléversement', files_api_upload_failed:'Échec du téléversement Files API', files_api_processing_failed:'Échec du traitement Files API', pdf_text_extraction_failed:"Échec de l’extraction du texte du PDF", attached_pdf_text:'Texte du PDF joint :\n{0}',
+            files_api_start_failed:'Impossible de démarrer le téléversement Files API', files_api_no_upload_url:'Files API n’a renvoyé aucune URL de téléversement', files_api_upload_failed:'Échec du téléversement Files API', files_api_processing_failed:'Échec du traitement Files API', files_api_processing_timeout:'Délai de traitement Files API dépassé', pdf_text_extraction_failed:"Échec de l’extraction du texte du PDF", attached_pdf_text:'Texte du PDF joint :\n{0}',
             data_not_loaded_upload_blocked:"Les données ne sont pas chargées de façon sûre ; l’envoi a été bloqué", cloud_metadata_busy:'Les métadonnées cloud sont en cours de synchronisation ; réessayez bientôt', cloud_metadata_corrupt:'Les métadonnées cloud sont corrompues', empty_local_cloud_nonempty_blocked:'Les données locales sont vides mais celles du cloud ne le sont pas ; remplacement bloqué', r2_not_configured:'R2 n’est pas configuré', r2_read_verification_failed:'Échec de la vérification R2 après écriture', cloud_notebook_position_invalid:'La position cloud du carnet est invalide', recording_not_committed:"L’enregistrement n’est pas entièrement validé", cloud_metadata_not_committed:'Les métadonnées cloud n’ont pas été validées',
             local_class_material_missing:'Support de cours local manquant : {0}', class_material_index_changed:"L’index des supports de cours a changé : {0}", class_note_content_missing:'Contenu du cours manquant : {0}', class_note_index_changed:"L’index des cours a changé : {0}", delete_cloud_class_material_failed:'Échec de suppression du support cloud : {0}', delete_cloud_class_note_failed:'Échec de suppression du cours cloud : {0}',
             notification_lecture_sync_title:'Synchronisation du cours terminée', notification_lecture_sync_body:'Le cours a été synchronisé dans le cloud', notification_abstract_sync_title:'Synchronisation du résumé terminée', notification_abstract_sync_body:'Le résumé a été synchronisé dans le cloud', network_endpoint_cors_error:'Erreur de réseau, d’endpoint ou de configuration CORS', permission_key_error:'Erreur d’autorisation ou d’identifiants', bucket_not_found:'Bucket introuvable',
@@ -18748,13 +18748,17 @@
             return null;
         }
 
-        // 构造 Gemini contents，带 PDF。超过 18MB 走 Files API。
+        // 构造 Gemini contents，带 PDF。官方 Gemini 的大文件走 Files API；
+        // 自定义 Gemini 兼容端点通常没有 Files API，50MB 内改用 inline_data。
         async function buildGeminiContentsWithPdf(base, key, messages, pdfAttachment) {
             const bytes = pdfAttachment.bytes;
             const inlineThreshold = 18 * 1024 * 1024; // 18 MB
+            const inlinePdfLimit = 45 * 1024 * 1024; // 给 PDF 50 MB 上限及提示词留余量
+            const officialGeminiEndpoint = /^https:\/\/generativelanguage\.googleapis\.com(?:\/|$)/i.test(base);
             let fileRef = null; // { file_uri, mime_type } for Files API
             let inlineBase64 = null;
-            if (bytes.length <= inlineThreshold) {
+            if (bytes.length <= inlineThreshold ||
+                (!officialGeminiEndpoint && bytes.length <= inlinePdfLimit)) {
                 inlineBase64 = pdfAttachment.base64 || uint8ToBase64(bytes);
             } else {
                 fileRef = await geminiUploadFile(base, key, bytes, 'application/pdf', pdfAttachment.name || 'book.pdf');
@@ -18816,23 +18820,35 @@
                 throw new Error(i18n('files_api_upload_failed', putResp.status, t));
             }
             const info = await putResp.json();
-            // 上传后文件有个 ACTIVE 状态过程，通常 PDF 立即可用，但保险起见轮询一次
-            const fileObj = info.file || info;
+            // 扫描版 PDF 的服务端处理可能明显超过 20 秒；只有 ACTIVE 才能用于推理。
+            let fileObj = info.file || info;
             const name = fileObj.name;
             const mime = fileObj.mimeType || mimeType;
             let uri = fileObj.uri;
-            // 轮询直到 state=ACTIVE
-            if (fileObj.state && fileObj.state !== 'ACTIVE') {
-                for (let i = 0; i < 20; i++) {
-                    await new Promise(r => setTimeout(r, 1000));
-                    const poll = await fetch(base + '/' + name + '?key=' + encodeURIComponent(key));
-                    if (!poll.ok) break;
-                    const pd = await poll.json();
-                    if (pd.state === 'ACTIVE') { uri = pd.uri; break; }
-                    if (pd.state === 'FAILED') throw new Error(i18n('files_api_processing_failed'));
+            const processingDeadline = Date.now() + 5 * 60 * 1000;
+            let pollDelay = 1500;
+            while (fileObj.state && fileObj.state !== 'ACTIVE') {
+                if (fileObj.state === 'FAILED') {
+                    const detail = fileObj.error?.message || '';
+                    throw new Error(i18n('files_api_processing_failed') + (detail ? ': ' + detail : ''));
                 }
+                if (Date.now() >= processingDeadline) {
+                    throw new Error(i18n('files_api_processing_timeout'));
+                }
+                await new Promise(r => setTimeout(r, pollDelay));
+                const poll = await fetch(base + '/' + name + '?key=' + encodeURIComponent(key));
+                if (!poll.ok) {
+                    const detail = await poll.text().catch(() => '');
+                    throw new Error(i18n('files_api_processing_failed') +
+                        ` (${poll.status})` + (detail ? ': ' + detail : ''));
+                }
+                const polled = await poll.json();
+                fileObj = polled.file || polled;
+                uri = fileObj.uri || uri;
+                pollDelay = Math.min(5000, Math.round(pollDelay * 1.35));
             }
-            return { file_uri: uri, mime_type: mime };
+            if (!uri) throw new Error(i18n('files_api_processing_failed'));
+            return { file_uri: uri, mime_type: fileObj.mimeType || mime };
         }
 
         // OpenAI-compatible API call with message history (保留兼容)
@@ -21818,6 +21834,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         // ==================== Classroom ====================
         let currentClassroomFolder = null;   // { type: 'course'|'seminar', folderId }
         let currentClassroomSession = null;  // { type, folderId, sessionId }
+        let classroomFolderCreatePending = false;
 
         function renderClassroomPage() {
             currentClassroomFolder = null;
@@ -21869,21 +21886,29 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             }
         }
 
-        function onClassroomColumnClick(e, type) {
+        async function onClassroomColumnClick(e, type) {
             if (e.target.closest('.classroom-folder')) return;
-            const name = prompt(i18n(type === 'course' ? 'new_course_name_prompt' : 'new_seminar_name_prompt'));
-            if (!name || !name.trim()) return;
-            if (!appData.classroom) appData.classroom = { courses: [], seminars: [] };
-            const list = type === 'course' ? appData.classroom.courses : appData.classroom.seminars;
-            list.push({
-                id: 'cls_' + Date.now() + '_' + Math.random().toString(36).slice(2, 6),
-                name: name.trim(),
-                createdAt: new Date().toISOString(),
-                sessions: []
-            });
-            saveData();
-            debouncedChatSync();
-            renderClassroomPage();
+            if (classroomFolderCreatePending) return;
+            classroomFolderCreatePending = true;
+            try {
+                // 启动云同步会替换课堂 metadata；等合并完成后再落创建操作，避免首次创建被覆盖。
+                await r2StartupMetadataReady.catch(() => {});
+                const name = prompt(i18n(type === 'course' ? 'new_course_name_prompt' : 'new_seminar_name_prompt'));
+                if (!name || !name.trim()) return;
+                if (!appData.classroom) appData.classroom = { courses: [], seminars: [] };
+                const list = type === 'course' ? appData.classroom.courses : appData.classroom.seminars;
+                list.push({
+                    id: 'cls_' + Date.now() + '_' + Math.random().toString(36).slice(2, 6),
+                    name: name.trim(),
+                    createdAt: new Date().toISOString(),
+                    sessions: []
+                });
+                saveData();
+                debouncedChatSync();
+                renderClassroomPage();
+            } finally {
+                classroomFolderCreatePending = false;
+            }
         }
 
         function getClassroomFolder(type, folderId) {
@@ -29295,14 +29320,23 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 </div>`;
         }
         async function nbInsertPage(after) {
-            const nb = nbCurrentNotebook();
-            if (!nb) return;
+            const notebookId = nbState.notebookId;
+            const anchorPageId = nbCurrentPage()?.id;
+            if (!notebookId || !anchorPageId) return;
             await nbSavePageNow();
+            const nb = nbGetNotebook(notebookId);
+            if (!nb || nbState.notebookId !== notebookId) return;
+            const anchorIndex = (nb.pages || []).findIndex(page => page?.id === anchorPageId);
+            if (anchorIndex < 0) {
+                showToast(i18n('page_deleted'));
+                return;
+            }
             const sel = document.getElementById('nbNewPageTpl');
-            const tpl = (!sel || sel.value === '__cur__') ? (nbCurrentPage().template || 'blank') : sel.value;
+            const anchorPage = nb.pages[anchorIndex];
+            const tpl = (!sel || sel.value === '__cur__') ? (anchorPage.template || 'blank') : sel.value;
             const now = new Date().toISOString();
             const page = { id: nbUid('nbp'), template: tpl, createdAt: now, updatedAt: now };
-            const at = nbState.pageIndex + (after ? 1 : 0);
+            const at = anchorIndex + (after ? 1 : 0);
             nb.pages.splice(at, 0, page);
             nbTouch(nb);
             saveData();


### PR DESCRIPTION
## 修复内容

- 笔记页插入改为以当前页面 ID 为锚点，在异步保存后重新定位，确保新页插入当前页之前/之后，而不是落到笔记本末尾。
- 课程/讲座文件夹创建等待启动 R2 metadata 合并完成，并阻止等待期间重复创建，避免第一次创建被云同步覆盖。
- 大型扫描 PDF 使用 Gemini Files API 时持续等待文件真正进入 `ACTIVE`（最长 5 分钟），并为不提供 Files API 的自定义 Gemini 兼容端点在 PDF 安全大小内使用 inline data。
- 同步更新 GitHub Pages 与 Android 内置的两份 `index.html`。

## 验证

- 两份发布资源内容一致（`cmp`）
- 两份 HTML 的内联 JavaScript 均通过语法解析
- `git diff --check` 通过

按要求未执行大范围测试，未新增测试文件。