### PR TITLE
Fix BOOX reader startup white screen and crash

### DIFF
--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -9710,6 +9710,75 @@
             }
         }
 
+        function detectBooxReaderRuntime() {
+            try {
+                const nativeBridge = window.BooxPenNative;
+                if (nativeBridge && typeof nativeBridge.isBooxDevice === 'function'
+                        && nativeBridge.isBooxDevice()) return true;
+                if (nativeBridge && typeof nativeBridge.isAvailable === 'function'
+                        && nativeBridge.isAvailable()) return true;
+            } catch (e) {}
+            return /\b(?:boox|onyx)\b/i.test(navigator.userAgent || '');
+        }
+
+        const READER_IS_BOOX_RUNTIME = detectBooxReaderRuntime();
+        const PDF_BASE64_DECODE_CHUNK_CHARS = 256 * 1024; // Must stay divisible by 4.
+
+        function yieldReaderUi() {
+            return new Promise(resolve => setTimeout(resolve, 0));
+        }
+
+        function showReaderPdfLoadingState() {
+            const wrapper = document.getElementById('pdfCanvasWrapper');
+            if (!wrapper) return;
+            const loading = document.createElement('div');
+            loading.id = 'readerPdfLoading';
+            loading.style.cssText = 'padding:40px;text-align:center;color:var(--text-secondary);';
+            loading.textContent = i18n('loading_pdf');
+            wrapper.replaceChildren(loading);
+        }
+
+        // Decode legacy data-URL PDFs without creating one full-size base64
+        // substring and one full-size binary string at the same time. Those
+        // temporary copies can exceed the BOOX WebView heap before PDF.js starts.
+        async function decodePdfFileData(fileData, shouldContinue) {
+            if (fileData instanceof Blob) {
+                const buffer = await fileData.arrayBuffer();
+                return !shouldContinue || shouldContinue() ? new Uint8Array(buffer) : null;
+            }
+            if (fileData instanceof ArrayBuffer) return new Uint8Array(fileData);
+            if (ArrayBuffer.isView(fileData)) {
+                return new Uint8Array(fileData.buffer, fileData.byteOffset, fileData.byteLength);
+            }
+            if (typeof fileData !== 'string') throw new Error('Unsupported PDF storage format');
+
+            const comma = fileData.indexOf(',');
+            if (comma < 0 || !fileData.slice(0, comma).toLowerCase().includes(';base64')) {
+                throw new Error('Invalid PDF data URL');
+            }
+            const encodedStart = comma + 1;
+            const encodedLength = fileData.length - encodedStart;
+            const padding = (fileData.endsWith('==') ? 2 : (fileData.endsWith('=') ? 1 : 0));
+            const decodedLength = Math.max(0, Math.floor(encodedLength * 3 / 4) - padding);
+            const bytes = new Uint8Array(decodedLength);
+            let written = 0;
+            let chunkIndex = 0;
+
+            for (let start = encodedStart; start < fileData.length;) {
+                let end = Math.min(fileData.length, start + PDF_BASE64_DECODE_CHUNK_CHARS);
+                if (end < fileData.length) end -= (end - start) % 4;
+                const rawChunk = atob(fileData.slice(start, end));
+                for (let i = 0; i < rawChunk.length; i++) bytes[written++] = rawChunk.charCodeAt(i);
+                start = end;
+                chunkIndex++;
+                if (start < fileData.length && chunkIndex % 4 === 0) {
+                    await yieldReaderUi();
+                    if (shouldContinue && !shouldContinue()) return null;
+                }
+            }
+            return written === bytes.length ? bytes : bytes.subarray(0, written);
+        }
+
         async function loadPDF(doc) {
             const documentLoadGeneration = ++readerDocumentLoadGeneration;
             let scrollReleaseScheduled = false;
@@ -9718,6 +9787,11 @@
                 // then release its GPU/heap resources before allocating the next.
                 suppressScrollWriteback = true;
                 await disposeReaderDocumentResources();
+                if (documentLoadGeneration !== readerDocumentLoadGeneration
+                        || !currentDoc || currentDoc.id !== doc.id) return;
+                showReaderPdfLoadingState();
+                document.getElementById('readerPageNav').style.display = 'none';
+                await new Promise(resolve => requestAnimationFrame(() => resolve()));
                 if (documentLoadGeneration !== readerDocumentLoadGeneration
                         || !currentDoc || currentDoc.id !== doc.id) return;
                 // 重置缩放倍率
@@ -9755,17 +9829,14 @@
                 if (documentLoadGeneration !== readerDocumentLoadGeneration
                         || !currentDoc || currentDoc.id !== doc.id) return;
                 
-                let data = fileData.split(',')[1];
-                let raw = atob(data);
-                let uint8 = new Uint8Array(raw.length);
-                for (let i = 0; i < raw.length; i++) uint8[i] = raw.charCodeAt(i);
+                let uint8 = await decodePdfFileData(fileData, () =>
+                    documentLoadGeneration === readerDocumentLoadGeneration
+                        && currentDoc && currentDoc.id === doc.id);
+                fileData = null;
+                if (!uint8) return;
 
                 const loadingTask = pdfjsLib.getDocument({ data: uint8 });
-                // PDF.js owns/transfers the byte buffer from here. Drop the
-                // temporary data-URL/base64/binary copies before parsing pages.
-                fileData = null;
-                data = null;
-                raw = null;
+                // PDF.js owns/transfers the byte buffer from here.
                 uint8 = null;
                 readerPdfLoadingTask = loadingTask;
                 let loadedPdfDoc;
@@ -9869,10 +9940,13 @@
         }
 
         // ==================== Continuous Scroll Mode (Note Mode) ====================
