### PR TITLE
把作答准则原文写入 AI 系统提示

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,22 @@ This repository ships the current Math Reader web app as an Android APK. BOOX/E 
 
 API Key 保存在本机设置中，不会随 R2 元数据同步到云端；完整 ZIP 备份会包含本机设置，因此仍须把 ZIP 当作敏感文件保管。
 
+**AI 作答准则（内置，无需配置）**
+
+下列准则会自动附加到讲解、阅读问 AI、讲义、课堂笔记与批改的系统提示中：
+
+> 在各种问ai中，严格禁止“根据xx性质”“根据xx定理”而对定理内容性质内容不做任何阐述和解释的不负责任的回答。
+>
+> 一个定理如果存在多个版本和推广，必须保证使用的定理版本和讲解的定理版本字节级一致，禁止使用拓展定理却只给出基础版本说明。
+>
+> 回答必须和之前保持至少50%的一致性，在所有前文的基础上回答。
+>
+> 禁止更改聊天历史已经出现过的数学符号和记号。
+>
+> 严谨数学，禁止口语化。
+
+OCR、手写识别、大纲生成、识题、录音转写与 Quiz 出题只做识别或结构化抽取，不注入该准则。
+
 ### 3. 书架：导入和管理资料
 
 1. 打开 **书架**，点击“书籍”或“论文”栏的空白处。
@@ -233,6 +249,22 @@ Open **Settings → API Setting**:
 Use a strong text/LaTeX model for chat, outlines, lectures, and abstracts. Lasso questions, handwriting indexing, exercise extraction, and grading require vision input. Classroom transcription requires an API that accepts the audio sent by the app. PDF outline and lecture generation require a provider compatible with the app's PDF attachment calls.
 
 API credentials stay local and are excluded from R2 metadata sync. A full ZIP contains local settings, so protect the ZIP as a sensitive file.
+
+**Built-in answering standards (always on)**
+
+These standards are appended automatically to the system prompts used for explanations, reader questions, lectures, classroom notes, and grading:
+
+> In every question put to the AI, irresponsible answers that say "by the xx property" or "by the xx theorem" while giving no statement or explanation of the content of that theorem or property are strictly forbidden.
+>
+> If a theorem has several versions and generalizations, the version used and the version explained must be identical byte for byte; using an extended theorem while giving only the statement of the basic version is forbidden.
+>
+> Answers must stay at least 50% consistent with the previous ones, and must be given on the basis of everything said before.
+>
+> Changing mathematical symbols and notation that have already appeared in the chat history is forbidden.
+>
+> Rigorous mathematics; colloquial language is forbidden.
+
+OCR, handwriting recognition, outline generation, exercise extraction, audio transcription, and quiz generation only recognize or extract structure, so the standards are not injected there.
 
 ### 3. Library
 

--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -6480,6 +6480,7 @@
                 prompt_math_ai:'你是一个数学AI助手。',prompt_user_notes:'用户笔记: ',prompt_none:'无',
                 prompt_help_instruction:'请根据用户问题给出帮助。回答必须严格基于纯数学：给出严谨的定义、定理与证明，使用规范的数学语言和符号。简洁、准确、数学专业。严禁使用任何比喻、类比或直觉化的形象说法；严禁从物理（如力、能量、运动、场等物理概念或物理直觉）角度进行解释。只就数学本身进行论述。',
                 prompt_workflow:'参考工作流程:\nstage1:用户提出附件相关问题，你结合附件给出回答。\nstage2:用户针对你的回答提出问题，你针对问题给出回答（禁止结合附件）。stage 2的回答必须完全独立,仅针对数学问题本身进行专业解释。严禁提及、暗示或关联任何附件内容。',
+                prompt_math_standards:'在各种问ai中，严格禁止“根据xx性质”“根据xx定理”而对定理内容性质内容不做任何阐述和解释的不负责任的回答。\n一个定理如果存在多个版本和推广，必须保证使用的定理版本和讲解的定理版本字节级一致，禁止使用拓展定理却只给出基础版本说明。\n回答必须和之前保持至少50%的一致性，在所有前文的基础上回答。\n禁止更改聊天历史已经出现过的数学符号和记号。\n严谨数学，禁止口语化。',
                 prompt_ocr:'你是OCR识别助手，识别图片中的文字和数学公式。',
                 prompt_math_explain:'你是一个专业的数学讲师，为数学基础一般（仅学过基础数学分析和线性代数）的学生简洁解释数学内容。\n\n要求：\n- 使用严谨的数学语言，不要口语化表达\n- 直接陈述数学内容\n- 使用LaTeX格式：行内公式用 $...$ ，独立公式用 $$...$$',
                 prompt_chat_base:'你是一个友好、专业的数学学习助手。你的任务是帮助用户理解数学概念、解决数学问题、提供学习建议。\n请用清晰易懂的语言回答，必要时使用LaTeX格式的数学公式（用$...$包裹行内公式）。\n保持回答简洁但完整，如果问题复杂，可以分步骤解释。',
