### PR TITLE
修复笔记页插入位置和首次新建课程失败

### DIFF
--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -16044,12 +16044,37 @@
                         syncTimestamp(cloudPage.updatedAt || cloudPage.createdAt)
                         ? localPage : cloudPage;
                 }).filter(Boolean);
-                for (const localPage of (localItem?.pages || [])) {
+                const localPageOrder = localItem?.pages || [];
+                for (let localIndex = 0; localIndex < localPageOrder.length; localIndex++) {
+                    const localPage = localPageOrder[localIndex];
                     if (!localPage?.id || cloudPageIds.has(localPage.id)) continue;
                     if (!(cloudItem?.pages || []).length ||
                         syncTimestamp(localPage.updatedAt || localPage.createdAt) > cloudNotebookUpdatedAt ||
                         localNotebookUpdatedAt > cloudNotebookUpdatedAt) {
-                        result.pages.push(localPage);
+                        // 云端列表是合并基底，但本地新插入页必须保持其相对位置；
+                        // 直接 push 会把“在当前页后插入”错误地移动到笔记本末尾。
+                        let insertAt = result.pages.length;
+                        let anchoredAfterPrevious = false;
+                        for (let i = localIndex - 1; i >= 0; i--) {
+                            const previousId = localPageOrder[i]?.id;
+                            const previousIndex = result.pages.findIndex(page => page?.id === previousId);
+                            if (previousIndex >= 0) {
+                                insertAt = previousIndex + 1;
+                                anchoredAfterPrevious = true;
+                                break;
+                            }
+                        }
+                        if (!anchoredAfterPrevious) {
+                            for (let i = localIndex + 1; i < localPageOrder.length; i++) {
+                                const nextId = localPageOrder[i]?.id;
+                                const nextIndex = result.pages.findIndex(page => page?.id === nextId);
+                                if (nextIndex >= 0) {
+                                    insertAt = nextIndex;
+                                    break;
+                                }
+                            }
+                        }
+                        result.pages.splice(insertAt, 0, localPage);
                     }
                 }
                 const cloudPositionTs = positionTs(cloudItem);
@@ -21869,21 +21894,32 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             }
         }
 