-        // A PDF page has both a PDF canvas and a same-sized annotation canvas. Keep
-        // each backing store modest on memory-constrained iPad PWAs and allow a
-        // scale below 1 at high zoom so the cap remains real.
-        const READER_MAX_CANVAS_PIXELS = 4 * 1024 * 1024;
+        // A PDF page has both a PDF canvas and a same-sized annotation canvas.
+        // BOOX WebView renderers have a tighter heap/GPU budget, so keep their
+        // backing stores and off-screen render window smaller.
+        const READER_MAX_CANVAS_PIXELS = (READER_IS_BOOX_RUNTIME ? 2 : 4) * 1024 * 1024;
+        const READER_RENDER_MARGIN_SCREENS = READER_IS_BOOX_RUNTIME ? 0.25 : 1;
+        const READER_KEEP_MARGIN_SCREENS = READER_IS_BOOX_RUNTIME ? 0.75 : 2;
+        const READER_PLACEHOLDER_BATCH_SIZE = 400;
         let renderedPages = new Set();
         let pageElements = {};
         let isRenderingAllPages = false;
@@ -9892,35 +9966,52 @@
             const wrapper = document.getElementById('pdfCanvasWrapper');
             releaseAllReaderCanvases();
             resetReaderInkHistory();
-            wrapper.innerHTML = '';
             renderedPages.clear();
             pageElements = {};
 
             try {
-                // 创建所有页面的占位符
-                for (let i = 1; i <= totalPages; i++) {
-                    const page = await sourcePdfDoc.getPage(i);
-                    if (renderGeneration !== readerRenderGeneration || pdfDoc !== sourcePdfDoc) return;
-                    const scale = getReaderRenderScale(page);
-                    const viewport = page.getViewport({ scale });
+                // Read one page for the initial aspect ratio. Calling getPage()
+                // for every page before first paint makes large PDFs appear as a
+                // white screen and keeps every PDFPageProxy cached by PDF.js.
+                const seedPageNum = Math.max(1, Math.min(totalPages, currentPage || 1));
+                const seedPage = await sourcePdfDoc.getPage(seedPageNum);
+                if (renderGeneration !== readerRenderGeneration || pdfDoc !== sourcePdfDoc) return;
+                const seedScale = getReaderRenderScale(seedPage);
+                const seedViewport = seedPage.getViewport({ scale: seedScale });
+                const fragment = document.createDocumentFragment();
 
+                // Most PDFs use one page size. Lightweight approximate
+                // placeholders make continuous scrolling available immediately;
+                // renderSinglePage corrects each page to its actual dimensions.
+                for (let i = 1; i <= totalPages; i++) {
                     const placeholder = document.createElement('div');
                     placeholder.className = 'pdf-page-placeholder';
                     placeholder.dataset.page = i;
-                    placeholder.style.width = viewport.width + 'px';
-                    placeholder.style.height = viewport.height + 'px';
+                    placeholder.style.width = seedViewport.width + 'px';
+                    placeholder.style.height = seedViewport.height + 'px';
                     placeholder.style.background = '#fff';
                     placeholder.style.boxShadow = 'var(--shadow)';
                     placeholder.style.position = 'relative';
+                    if (i === seedPageNum) {
+                        const pageLoading = document.createElement('div');
+                        pageLoading.style.cssText = 'position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--text-secondary);';
+                        pageLoading.textContent = i18n('loading_pdf');
+                        placeholder.appendChild(pageLoading);
+                    }
 
-                    pageElements[i] = { placeholder, viewport, rendered: false };
-                    wrapper.appendChild(placeholder);
+                    pageElements[i] = { placeholder, viewport: seedViewport, rendered: false };
+                    fragment.appendChild(placeholder);
+                    if (i < totalPages && i % READER_PLACEHOLDER_BATCH_SIZE === 0) {
+                        await yieldReaderUi();
+                        if (renderGeneration !== readerRenderGeneration || pdfDoc !== sourcePdfDoc) return;
+                    }
                 }
+                wrapper.replaceChildren(fragment);
 
                 if (einkMode) {
                     isRenderingAllPages = false;
                     setupEinkReaderTapZones();
-                    einkShowPage(currentPage || 1);
+                    await einkShowPage(currentPage || 1);
                 } else {
                     // Position the placeholder list before allocating canvases.
                     // Deep-page restore must not first render the page-one window
@@ -9973,12 +10064,15 @@
             const container = document.getElementById('readerContainer');
             const containerRect = container.getBoundingClientRect();
             const scrollTop = container.scrollTop;
-            const viewportTop = scrollTop - containerRect.height;
-            const viewportBottom = scrollTop + containerRect.height * 2;
+            const viewportTop = scrollTop - containerRect.height * READER_RENDER_MARGIN_SCREENS;
+            const viewportBottom = scrollTop
+                + containerRect.height * (1 + READER_RENDER_MARGIN_SCREENS);
 
             const releaseOutsideKeepWindow = candidateScrollTop => {
-                const keepTop = candidateScrollTop - containerRect.height * 2;
-                const keepBottom = candidateScrollTop + containerRect.height * 3;
+                const keepTop = candidateScrollTop
+                    - containerRect.height * READER_KEEP_MARGIN_SCREENS;
+                const keepBottom = candidateScrollTop
+                    + containerRect.height * (1 + READER_KEEP_MARGIN_SCREENS);
                 for (let i = 1; i <= totalPages; i++) {
                     const pageData = pageElements[i];
                     if (!pageData || !pageData.rendered || pageData.renderingPromise) continue;
@@ -10028,8 +10122,11 @@
                 try { page.cleanup(); } catch (e) {}
                 return;
             }
-            const viewport = pageData.viewport;
+            const viewport = page.getViewport({ scale: getReaderRenderScale(page) });
             const placeholder = pageData.placeholder;
+            pageData.viewport = viewport;
+            placeholder.style.width = viewport.width + 'px';
+            placeholder.style.height = viewport.height + 'px';
 
             // 限制canvas实际像素，zoom大时降低DPR避免内存爆炸
             let dpr = window.devicePixelRatio || 1;
@@ -10785,7 +10882,7 @@
             }
         }
 
-        function einkShowPage(pageNum) {
+        async function einkShowPage(pageNum) {
             if (pageNum < 1 || pageNum > totalPages) return;
             closeAllNoteBubbles();
             clearReaderTextSelection();
@@ -10799,7 +10896,18 @@
             if (!pageData) return;
             pageData.placeholder.classList.add('eink-visible');
             currentPage = pageNum;
-            if (!pageData.rendered) renderSinglePage(pageNum);
+            // E-Ink mode shows only one page. Release every previous page before
+            // allocating the next pair of PDF/annotation canvases so memory does
+            // not grow with each page turn.
+            Array.from(renderedPages).forEach(renderedPage => {
+                if (renderedPage !== pageNum) releaseReaderPage(renderedPage);
+            });
+            if (!pageData.rendered) await renderSinglePage(pageNum);
+            if (pageElements[pageNum] !== pageData) return;
+            if (currentPage !== pageNum) {
+                releaseReaderPage(pageNum);
+                return;
+            }
             einkFitPage(pageData);
             document.getElementById('pageInfo').textContent = `${currentPage} / ${totalPages}`;
             if (!suppressScrollWriteback && !isRenderingAllPages && currentDoc && totalPages > 0) {

--- a/app/src/main/java/com/mathreader/boox/BooxPenBridge.java
+++ b/app/src/main/java/com/mathreader/boox/BooxPenBridge.java
@@ -2,6 +2,7 @@ package com.mathreader.boox;
 
 import android.app.Activity;
 import android.graphics.Rect;
+import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
@@ -96,6 +97,18 @@ public class BooxPenBridge {
     @JavascriptInterface
     public boolean isAvailable() {
         return sdkAvailable;
+    }
+
+    /**
+     * BOOX devices have a smaller WebView/GPU memory budget than most tablets.
+     * Expose the platform independently of pen-SDK initialization so the reader
+     * can still select its low-memory rendering profile if the SDK is unavailable.
+     */
+    @JavascriptInterface
+    public boolean isBooxDevice() {
+        String device = (Build.MANUFACTURER + " " + Build.BRAND + " " + Build.MODEL)
+                .toLowerCase(Locale.US);
+        return device.contains("onyx") || device.contains("boox");
     }
 
     /**

--- a/app/src/main/java/com/mathreader/boox/MainActivity.java
+++ b/app/src/main/java/com/mathreader/boox/MainActivity.java
@@ -11,6 +11,7 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.util.Log;
 import android.webkit.PermissionRequest;
+import android.webkit.RenderProcessGoneDetail;
 import android.webkit.URLUtil;
 import android.webkit.ValueCallback;
 import android.webkit.WebChromeClient;
@@ -20,6 +21,7 @@ import android.webkit.WebSettings;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.Toast;
+import android.view.ViewGroup;
 
 import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
@@ -144,6 +146,36 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public void onPageFinished(WebView view, String url) {
                 injectAdapter();
+            }
+
+            @Override
+            public boolean onRenderProcessGone(WebView view, RenderProcessGoneDetail detail) {
+                Log.e(TAG, "WebView renderer exited; didCrash=" + detail.didCrash()
+                        + ", priority=" + detail.rendererPriorityAtExit());
+                if (view != webView) {
+                    return true;
+                }
+
+                // A renderer that exceeded the BOOX memory budget cannot be reused.
+                // Remove it and recreate the activity instead of letting Android
+                // terminate the whole app (WebViewClient's default behavior).
+                if (penBridge != null) {
+                    penBridge.onDestroy();
+                    penBridge = null;
+                }
+                if (view.getParent() instanceof ViewGroup) {
+                    ((ViewGroup) view.getParent()).removeView(view);
+                }
+                view.destroy();
+                webView = null;
+                Toast.makeText(MainActivity.this, R.string.reader_restarted,
+                        Toast.LENGTH_LONG).show();
+                getWindow().getDecorView().post(() -> {
+                    if (!isFinishing() && !isDestroyed()) {
+                        recreate();
+                    }
+                });
+                return true;
             }
         });
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name">数学阅读</string>
+    <string name="reader_restarted">阅读器内存不足，已安全重启；请重新打开文档</string>
 </resources>

--- a/docs/index.html
+++ b/docs/index.html
@@ -9710,6 +9710,75 @@
             }
         }
 
+        function detectBooxReaderRuntime() {
+            try {
+                const nativeBridge = window.BooxPenNative;
+                if (nativeBridge && typeof nativeBridge.isBooxDevice === 'function'
+                        && nativeBridge.isBooxDevice()) return true;
+                if (nativeBridge && typeof nativeBridge.isAvailable === 'function'
+                        && nativeBridge.isAvailable()) return true;
+            } catch (e) {}
+            return /\b(?:boox|onyx)\b/i.test(navigator.userAgent || '');
+        }
+
+        const READER_IS_BOOX_RUNTIME = detectBooxReaderRuntime();
+        const PDF_BASE64_DECODE_CHUNK_CHARS = 256 * 1024; // Must stay divisible by 4.
+
+        function yieldReaderUi() {
+            return new Promise(resolve => setTimeout(resolve, 0));
+        }
+
+        function showReaderPdfLoadingState() {
+            const wrapper = document.getElementById('pdfCanvasWrapper');
+            if (!wrapper) return;
+            const loading = document.createElement('div');
+            loading.id = 'readerPdfLoading';
+            loading.style.cssText = 'padding:40px;text-align:center;color:var(--text-secondary);';
+            loading.textContent = i18n('loading_pdf');
+            wrapper.replaceChildren(loading);
+        }
+
+        // Decode legacy data-URL PDFs without creating one full-size base64
+        // substring and one full-size binary string at the same time. Those
+        // temporary copies can exceed the BOOX WebView heap before PDF.js starts.
+        async function decodePdfFileData(fileData, shouldContinue) {
+            if (fileData instanceof Blob) {
+                const buffer = await fileData.arrayBuffer();
+                return !shouldContinue || shouldContinue() ? new Uint8Array(buffer) : null;
+            }
+            if (fileData instanceof ArrayBuffer) return new Uint8Array(fileData);
+            if (ArrayBuffer.isView(fileData)) {
+                return new Uint8Array(fileData.buffer, fileData.byteOffset, fileData.byteLength);
+            }
+            if (typeof fileData !== 'string') throw new Error('Unsupported PDF storage format');
+
+            const comma = fileData.indexOf(',');
+            if (comma < 0 || !fileData.slice(0, comma).toLowerCase().includes(';base64')) {
+                throw new Error('Invalid PDF data URL');
+            }
+            const encodedStart = comma + 1;
+            const encodedLength = fileData.length - encodedStart;
+            const padding = (fileData.endsWith('==') ? 2 : (fileData.endsWith('=') ? 1 : 0));
+            const decodedLength = Math.max(0, Math.floor(encodedLength * 3 / 4) - padding);
+            const bytes = new Uint8Array(decodedLength);
+            let written = 0;
+            let chunkIndex = 0;
+
+            for (let start = encodedStart; start < fileData.length;) {
+                let end = Math.min(fileData.length, start + PDF_BASE64_DECODE_CHUNK_CHARS);
+                if (end < fileData.length) end -= (end - start) % 4;
+                const rawChunk = atob(fileData.slice(start, end));
+                for (let i = 0; i < rawChunk.length; i++) bytes[written++] = rawChunk.charCodeAt(i);
+                start = end;
+                chunkIndex++;
+                if (start < fileData.length && chunkIndex % 4 === 0) {
+                    await yieldReaderUi();
+                    if (shouldContinue && !shouldContinue()) return null;
+                }
+            }
+            return written === bytes.length ? bytes : bytes.subarray(0, written);
+        }
+
         async function loadPDF(doc) {
             const documentLoadGeneration = ++readerDocumentLoadGeneration;
             let scrollReleaseScheduled = false;
@@ -9718,6 +9787,11 @@
                 // then release its GPU/heap resources before allocating the next.
                 suppressScrollWriteback = true;
                 await disposeReaderDocumentResources();
+                if (documentLoadGeneration !== readerDocumentLoadGeneration
+                        || !currentDoc || currentDoc.id !== doc.id) return;
+                showReaderPdfLoadingState();
+                document.getElementById('readerPageNav').style.display = 'none';
+                await new Promise(resolve => requestAnimationFrame(() => resolve()));
                 if (documentLoadGeneration !== readerDocumentLoadGeneration
                         || !currentDoc || currentDoc.id !== doc.id) return;
                 // 重置缩放倍率
@@ -9755,17 +9829,14 @@
                 if (documentLoadGeneration !== readerDocumentLoadGeneration
                         || !currentDoc || currentDoc.id !== doc.id) return;
                 
-                let data = fileData.split(',')[1];
-                let raw = atob(data);
-                let uint8 = new Uint8Array(raw.length);
-                for (let i = 0; i < raw.length; i++) uint8[i] = raw.charCodeAt(i);
+                let uint8 = await decodePdfFileData(fileData, () =>
+                    documentLoadGeneration === readerDocumentLoadGeneration
+                        && currentDoc && currentDoc.id === doc.id);
+                fileData = null;
+                if (!uint8) return;
 
                 const loadingTask = pdfjsLib.getDocument({ data: uint8 });
-                // PDF.js owns/transfers the byte buffer from here. Drop the
-                // temporary data-URL/base64/binary copies before parsing pages.
-                fileData = null;
-                data = null;
-                raw = null;
+                // PDF.js owns/transfers the byte buffer from here.
                 uint8 = null;
                 readerPdfLoadingTask = loadingTask;
                 let loadedPdfDoc;
@@ -9869,10 +9940,13 @@
         }
 
         // ==================== Continuous Scroll Mode (Note Mode) ====================
-        // A PDF page has both a PDF canvas and a same-sized annotation canvas. Keep
-        // each backing store modest on memory-constrained iPad PWAs and allow a
-        // scale below 1 at high zoom so the cap remains real.
-        const READER_MAX_CANVAS_PIXELS = 4 * 1024 * 1024;
+        // A PDF page has both a PDF canvas and a same-sized annotation canvas.
+        // BOOX WebView renderers have a tighter heap/GPU budget, so keep their
+        // backing stores and off-screen render window smaller.
+        const READER_MAX_CANVAS_PIXELS = (READER_IS_BOOX_RUNTIME ? 2 : 4) * 1024 * 1024;
+        const READER_RENDER_MARGIN_SCREENS = READER_IS_BOOX_RUNTIME ? 0.25 : 1;
+        const READER_KEEP_MARGIN_SCREENS = READER_IS_BOOX_RUNTIME ? 0.75 : 2;
+        const READER_PLACEHOLDER_BATCH_SIZE = 400;
         let renderedPages = new Set();
         let pageElements = {};
         let isRenderingAllPages = false;
@@ -9892,35 +9966,52 @@
             const wrapper = document.getElementById('pdfCanvasWrapper');
             releaseAllReaderCanvases();
             resetReaderInkHistory();
-            wrapper.innerHTML = '';
             renderedPages.clear();
             pageElements = {};
 
             try {
-                // 创建所有页面的占位符
-                for (let i = 1; i <= totalPages; i++) {
-                    const page = await sourcePdfDoc.getPage(i);
-                    if (renderGeneration !== readerRenderGeneration || pdfDoc !== sourcePdfDoc) return;
-                    const scale = getReaderRenderScale(page);
-                    const viewport = page.getViewport({ scale });
+                // Read one page for the initial aspect ratio. Calling getPage()
+                // for every page before first paint makes large PDFs appear as a
+                // white screen and keeps every PDFPageProxy cached by PDF.js.
+                const seedPageNum = Math.max(1, Math.min(totalPages, currentPage || 1));
+                const seedPage = await sourcePdfDoc.getPage(seedPageNum);
+                if (renderGeneration !== readerRenderGeneration || pdfDoc !== sourcePdfDoc) return;
+                const seedScale = getReaderRenderScale(seedPage);
+                const seedViewport = seedPage.getViewport({ scale: seedScale });
+                const fragment = document.createDocumentFragment();
 
+                // Most PDFs use one page size. Lightweight approximate
+                // placeholders make continuous scrolling available immediately;
+                // renderSinglePage corrects each page to its actual dimensions.
+                for (let i = 1; i <= totalPages; i++) {
                     const placeholder = document.createElement('div');
                     placeholder.className = 'pdf-page-placeholder';
                     placeholder.dataset.page = i;
-                    placeholder.style.width = viewport.width + 'px';
-                    placeholder.style.height = viewport.height + 'px';
+                    placeholder.style.width = seedViewport.width + 'px';
+                    placeholder.style.height = seedViewport.height + 'px';
                     placeholder.style.background = '#fff';
                     placeholder.style.boxShadow = 'var(--shadow)';
                     placeholder.style.position = 'relative';
+                    if (i === seedPageNum) {
+                        const pageLoading = document.createElement('div');
+                        pageLoading.style.cssText = 'position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:var(--text-secondary);';
+                        pageLoading.textContent = i18n('loading_pdf');
+                        placeholder.appendChild(pageLoading);
+                    }
 
-                    pageElements[i] = { placeholder, viewport, rendered: false };
-                    wrapper.appendChild(placeholder);
+                    pageElements[i] = { placeholder, viewport: seedViewport, rendered: false };
+                    fragment.appendChild(placeholder);
+                    if (i < totalPages && i % READER_PLACEHOLDER_BATCH_SIZE === 0) {
+                        await yieldReaderUi();
+                        if (renderGeneration !== readerRenderGeneration || pdfDoc !== sourcePdfDoc) return;
+                    }
                 }
+                wrapper.replaceChildren(fragment);
 
                 if (einkMode) {
                     isRenderingAllPages = false;
                     setupEinkReaderTapZones();
-                    einkShowPage(currentPage || 1);
+                    await einkShowPage(currentPage || 1);
                 } else {
                     // Position the placeholder list before allocating canvases.
                     // Deep-page restore must not first render the page-one window
@@ -9973,12 +10064,15 @@
             const container = document.getElementById('readerContainer');
             const containerRect = container.getBoundingClientRect();
             const scrollTop = container.scrollTop;
-            const viewportTop = scrollTop - containerRect.height;
-            const viewportBottom = scrollTop + containerRect.height * 2;
+            const viewportTop = scrollTop - containerRect.height * READER_RENDER_MARGIN_SCREENS;
+            const viewportBottom = scrollTop
+                + containerRect.height * (1 + READER_RENDER_MARGIN_SCREENS);
 
             const releaseOutsideKeepWindow = candidateScrollTop => {
-                const keepTop = candidateScrollTop - containerRect.height * 2;
-                const keepBottom = candidateScrollTop + containerRect.height * 3;
+                const keepTop = candidateScrollTop
+                    - containerRect.height * READER_KEEP_MARGIN_SCREENS;
+                const keepBottom = candidateScrollTop
+                    + containerRect.height * (1 + READER_KEEP_MARGIN_SCREENS);
                 for (let i = 1; i <= totalPages; i++) {
                     const pageData = pageElements[i];
                     if (!pageData || !pageData.rendered || pageData.renderingPromise) continue;
@@ -10028,8 +10122,11 @@
                 try { page.cleanup(); } catch (e) {}
                 return;
             }
-            const viewport = pageData.viewport;
+            const viewport = page.getViewport({ scale: getReaderRenderScale(page) });
             const placeholder = pageData.placeholder;
+            pageData.viewport = viewport;
+            placeholder.style.width = viewport.width + 'px';
+            placeholder.style.height = viewport.height + 'px';
 
             // 限制canvas实际像素，zoom大时降低DPR避免内存爆炸
             let dpr = window.devicePixelRatio || 1;
@@ -10785,7 +10882,7 @@
             }
         }
 
-        function einkShowPage(pageNum) {
+        async function einkShowPage(pageNum) {
             if (pageNum < 1 || pageNum > totalPages) return;
             closeAllNoteBubbles();
             clearReaderTextSelection();
@@ -10799,7 +10896,18 @@
             if (!pageData) return;
             pageData.placeholder.classList.add('eink-visible');
             currentPage = pageNum;
-            if (!pageData.rendered) renderSinglePage(pageNum);
+            // E-Ink mode shows only one page. Release every previous page before
+            // allocating the next pair of PDF/annotation canvases so memory does
+            // not grow with each page turn.
+            Array.from(renderedPages).forEach(renderedPage => {
+                if (renderedPage !== pageNum) releaseReaderPage(renderedPage);
+            });
+            if (!pageData.rendered) await renderSinglePage(pageNum);
+            if (pageElements[pageNum] !== pageData) return;
+            if (currentPage !== pageNum) {
+                releaseReaderPage(pageNum);
+                return;
+            }
             einkFitPage(pageData);
             document.getElementById('pageInfo').textContent = `${currentPage} / ${totalPages}`;
             if (!suppressScrollWriteback && !isRenderingAllPages && currentDoc && totalPages > 0) {


### PR DESCRIPTION
## 问题

BOOX 设备进入阅读界面时，旧实现会在首屏出现前遍历整本文档的页面对象，同时保留 data URL、Base64 子串、完整二进制字符串和 PDF 字节数组。阅读页还会分配 PDF 与批注双层画布；在 BOOX WebView 的内存预算下，这会造成长时间白屏，随后渲染进程或应用退出。

## 修复

- 增加 BOOX 运行环境识别，为 BOOX 使用更低的单页 Canvas 像素预算和更小的预渲染窗口。
- PDF Base64 数据改为分块解码，并在解码期间让出事件循环、显示加载状态。
- 初始布局只读取当前页尺寸，不再在首屏前逐页调用 `getPage()`。
- 墨水屏翻页前释放其他已渲染页面，避免双层 Canvas 持续累积。
- 实际渲染页面时重新校正每页尺寸，兼容混合页面大小的 PDF。
- 处理 Android `onRenderProcessGone`：渲染进程退出时销毁失效 WebView 并安全重建阅读界面，避免整个应用直接闪退。
- 同步更新 APK 内置页面与 GitHub Pages 镜像。

## 验证

- 内联 JavaScript 语法解析通过。
- 分块 PDF 解码覆盖多种长度并逐字节一致。
- 本地页面启动正常，控制台无错误。
- 两份 `index.html` 内容一致。
- `git diff --check` 通过。

当前环境未安装 JDK，因此未执行完整 Android Gradle 编译；未运行全量测试。