@@ -6667,6 +6668,7 @@
                 prompt_math_ai:'You are a math AI assistant.',prompt_user_notes:'User notes: ',prompt_none:'None',
                 prompt_help_instruction:'Help the user based on their question. Answers must be strictly grounded in pure mathematics: give rigorous definitions, theorems, and proofs using formal mathematical language and notation. Be concise, accurate, and mathematically professional. Strictly forbid any metaphors, analogies, or intuitive imagery; strictly forbid explanations from a physics perspective (forces, energy, motion, fields, or physical intuition). Discuss the mathematics itself only.',
                 prompt_workflow:'Workflow:\nstage1: User asks about the attachment, answer based on attachment.\nstage2: User asks follow-up, answer independently (no attachment reference). Stage 2 must be completely independent.',
+                prompt_math_standards:'In every question put to the AI, irresponsible answers that say "by the xx property" or "by the xx theorem" while giving no statement or explanation of the content of that theorem or property are strictly forbidden.\nIf a theorem has several versions and generalizations, the version used and the version explained must be identical byte for byte; using an extended theorem while giving only the statement of the basic version is forbidden.\nAnswers must stay at least 50% consistent with the previous ones, and must be given on the basis of everything said before.\nChanging mathematical symbols and notation that have already appeared in the chat history is forbidden.\nRigorous mathematics; colloquial language is forbidden.',
                 prompt_ocr:'You are an OCR assistant. Recognize text and math formulas in images.',
                 prompt_math_explain:'You are a professional math lecturer. Explain math content concisely for students with basic math background (calculus and linear algebra only).\n\nRequirements:\n- Rigorous mathematical language\n- Direct statements\n- LaTeX: $...$ inline, $$...$$ display',
                 prompt_chat_base:'You are a friendly, professional math learning assistant. Help users understand math concepts, solve problems, and provide advice.\nAnswer clearly, using LaTeX ($...$) when needed.\nKeep answers concise but complete.',
@@ -6854,6 +6856,7 @@
                 prompt_math_ai:'Tu es un assistant IA en mathématiques.',prompt_user_notes:'Notes : ',prompt_none:'Aucune',
                 prompt_help_instruction:'Aide l\'utilisateur. Les réponses doivent reposer strictement sur les mathématiques pures : définitions, théorèmes et démonstrations rigoureux, avec un langage et une notation mathématiques formels. Sois concis, précis et professionnel. Interdis strictement toute métaphore, analogie ou image intuitive ; interdis strictement les explications d\'ordre physique (forces, énergie, mouvement, champs ou intuition physique). Traite uniquement des mathématiques elles-mêmes.',
                 prompt_workflow:'Workflow :\nstage1 : Question sur la pièce jointe → réponse basée sur la pièce jointe.\nstage2 : Suivi → réponse indépendante, sans référence à la pièce jointe.',
+                prompt_math_standards:'Dans toute question posée à l\'IA, les réponses irresponsables qui disent « par la propriété xx » ou « par le théorème xx » sans donner aucun énoncé ni aucune explication du contenu de ce théorème ou de cette propriété sont strictement interdites.\nSi un théorème possède plusieurs versions et généralisations, la version utilisée et la version expliquée doivent être identiques octet pour octet ; utiliser un théorème étendu en ne donnant que l\'énoncé de la version de base est interdit.\nLes réponses doivent rester cohérentes à au moins 50 % avec les précédentes et être données sur la base de tout ce qui a été dit auparavant.\nModifier les symboles et notations mathématiques déjà apparus dans l\'historique de la conversation est interdit.\nMathématiques rigoureuses ; le langage familier est interdit.',
                 prompt_ocr:'Tu es un assistant OCR. Reconnais texte et formules dans les images.',
                 prompt_math_explain:'Tu es un professeur de mathématiques professionnel. Explique le contenu mathématique de manière concise pour des étudiants avec des bases en analyse et algèbre linéaire.\n\nExigences :\n- Langage mathématique rigoureux\n- Énoncés directs\n- LaTeX : $...$ en ligne, $$...$$ en bloc',
                 prompt_chat_base:'Tu es un assistant mathématique amical et professionnel. Aide à comprendre, résoudre et conseiller.\nUtilise LaTeX ($...$) si nécessaire. Reste concis mais complet.',