-        function onClassroomColumnClick(e, type) {
-            if (e.target.closest('.classroom-folder')) return;
+        let _classroomFolderCreatePending = false;
+        async function onClassroomColumnClick(e, type) {
+            if (e.target.closest('.classroom-folder') || _classroomFolderCreatePending) return;
             const name = prompt(i18n(type === 'course' ? 'new_course_name_prompt' : 'new_seminar_name_prompt'));
             if (!name || !name.trim()) return;
-            if (!appData.classroom) appData.classroom = { courses: [], seminars: [] };
-            const list = type === 'course' ? appData.classroom.courses : appData.classroom.seminars;
-            list.push({
-                id: 'cls_' + Date.now() + '_' + Math.random().toString(36).slice(2, 6),
-                name: name.trim(),
-                createdAt: new Date().toISOString(),
-                sessions: []
-            });
-            saveData();
-            debouncedChatSync();
-            renderClassroomPage();
+            _classroomFolderCreatePending = true;
+            try {
+                // 启动云同步可能正在替换 classroom 快照。等 metadata 合并完成后再读取
+                // 最新数组并写入，避免第一次新建被稍后完成的启动拉取覆盖。
+                await r2StartupMetadataReady.catch(() => {});
+                if (!appData.classroom) appData.classroom = { courses: [], seminars: [] };
+                if (!Array.isArray(appData.classroom.courses)) appData.classroom.courses = [];
+                if (!Array.isArray(appData.classroom.seminars)) appData.classroom.seminars = [];
+                const list = type === 'course' ? appData.classroom.courses : appData.classroom.seminars;
+                list.push({
+                    id: 'cls_' + Date.now() + '_' + Math.random().toString(36).slice(2, 6),
+                    name: name.trim(),
+                    createdAt: new Date().toISOString(),
+                    sessions: []
+                });
+                saveData();
+                debouncedChatSync();
+                renderClassroomPage();
+            } finally {
+                _classroomFolderCreatePending = false;
+            }
         }
 
         function getClassroomFolder(type, folderId) {

--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -29331,14 +29331,23 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 </div>`;
         }
         async function nbInsertPage(after) {
-            const nb = nbCurrentNotebook();
-            if (!nb) return;
+            const notebookId = nbState.notebookId;
+            const anchorPageId = nbCurrentPage()?.id;
+            if (!notebookId || !anchorPageId) return;
             await nbSavePageNow();
+            const nb = nbGetNotebook(notebookId);
+            if (!nb || nbState.notebookId !== notebookId) return;
+            const anchorIndex = (nb.pages || []).findIndex(page => page?.id === anchorPageId);
+            if (anchorIndex < 0) {
+                showToast(i18n('page_deleted'));
+                return;
+            }
             const sel = document.getElementById('nbNewPageTpl');
-            const tpl = (!sel || sel.value === '__cur__') ? (nbCurrentPage().template || 'blank') : sel.value;
+            const anchorPage = nb.pages[anchorIndex];
+            const tpl = (!sel || sel.value === '__cur__') ? (anchorPage.template || 'blank') : sel.value;
             const now = new Date().toISOString();
             const page = { id: nbUid('nbp'), template: tpl, createdAt: now, updatedAt: now };
-            const at = nbState.pageIndex + (after ? 1 : 0);
+            const at = anchorIndex + (after ? 1 : 0);
             nb.pages.splice(at, 0, page);
             nbTouch(nb);
             saveData();

--- a/docs/index.html
+++ b/docs/index.html
@@ -16044,12 +16044,37 @@
                         syncTimestamp(cloudPage.updatedAt || cloudPage.createdAt)
                         ? localPage : cloudPage;
                 }).filter(Boolean);
-                for (const localPage of (localItem?.pages || [])) {
+                const localPageOrder = localItem?.pages || [];
+                for (let localIndex = 0; localIndex < localPageOrder.length; localIndex++) {
+                    const localPage = localPageOrder[localIndex];
                     if (!localPage?.id || cloudPageIds.has(localPage.id)) continue;
                     if (!(cloudItem?.pages || []).length ||
                         syncTimestamp(localPage.updatedAt || localPage.createdAt) > cloudNotebookUpdatedAt ||
                         localNotebookUpdatedAt > cloudNotebookUpdatedAt) {
-                        result.pages.push(localPage);
+                        // 云端列表是合并基底，但本地新插入页必须保持其相对位置；
+                        // 直接 push 会把“在当前页后插入”错误地移动到笔记本末尾。
+                        let insertAt = result.pages.length;
+                        let anchoredAfterPrevious = false;
+                        for (let i = localIndex - 1; i >= 0; i--) {
+                            const previousId = localPageOrder[i]?.id;
+                            const previousIndex = result.pages.findIndex(page => page?.id === previousId);
+                            if (previousIndex >= 0) {
+                                insertAt = previousIndex + 1;
+                                anchoredAfterPrevious = true;
+                                break;
+                            }
+                        }
+                        if (!anchoredAfterPrevious) {
+                            for (let i = localIndex + 1; i < localPageOrder.length; i++) {
+                                const nextId = localPageOrder[i]?.id;
+                                const nextIndex = result.pages.findIndex(page => page?.id === nextId);
+                                if (nextIndex >= 0) {
+                                    insertAt = nextIndex;
+                                    break;
+                                }
+                            }
+                        }
+                        result.pages.splice(insertAt, 0, localPage);
                     }
                 }
                 const cloudPositionTs = positionTs(cloudItem);
@@ -21869,21 +21894,32 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             }
         }
 
-        function onClassroomColumnClick(e, type) {
-            if (e.target.closest('.classroom-folder')) return;
+        let _classroomFolderCreatePending = false;
+        async function onClassroomColumnClick(e, type) {
+            if (e.target.closest('.classroom-folder') || _classroomFolderCreatePending) return;
             const name = prompt(i18n(type === 'course' ? 'new_course_name_prompt' : 'new_seminar_name_prompt'));
             if (!name || !name.trim()) return;
-            if (!appData.classroom) appData.classroom = { courses: [], seminars: [] };
-            const list = type === 'course' ? appData.classroom.courses : appData.classroom.seminars;
-            list.push({
-                id: 'cls_' + Date.now() + '_' + Math.random().toString(36).slice(2, 6),
-                name: name.trim(),
-                createdAt: new Date().toISOString(),
-                sessions: []
-            });
-            saveData();
-            debouncedChatSync();
-            renderClassroomPage();
+            _classroomFolderCreatePending = true;
+            try {
+                // 启动云同步可能正在替换 classroom 快照。等 metadata 合并完成后再读取
+                // 最新数组并写入，避免第一次新建被稍后完成的启动拉取覆盖。
+                await r2StartupMetadataReady.catch(() => {});
+                if (!appData.classroom) appData.classroom = { courses: [], seminars: [] };
+                if (!Array.isArray(appData.classroom.courses)) appData.classroom.courses = [];
+                if (!Array.isArray(appData.classroom.seminars)) appData.classroom.seminars = [];
+                const list = type === 'course' ? appData.classroom.courses : appData.classroom.seminars;
+                list.push({
+                    id: 'cls_' + Date.now() + '_' + Math.random().toString(36).slice(2, 6),
+                    name: name.trim(),
+                    createdAt: new Date().toISOString(),
+                    sessions: []
+                });
+                saveData();
+                debouncedChatSync();
+                renderClassroomPage();
+            } finally {
+                _classroomFolderCreatePending = false;
+            }
         }
 
         function getClassroomFolder(type, folderId) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -29331,14 +29331,23 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 </div>`;
         }
         async function nbInsertPage(after) {
-            const nb = nbCurrentNotebook();
-            if (!nb) return;
+            const notebookId = nbState.notebookId;
+            const anchorPageId = nbCurrentPage()?.id;
+            if (!notebookId || !anchorPageId) return;
             await nbSavePageNow();
+            const nb = nbGetNotebook(notebookId);
+            if (!nb || nbState.notebookId !== notebookId) return;
+            const anchorIndex = (nb.pages || []).findIndex(page => page?.id === anchorPageId);
+            if (anchorIndex < 0) {
+                showToast(i18n('page_deleted'));
+                return;
+            }
             const sel = document.getElementById('nbNewPageTpl');
-            const tpl = (!sel || sel.value === '__cur__') ? (nbCurrentPage().template || 'blank') : sel.value;
+            const anchorPage = nb.pages[anchorIndex];
+            const tpl = (!sel || sel.value === '__cur__') ? (anchorPage.template || 'blank') : sel.value;
             const now = new Date().toISOString();
             const page = { id: nbUid('nbp'), template: tpl, createdAt: now, updatedAt: now };
-            const at = nbState.pageIndex + (after ? 1 : 0);
+            const at = anchorIndex + (after ? 1 : 0);
             nb.pages.splice(at, 0, page);
             nbTouch(nb);
             saveData();


### PR DESCRIPTION
## 修复内容

- 笔记本云端 metadata 合并时，按本地页面的相邻锚点保留新插入页的位置，避免“在当前页后插入”被移动到笔记本末尾。
- 页面插入在异步保存前记录笔记本 ID 与当前页 ID，保存完成后按 ID 重新定位锚点，避免保存期间切页导致新页插到错误位置或末尾。
- 新建课程/讲座时等待启动 metadata 合并完成后再写入最新课堂数组，避免第一次创建被启动云同步覆盖；等待期间阻止重复创建。
- 同步更新 `docs/index.html` 与 Android 内置网页副本。

## 最小验证

- 内联 JavaScript 语法检查通过。
- 页面合并场景验证：`A, 新页, B, C` 与 `A, B, 新页, C` 顺序均保持。
- 页面插入竞态验证：从 A 后开始插入、异步保存期间切到 C，最终仍为 `A, 新页, B, C`。
- 启动云同步期间首次新建课程场景通过，云端课程与首次新建课程均保留。
- 两个网页副本 `cmp` 一致，`git diff --check` 通过。
- 未新增测试文件。