@@ -12907,7 +12910,7 @@
 
         async function requestTextSelectionAI(selectedText, userDesc) {
             const prompt = buildSelectionAskPrompt(selectedText, userDesc);
-            return await callAI(i18n('prompt_math_explain'), [{ role: 'user', content: prompt }])
+            return await callAI(withMathStandards(i18n('prompt_math_explain')), [{ role: 'user', content: prompt }])
                 || i18n('chat_no_ai_answer');
         }
 
@@ -12936,7 +12939,7 @@
                     { type: 'image_url', image_url: { url: sel.image } },
                     { type: 'text', text: tip }
                 ] }];
-                const aiResponse = await callAI(i18n('prompt_math_explain'), messages)
+                const aiResponse = await callAI(withMathStandards(i18n('prompt_math_explain')), messages)
                     || i18n('chat_no_ai_answer');
                 addDocAiComment(docId, sel.page, sel.cx, sel.cy, aiResponse, userDesc);
                 showToast(i18n('toast_note_added'));
@@ -18271,7 +18274,7 @@
             // Build system prompt
             const notes = getDocAnnotations(currentDoc.id, currentPage, 'note');
             const notesSummary = notes.map(n => n.text).filter(Boolean).join('; ');
-            const systemPrompt = `${i18n('prompt_math_ai')}\n\n${i18n('prompt_user_notes')}${notesSummary || i18n('prompt_none')}\n${i18n('prompt_help_instruction')}\n${i18n('prompt_workflow')}`;
+            const systemPrompt = withMathStandards(`${i18n('prompt_math_ai')}\n\n${i18n('prompt_user_notes')}${notesSummary || i18n('prompt_none')}\n${i18n('prompt_help_instruction')}\n${i18n('prompt_workflow')}`);
 
             let pdfAttachment = null;
             if (currentDoc.type === 'pdf') {
@@ -18399,7 +18402,7 @@
             // Build system prompt with context
             const notes = getDocAnnotations(currentDoc.id, currentPage, 'note');
             const notesSummary = notes.map(n => n.text).filter(Boolean).join('; ');
-            const systemPrompt = `${i18n('prompt_math_ai')}\n\n${i18n('prompt_user_notes')}${notesSummary || i18n('prompt_none')}\n${i18n('prompt_help_instruction')}\n${i18n('prompt_workflow')}`;
+            const systemPrompt = withMathStandards(`${i18n('prompt_math_ai')}\n\n${i18n('prompt_user_notes')}${notesSummary || i18n('prompt_none')}\n${i18n('prompt_help_instruction')}\n${i18n('prompt_workflow')}`);
 
             const apiMessages = buildReaderChatApiMessages(history);
 
@@ -18451,6 +18454,15 @@
                 saveReaderChatHistory(currentDoc.id, history);
                 renderReaderChatHistory();
             }
+        }
+
+        // ==================== 数学作答准则 ====================
+        // 讲解、答疑、讲义、课堂笔记与批改共用同一套准则，禁止只报定理名而不给内容的回答。
+        // 识别类（OCR、手写识别）与纯结构化抽取（大纲、识题）不注入，避免干扰其输出格式。
+        function withMathStandards(systemPrompt) {
+            const base = String(systemPrompt || '').trim();
+            const standards = i18n('prompt_math_standards');
+            return base ? base + '\n\n' + standards : standards;
         }
 
         // ==================== 通用AI调用 ====================
@@ -19387,7 +19399,7 @@ ${i18n('prompt_outline_gen')}`;
 
             activeLectureGenerationCount++;
             try {
-                const systemPrompt = i18n('prompt_lecture_sys');
+                const systemPrompt = withMathStandards(i18n('prompt_lecture_sys'));
 
                 const userMessage = `${i18n('prompt_lecture_book')}${book.title}
 ${i18n('prompt_lecture_chapter')}${chapter.title}
@@ -21339,7 +21351,7 @@ ${i18n('prompt_lecture_gen')}`;
             }
 
             try {
-                const aiResponse = await callAI(i18n('prompt_math_explain'), [{ role: 'user', content: prompt }]) || i18n('chat_no_ai_answer');
+                const aiResponse = await callAI(withMathStandards(i18n('prompt_math_explain')), [{ role: 'user', content: prompt }]) || i18n('chat_no_ai_answer');
 
                 // 在选中文本下方插入AI回答笔记
                 const qDiv = document.getElementById('exerciseDoingQuestion');
@@ -21577,7 +21589,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     basePrompt += i18n('prompt_wrong_context') + window._wrongAIContext;
                 }
 
-                const systemPrompt = persona ? (persona + '\n\n' + basePrompt) : basePrompt;
+                const systemPrompt = withMathStandards(persona ? (persona + '\n\n' + basePrompt) : basePrompt);
 
                 // 获取之前的聊天记录作为上下文
                 const chatMessages = [];
@@ -24054,6 +24066,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             if (isSeminar) {
                 systemPrompt += i18n('prompt_seminar_extra');
             }
+            systemPrompt = withMathStandards(systemPrompt);
 
             const userMsg = i18n('prompt_note_user', folder.name, session.title, material.ref);
 
@@ -24850,7 +24863,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
             if (!confirm(i18n('confirm_delete'))) return;
 
-            const systemPrompt = i18n('prompt_grade_system');
+            const systemPrompt = withMathStandards(i18n('prompt_grade_system'));
 
             let graded = 0;
             let failed = 0;
@@ -27173,7 +27186,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             // Show loading
             showToast(i18n('toast_asking_ai'));
 
-            const systemPrompt = i18n('prompt_grade_system');
+            const systemPrompt = withMathStandards(i18n('prompt_grade_system'));
 
             try {
                 const msgContent = [{
@@ -27477,7 +27490,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
             showToast(i18n('toast_asking_ai'));
 
-            const systemPrompt = i18n('prompt_grade_system');
+            const systemPrompt = withMathStandards(i18n('prompt_grade_system'));
 
             try {
                 const msgContent = [{
@@ -31052,7 +31065,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             if (btn) { btn.disabled = true; btn.textContent = i18n('grading'); }
             showToast(i18n('grading_in_progress'));
 
-            const systemPrompt = i18n('prompt_review_grade_system');
+            const systemPrompt = withMathStandards(i18n('prompt_review_grade_system'));
 
             try {
                 const msgContent = [{

--- a/docs/index.html
+++ b/docs/index.html
@@ -6480,6 +6480,7 @@
                 prompt_math_ai:'你是一个数学AI助手。',prompt_user_notes:'用户笔记: ',prompt_none:'无',
                 prompt_help_instruction:'请根据用户问题给出帮助。回答必须严格基于纯数学：给出严谨的定义、定理与证明，使用规范的数学语言和符号。简洁、准确、数学专业。严禁使用任何比喻、类比或直觉化的形象说法；严禁从物理（如力、能量、运动、场等物理概念或物理直觉）角度进行解释。只就数学本身进行论述。',
                 prompt_workflow:'参考工作流程:\nstage1:用户提出附件相关问题，你结合附件给出回答。\nstage2:用户针对你的回答提出问题，你针对问题给出回答（禁止结合附件）。stage 2的回答必须完全独立,仅针对数学问题本身进行专业解释。严禁提及、暗示或关联任何附件内容。',
+                prompt_math_standards:'在各种问ai中，严格禁止“根据xx性质”“根据xx定理”而对定理内容性质内容不做任何阐述和解释的不负责任的回答。\n一个定理如果存在多个版本和推广，必须保证使用的定理版本和讲解的定理版本字节级一致，禁止使用拓展定理却只给出基础版本说明。\n回答必须和之前保持至少50%的一致性，在所有前文的基础上回答。\n禁止更改聊天历史已经出现过的数学符号和记号。\n严谨数学，禁止口语化。',
                 prompt_ocr:'你是OCR识别助手，识别图片中的文字和数学公式。',
                 prompt_math_explain:'你是一个专业的数学讲师，为数学基础一般（仅学过基础数学分析和线性代数）的学生简洁解释数学内容。\n\n要求：\n- 使用严谨的数学语言，不要口语化表达\n- 直接陈述数学内容\n- 使用LaTeX格式：行内公式用 $...$ ，独立公式用 $$...$$',
                 prompt_chat_base:'你是一个友好、专业的数学学习助手。你的任务是帮助用户理解数学概念、解决数学问题、提供学习建议。\n请用清晰易懂的语言回答，必要时使用LaTeX格式的数学公式（用$...$包裹行内公式）。\n保持回答简洁但完整，如果问题复杂，可以分步骤解释。',
@@ -6667,6 +6668,7 @@
                 prompt_math_ai:'You are a math AI assistant.',prompt_user_notes:'User notes: ',prompt_none:'None',
                 prompt_help_instruction:'Help the user based on their question. Answers must be strictly grounded in pure mathematics: give rigorous definitions, theorems, and proofs using formal mathematical language and notation. Be concise, accurate, and mathematically professional. Strictly forbid any metaphors, analogies, or intuitive imagery; strictly forbid explanations from a physics perspective (forces, energy, motion, fields, or physical intuition). Discuss the mathematics itself only.',
                 prompt_workflow:'Workflow:\nstage1: User asks about the attachment, answer based on attachment.\nstage2: User asks follow-up, answer independently (no attachment reference). Stage 2 must be completely independent.',
+                prompt_math_standards:'In every question put to the AI, irresponsible answers that say "by the xx property" or "by the xx theorem" while giving no statement or explanation of the content of that theorem or property are strictly forbidden.\nIf a theorem has several versions and generalizations, the version used and the version explained must be identical byte for byte; using an extended theorem while giving only the statement of the basic version is forbidden.\nAnswers must stay at least 50% consistent with the previous ones, and must be given on the basis of everything said before.\nChanging mathematical symbols and notation that have already appeared in the chat history is forbidden.\nRigorous mathematics; colloquial language is forbidden.',
                 prompt_ocr:'You are an OCR assistant. Recognize text and math formulas in images.',
                 prompt_math_explain:'You are a professional math lecturer. Explain math content concisely for students with basic math background (calculus and linear algebra only).\n\nRequirements:\n- Rigorous mathematical language\n- Direct statements\n- LaTeX: $...$ inline, $$...$$ display',
                 prompt_chat_base:'You are a friendly, professional math learning assistant. Help users understand math concepts, solve problems, and provide advice.\nAnswer clearly, using LaTeX ($...$) when needed.\nKeep answers concise but complete.',
@@ -6854,6 +6856,7 @@
                 prompt_math_ai:'Tu es un assistant IA en mathématiques.',prompt_user_notes:'Notes : ',prompt_none:'Aucune',
                 prompt_help_instruction:'Aide l\'utilisateur. Les réponses doivent reposer strictement sur les mathématiques pures : définitions, théorèmes et démonstrations rigoureux, avec un langage et une notation mathématiques formels. Sois concis, précis et professionnel. Interdis strictement toute métaphore, analogie ou image intuitive ; interdis strictement les explications d\'ordre physique (forces, énergie, mouvement, champs ou intuition physique). Traite uniquement des mathématiques elles-mêmes.',
                 prompt_workflow:'Workflow :\nstage1 : Question sur la pièce jointe → réponse basée sur la pièce jointe.\nstage2 : Suivi → réponse indépendante, sans référence à la pièce jointe.',
+                prompt_math_standards:'Dans toute question posée à l\'IA, les réponses irresponsables qui disent « par la propriété xx » ou « par le théorème xx » sans donner aucun énoncé ni aucune explication du contenu de ce théorème ou de cette propriété sont strictement interdites.\nSi un théorème possède plusieurs versions et généralisations, la version utilisée et la version expliquée doivent être identiques octet pour octet ; utiliser un théorème étendu en ne donnant que l\'énoncé de la version de base est interdit.\nLes réponses doivent rester cohérentes à au moins 50 % avec les précédentes et être données sur la base de tout ce qui a été dit auparavant.\nModifier les symboles et notations mathématiques déjà apparus dans l\'historique de la conversation est interdit.\nMathématiques rigoureuses ; le langage familier est interdit.',
                 prompt_ocr:'Tu es un assistant OCR. Reconnais texte et formules dans les images.',
                 prompt_math_explain:'Tu es un professeur de mathématiques professionnel. Explique le contenu mathématique de manière concise pour des étudiants avec des bases en analyse et algèbre linéaire.\n\nExigences :\n- Langage mathématique rigoureux\n- Énoncés directs\n- LaTeX : $...$ en ligne, $$...$$ en bloc',
                 prompt_chat_base:'Tu es un assistant mathématique amical et professionnel. Aide à comprendre, résoudre et conseiller.\nUtilise LaTeX ($...$) si nécessaire. Reste concis mais complet.',
@@ -12907,7 +12910,7 @@
 
         async function requestTextSelectionAI(selectedText, userDesc) {
             const prompt = buildSelectionAskPrompt(selectedText, userDesc);
-            return await callAI(i18n('prompt_math_explain'), [{ role: 'user', content: prompt }])
+            return await callAI(withMathStandards(i18n('prompt_math_explain')), [{ role: 'user', content: prompt }])
                 || i18n('chat_no_ai_answer');
         }
 
@@ -12936,7 +12939,7 @@
                     { type: 'image_url', image_url: { url: sel.image } },
                     { type: 'text', text: tip }
                 ] }];
-                const aiResponse = await callAI(i18n('prompt_math_explain'), messages)
+                const aiResponse = await callAI(withMathStandards(i18n('prompt_math_explain')), messages)
                     || i18n('chat_no_ai_answer');
                 addDocAiComment(docId, sel.page, sel.cx, sel.cy, aiResponse, userDesc);
                 showToast(i18n('toast_note_added'));
@@ -18271,7 +18274,7 @@
             // Build system prompt
             const notes = getDocAnnotations(currentDoc.id, currentPage, 'note');
             const notesSummary = notes.map(n => n.text).filter(Boolean).join('; ');
-            const systemPrompt = `${i18n('prompt_math_ai')}\n\n${i18n('prompt_user_notes')}${notesSummary || i18n('prompt_none')}\n${i18n('prompt_help_instruction')}\n${i18n('prompt_workflow')}`;
+            const systemPrompt = withMathStandards(`${i18n('prompt_math_ai')}\n\n${i18n('prompt_user_notes')}${notesSummary || i18n('prompt_none')}\n${i18n('prompt_help_instruction')}\n${i18n('prompt_workflow')}`);
 
             let pdfAttachment = null;
             if (currentDoc.type === 'pdf') {
@@ -18399,7 +18402,7 @@
             // Build system prompt with context
             const notes = getDocAnnotations(currentDoc.id, currentPage, 'note');
             const notesSummary = notes.map(n => n.text).filter(Boolean).join('; ');
-            const systemPrompt = `${i18n('prompt_math_ai')}\n\n${i18n('prompt_user_notes')}${notesSummary || i18n('prompt_none')}\n${i18n('prompt_help_instruction')}\n${i18n('prompt_workflow')}`;
+            const systemPrompt = withMathStandards(`${i18n('prompt_math_ai')}\n\n${i18n('prompt_user_notes')}${notesSummary || i18n('prompt_none')}\n${i18n('prompt_help_instruction')}\n${i18n('prompt_workflow')}`);
 
             const apiMessages = buildReaderChatApiMessages(history);
 
@@ -18451,6 +18454,15 @@
                 saveReaderChatHistory(currentDoc.id, history);
                 renderReaderChatHistory();
             }
+        }
+
+        // ==================== 数学作答准则 ====================
+        // 讲解、答疑、讲义、课堂笔记与批改共用同一套准则，禁止只报定理名而不给内容的回答。
+        // 识别类（OCR、手写识别）与纯结构化抽取（大纲、识题）不注入，避免干扰其输出格式。
+        function withMathStandards(systemPrompt) {
+            const base = String(systemPrompt || '').trim();
+            const standards = i18n('prompt_math_standards');
+            return base ? base + '\n\n' + standards : standards;
         }
 
         // ==================== 通用AI调用 ====================
@@ -19387,7 +19399,7 @@ ${i18n('prompt_outline_gen')}`;
 
             activeLectureGenerationCount++;
             try {
-                const systemPrompt = i18n('prompt_lecture_sys');
+                const systemPrompt = withMathStandards(i18n('prompt_lecture_sys'));
 
                 const userMessage = `${i18n('prompt_lecture_book')}${book.title}
 ${i18n('prompt_lecture_chapter')}${chapter.title}
@@ -21339,7 +21351,7 @@ ${i18n('prompt_lecture_gen')}`;
             }
 
             try {
-                const aiResponse = await callAI(i18n('prompt_math_explain'), [{ role: 'user', content: prompt }]) || i18n('chat_no_ai_answer');
+                const aiResponse = await callAI(withMathStandards(i18n('prompt_math_explain')), [{ role: 'user', content: prompt }]) || i18n('chat_no_ai_answer');
 
                 // 在选中文本下方插入AI回答笔记
                 const qDiv = document.getElementById('exerciseDoingQuestion');
@@ -21577,7 +21589,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     basePrompt += i18n('prompt_wrong_context') + window._wrongAIContext;
                 }
 
-                const systemPrompt = persona ? (persona + '\n\n' + basePrompt) : basePrompt;
+                const systemPrompt = withMathStandards(persona ? (persona + '\n\n' + basePrompt) : basePrompt);
 
                 // 获取之前的聊天记录作为上下文
                 const chatMessages = [];
@@ -24054,6 +24066,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             if (isSeminar) {
                 systemPrompt += i18n('prompt_seminar_extra');
             }
+            systemPrompt = withMathStandards(systemPrompt);
 
             const userMsg = i18n('prompt_note_user', folder.name, session.title, material.ref);
 
@@ -24850,7 +24863,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
             if (!confirm(i18n('confirm_delete'))) return;
 
-            const systemPrompt = i18n('prompt_grade_system');
+            const systemPrompt = withMathStandards(i18n('prompt_grade_system'));
 
             let graded = 0;
             let failed = 0;
@@ -27173,7 +27186,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             // Show loading
             showToast(i18n('toast_asking_ai'));
 
-            const systemPrompt = i18n('prompt_grade_system');
+            const systemPrompt = withMathStandards(i18n('prompt_grade_system'));
 
             try {
                 const msgContent = [{
@@ -27477,7 +27490,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
             showToast(i18n('toast_asking_ai'));
 
-            const systemPrompt = i18n('prompt_grade_system');
+            const systemPrompt = withMathStandards(i18n('prompt_grade_system'));
 
             try {
                 const msgContent = [{
@@ -31052,7 +31065,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             if (btn) { btn.disabled = true; btn.textContent = i18n('grading'); }
             showToast(i18n('grading_in_progress'));
 
-            const systemPrompt = i18n('prompt_review_grade_system');
+            const systemPrompt = withMathStandards(i18n('prompt_review_grade_system'));
 
             try {
                 const msgContent = [{


### PR DESCRIPTION
重开的 PR（#23 已被 #24 revert，本分支从 revert 后的 main 重新拉出）。这次准则文字为原文照抄，未作改写、未加解释。

## 注入的准则原文

```
在各种问ai中，严格禁止“根据xx性质”“根据xx定理”而对定理内容性质内容不做任何阐述和解释的不负责任的回答。
一个定理如果存在多个版本和推广，必须保证使用的定理版本和讲解的定理版本字节级一致，禁止使用拓展定理却只给出基础版本说明。
回答必须和之前保持至少50%的一致性，在所有前文的基础上回答。
禁止更改聊天历史已经出现过的数学符号和记号。
严谨数学，禁止口语化。
```

英文与法文为这五句的一一对应翻译，不增不减。

## 改动

- 新增 i18n 键 `prompt_math_standards`（中/英/法）。
- 新增 `withMathStandards(systemPrompt)`：把准则追加到原系统提示之后。
- 注入 12 处：选中文本讲解、套索图片讲解、习题选中讲解（`prompt_math_explain`）、阅读问 AI 的两处系统提示（含重发路径）、讲义生成（`prompt_lecture_sys`）、错题问 AI（`prompt_chat_base`）、课堂 AI 笔记（`prompt_note_sys`）、习题批改三处（`prompt_grade_system`）、复习 Quiz 批改（`prompt_review_grade_system`）。
- 未注入：OCR、手写识别与手写索引、大纲生成、识题抽取与截断续写、录音转写纪要、Quiz 出题、论文摘要——这些只做识别或结构化抽取。
- README 中英文各引用一次准则原文。

## 验证

本地脚本校验（未提交到仓库）：

- 页面唯一的内联 `<script>` 块（约 1.3 MB）通过 `vm.Script` 编译，三语字符串引号与转义无语法错误。
- 中文准则字符串与原文逐字符相等（断言比对）。
- `withMathStandards` 的拼接行为（含空值、首尾空白）符合预期。
- 断言 12 处注入点齐全，且识别类与抽取类提示词未被包裹。
- `cmp app/src/main/assets/www/index.html docs/index.html` 一致。

---
_Generated by [Claude Code](https://claude.ai/code/session_01Usb5pkV5CJj1yhdqxWJtFQ)_