### PR TITLE
修复笔记工具栏偶发点击失效并隔离书写区

### DIFF
--- a/app/src/main/assets/boox-pen.js
+++ b/app/src/main/assets/boox-pen.js
@@ -108,8 +108,6 @@
     // PWA 可主动请求重绘，清掉原生直渲染层的残留墨迹（套索轨迹、点按墨点等）
     window.__booxPen.refresh = function () { scheduleRefresh(150); };
 
-    var DPR = window.devicePixelRatio || 1;
-
     // 可手写画布注册表，按优先级排列（覆盖层在前）。
     // eraserBtn: 对应橡皮按钮（active 时挂起原生直渲染，走 PWA 默认事件路径）
     // eraserToggle: 全局函数名，回放原生笔侧橡皮笔迹时临时切换
@@ -133,8 +131,9 @@
     var activeCfg = null;
     var activeEls = [];
     var lastKey = 'off';
+    var nativeDrawingEnabled = false;
 
-    function isDrawable(el) {
+    function isGeometryVisible(el) {
         if (!el || !el.isConnected) { return false; }
         var cs = getComputedStyle(el);
         if (cs.display === 'none' || cs.visibility === 'hidden' || cs.pointerEvents === 'none') {
@@ -143,7 +142,13 @@
         var r = el.getBoundingClientRect();
         if (r.width < 4 || r.height < 4) { return false; }
         var vw = window.innerWidth, vh = window.innerHeight;
-        if (r.right <= 0 || r.bottom <= 0 || r.left >= vw || r.top >= vh) { return false; }
+        return r.right > 0 && r.bottom > 0 && r.left < vw && r.top < vh;
+    }
+
+    function isDrawable(el) {
+        if (!isGeometryVisible(el)) { return false; }
+        var r = el.getBoundingClientRect();
+        var vw = window.innerWidth, vh = window.innerHeight;
         // 顶层采样：被弹窗/面板遮住时不能抢笔
         var samples = [
             [r.left + r.width / 2, r.top + r.height / 2],
@@ -176,6 +181,7 @@
 
     function setNative(payload) {
         var key = payload ? JSON.stringify(payload) : 'off';
+        nativeDrawingEnabled = !!(payload && payload.enabled !== false);
         if (key === lastKey) { return; }
         lastKey = key;
         try {
@@ -194,13 +200,15 @@
             var els = cfg.selector
                 ? Array.prototype.slice.call(document.querySelectorAll(cfg.selector))
                 : [document.getElementById(cfg.id)];
-            els = els.filter(isDrawable);
+            // 面板/弹窗覆盖画布时仍保留边界，但把原生直写关闭。
+            // 这样关闭 UI 的同一次手势不会在中途重新抢回书写。
+            var suspended = cfg.suspendFlag && window[cfg.suspendFlag];
+            els = els.filter(suspended ? isGeometryVisible : isDrawable);
             if (els.length) { found = { cfg: cfg, els: els }; }
         }
-        if (!found || eraserActive(found.cfg)) {
-            activeCfg = found ? found.cfg : null;
-            activeEls = found ? found.els : [];
-            for (var g = 0; g < activeEls.length; g++) { installFingerGuard(activeEls[g]); }
+        if (!found) {
+            activeCfg = null;
+            activeEls = [];
             setNative(null);
             return;
         }
@@ -208,20 +216,30 @@
         activeEls = found.els;
         for (var g = 0; g < activeEls.length; g++) { installFingerGuard(activeEls[g]); }
         var vw = window.innerWidth, vh = window.innerHeight;
-        var rects = found.els.map(function (el) {
+        // WebView 的 MotionEvent 使用视图本地物理像素；DPR 可随缩放/窗口变化，
+        // 每次同步都重新读取，避免旧书写矩形压到工具栏。
+        var dpr = window.devicePixelRatio || 1;
+        function physicalRect(el) {
+            if (!el || !el.isConnected) { return null; }
+            var cs = getComputedStyle(el);
+            if (cs.display === 'none' || cs.visibility === 'hidden') { return null; }
             var r = el.getBoundingClientRect();
+            if (r.width < 1 || r.height < 1) { return null; }
             return [
-                Math.round(Math.max(r.left, 0) * DPR),
-                Math.round(Math.max(r.top, 0) * DPR),
-                Math.round(Math.min(r.right, vw) * DPR),
-                Math.round(Math.min(r.bottom, vh) * DPR)
+                Math.round(Math.max(r.left, 0) * dpr),
+                Math.round(Math.max(r.top, 0) * dpr),
+                Math.round(Math.min(r.right, vw) * dpr),
+                Math.round(Math.min(r.bottom, vh) * dpr)
             ];
-        });
+        }
+        var rects = found.els.map(function (el) {
+            return physicalRect(el);
+        }).filter(Boolean);
         var cssW = found.cfg.cssWidth || 2;
         if (found.cfg.widthFlag && Number(window[found.cfg.widthFlag]) > 0) {
             cssW = Number(window[found.cfg.widthFlag]);
         }
-        setNative({ rects: rects, width: cssW * DPR });
+        setNative({ rects: rects, width: cssW * dpr, enabled: !eraserActive(found.cfg) });
     }
 
     // 模式按钮切换后立即重算原生区域，避免等待轮询期间首笔仍落到旧画布。
@@ -243,7 +261,7 @@
     function installFingerGuard(el) {
         if (el._booxFingerGuard) { return; }
         var block = function (e) {
-            if (lastKey === 'off') { return; }
+            if (!nativeDrawingEnabled) { return; }
             if (e.pointerType === 'pen') { return; }
             e.stopPropagation();
             e.preventDefault();
@@ -304,8 +322,9 @@
     // points: [[viewPxX, viewPxY, pressure], ...]，erase: 笔侧橡皮
     window.__booxPen.onStroke = function (points, erase) {
         if (!activeEls.length || !points || !points.length) { return; }
+        var dpr = window.devicePixelRatio || 1;
         var pts = points.map(function (p) {
-            return [p[0] / DPR, p[1] / DPR, p[2] || 0.5];
+            return [p[0] / dpr, p[1] / dpr, p[2] || 0.5];
         });
         var x0 = pts[0][0], y0 = pts[0][1];
         var target = null;

--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -4541,6 +4541,7 @@
             display: flex; align-items: center; justify-content: space-between;
             padding: 0 10px; gap: 8px; z-index: 3010;
         }
+        .nb-topbar button, .nb-leftbar button { touch-action: manipulation; }
         .nb-topbar-left { display: flex; align-items: center; gap: 8px; min-width: 0; flex: 1; }
         .nb-topbar-right { display: flex; align-items: center; gap: 4px; flex-shrink: 0; }
         .nb-title { font-size: 15px; font-weight: 700; color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 30vw; }
@@ -28317,6 +28318,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         window.__nbNativeWidth = 2;
         let _nbOpenRequestToken = 0;
         let _nbPageLoadToken = 0;
+        let _nbPageMutationPending = false;
 
         function nbCurrentNotebook() { return nbGetNotebook(nbState.notebookId); }
         function nbCurrentPage() {
@@ -28394,6 +28396,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             nbState.redoStack = [];
             Object.keys(nbThumbCache).forEach(k => { delete nbThumbCache[k]; });
             window.__nbNativeSuspend = false;
+            nbSyncNativeRegions();
             renderNotebooksPage();
             // 关闭笔记本时做一次可见同步
             nbSyncNotebookEvent('notebook_close', closingPageId);
@@ -28476,22 +28479,27 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         function nbPrevPage() { if (nbState.pageIndex > 0) nbLoadPage(nbState.pageIndex - 1); }
         async function nbNextPage() {
             const nb = nbCurrentNotebook();
-            if (!nb) return;
+            if (!nb || _nbPageMutationPending) return;
             if (nbState.pageIndex < nb.pages.length - 1) {
                 nbLoadPage(nbState.pageIndex + 1);
                 return;
             }
             // 已是最后一页 → 自动以当前页模板追加新页
-            await nbSavePageNow();
-            const cur = nbCurrentPage();
-            const now = new Date().toISOString();
-            const page = { id: nbUid('nbp'), template: (cur && cur.template) || nb.template || 'blank', createdAt: now, updatedAt: now };
-            nb.pages.push(page);
-            nbTouch(nb);
-            saveData();
-            nbSyncNotebookEvent('notebook_page_add', page.id);
-            nbLoadPage(nb.pages.length - 1);
-            showToast(i18n('page_created'));
+            _nbPageMutationPending = true;
+            try {
+                await nbSavePageNow();
+                const cur = nbCurrentPage();
+                const now = new Date().toISOString();
+                const page = { id: nbUid('nbp'), template: (cur && cur.template) || nb.template || 'blank', createdAt: now, updatedAt: now };
+                nb.pages.push(page);
+                nbTouch(nb);
+                saveData();
+                nbSyncNotebookEvent('notebook_page_add', page.id);
+                await nbLoadPage(nb.pages.length - 1);
+                showToast(i18n('page_created'));
+            } finally {
+                _nbPageMutationPending = false;
+            }
         }
 
         // ==================== 布局与渲染 ====================
@@ -28524,6 +28532,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             window.__nbNativeWidth = Math.max(1, Math.min(14, brush.mm * NB_MM * s));
             nbDrawBg();
             nbRedraw();
+            nbSyncNativeRegions();
         }
 
         function nbCtx(id) {
@@ -28752,6 +28761,13 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         // 非书写工具（含套索）、或有弹窗/抽屉盖在画布上时，挂起 Boox 原生直渲染，
         // 走标准指针事件（否则原生层按矩形抢笔，会穿透弹窗直接书写）。
         // 选中文本框/媒体期间挂起，保证拖动、四角缩放的指针事件实时到达 DOM。
+        function nbSyncNativeRegions() {
+            try {
+                if (window.__booxPen && typeof window.__booxPen.syncRegions === 'function') {
+                    window.__booxPen.syncRegions();
+                }
+            } catch (e) {}
+        }
         function nbUpdateNativeSuspend() {
             const overlayOpen =
                 document.getElementById('nbPanel')?.classList.contains('show') ||
@@ -28760,6 +28776,8 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 document.getElementById('nbQuizModal')?.classList.contains('show') ||
                 document.getElementById('nbQuizFullscreen')?.classList.contains('show');
             window.__nbNativeSuspend = (nbState.tool !== 'pen') || !!overlayOpen || !!nbState.selectedTextId;
+            // 工具/面板状态改变时立即交接输入，不等 350ms 轮询。
+            nbSyncNativeRegions();
         }
         function nbNativeRefresh() {
             try { window.__booxPen && window.__booxPen.refresh && window.__booxPen.refresh(); } catch (e) {}
@@ -28769,7 +28787,6 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             if (nbState.tool !== 'eraser') nbState.prevTool = nbState.tool;
             nbState.tool = tool;
             if (tool !== 'lasso') nbClearSelection();
-            nbUpdateNativeSuspend();
             document.getElementById('nbEraserBtn').classList.toggle('active', tool === 'eraser');
             document.getElementById('nbLassoBtn').classList.toggle('active', tool === 'lasso');
             document.getElementById('nbTextBtn').classList.toggle('active', tool === 'text');
@@ -28777,14 +28794,11 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             document.querySelectorAll('.nb-brush-btn').forEach((b, i) =>
                 b.classList.toggle('active', tool === 'pen' && i === nbState.brushIndex));
             document.body.classList.toggle('nb-text-mode', tool === 'text');
+            // 状态和按钮选中态都提交后再交接原生输入。
+            nbUpdateNativeSuspend();
         }
         function toggleNbEraser() {
             nbSetTool(nbState.tool === 'eraser' ? (nbState.prevTool || 'pen') : 'eraser');
-            // 原生区域平时每 350ms 轮询一次；橡皮必须立即释放/接管画布，
-            // 否则切换后的第一次落笔仍会被上一种模式处理。
-            if (window.__booxPen && typeof window.__booxPen.syncRegions === 'function') {
-                window.__booxPen.syncRegions();
-            }
         }
         // 单击 = 仅切换笔刷（永不弹窗，点当前笔刷也只是确保选中）；
         // 双击（同一笔刷 400ms 内第二次点击，手动计时判定，不依赖平台 dblclick）= 配置弹窗
@@ -28803,9 +28817,9 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         }
         function nbSelectBrush(i) {
             nbState.brushIndex = i;
-            nbSetTool('pen');
             const brush = nbState.brushes[i];
             window.__nbNativeWidth = Math.max(1, Math.min(14, brush.mm * NB_MM * nbDisplayScale()));
+            nbSetTool('pen');
             nbRenderBrushBtns();
             // Boox 原生直渲染激活期间屏幕冻结、不展示底层 UI 更新——
             // 书写开始后点笔刷其实切换成功了但看不见。这里主动刷新一次让高亮立即上屏。
@@ -29746,30 +29760,36 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 </div>`;
         }
         async function nbInsertPage(after) {
-            const notebookId = nbState.notebookId;
-            const anchorPageId = nbCurrentPage()?.id;
-            if (!notebookId || !anchorPageId) return;
-            await nbSavePageNow();
-            const nb = nbGetNotebook(notebookId);
-            if (!nb || nbState.notebookId !== notebookId) return;
-            const anchorIndex = (nb.pages || []).findIndex(page => page?.id === anchorPageId);
-            if (anchorIndex < 0) {
-                showToast(i18n('page_deleted'));
-                return;
+            if (_nbPageMutationPending) return;
+            _nbPageMutationPending = true;
+            try {
+                const notebookId = nbState.notebookId;
+                const anchorPageId = nbCurrentPage()?.id;
+                if (!notebookId || !anchorPageId) return;
+                await nbSavePageNow();
+                const nb = nbGetNotebook(notebookId);
+                if (!nb || nbState.notebookId !== notebookId) return;
+                const anchorIndex = (nb.pages || []).findIndex(page => page?.id === anchorPageId);
+                if (anchorIndex < 0) {
+                    showToast(i18n('page_deleted'));
+                    return;
+                }
+                const sel = document.getElementById('nbNewPageTpl');
+                const anchorPage = nb.pages[anchorIndex];
+                const tpl = (!sel || sel.value === '__cur__') ? (anchorPage.template || 'blank') : sel.value;
+                const now = new Date().toISOString();
+                const page = { id: nbUid('nbp'), template: tpl, createdAt: now, updatedAt: now };
+                const at = anchorIndex + (after ? 1 : 0);
+                nb.pages.splice(at, 0, page);
+                nbTouch(nb);
+                saveData();
+                nbHidePanel();
+                nbSyncNotebookEvent('notebook_page_add', page.id);
+                await nbLoadPage(at);
+                showToast(i18n('page_inserted'));
+            } finally {
+                _nbPageMutationPending = false;
             }
-            const sel = document.getElementById('nbNewPageTpl');
-            const anchorPage = nb.pages[anchorIndex];
-            const tpl = (!sel || sel.value === '__cur__') ? (anchorPage.template || 'blank') : sel.value;
-            const now = new Date().toISOString();
-            const page = { id: nbUid('nbp'), template: tpl, createdAt: now, updatedAt: now };
-            const at = anchorIndex + (after ? 1 : 0);
-            nb.pages.splice(at, 0, page);
-            nbTouch(nb);
-            saveData();
-            nbHidePanel();
-            nbSyncNotebookEvent('notebook_page_add', page.id);
-            nbLoadPage(at);
-            showToast(i18n('page_inserted'));
         }
         async function nbDeleteCurrentPage() {
             nbHidePanel();

--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -28780,6 +28780,11 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         }
         function toggleNbEraser() {
             nbSetTool(nbState.tool === 'eraser' ? (nbState.prevTool || 'pen') : 'eraser');
+            // 原生区域平时每 350ms 轮询一次；橡皮必须立即释放/接管画布，
+            // 否则切换后的第一次落笔仍会被上一种模式处理。
+            if (window.__booxPen && typeof window.__booxPen.syncRegions === 'function') {
+                window.__booxPen.syncRegions();
+            }
         }
         // 单击 = 仅切换笔刷（永不弹窗，点当前笔刷也只是确保选中）；
         // 双击（同一笔刷 400ms 内第二次点击，手动计时判定，不依赖平台 dblclick）= 配置弹窗

--- a/app/src/main/java/com/mathreader/boox/BooxPenBridge.java
+++ b/app/src/main/java/com/mathreader/boox/BooxPenBridge.java
@@ -41,9 +41,31 @@ public class BooxPenBridge {
     private boolean rawOpened;
     // JS 侧期望的开关状态，onPause/onResume 时据此恢复
     private volatile boolean wantEnabled;
+    // 当前真正交给 TouchHelper 的书写区。区域外的手势属于 WebView UI，
+    // 必须在事件进入页面前暂停原生直写，避免工具栏按钮被冻结或吞掉。
+    private final List<Rect> activeDrawingRects = new ArrayList<>();
+    private boolean uiGesturePaused;
+    private boolean refreshPaused;
+    private boolean activityResumed;
     // 最近一次按下的输入工具类型（手指 / 触控笔），供阅读界面区分翻页与套索。
     // 默认手指：检测失败时退化为"点触翻页"，不会误吞翻页操作。
     private volatile int lastToolType = MotionEvent.TOOL_TYPE_FINGER;
+
+    private final Runnable resumeAfterUiGesture = () -> {
+        if (!uiGesturePaused) {
+            return;
+        }
+        uiGesturePaused = false;
+        enableRawDrawingIfAllowed("resume after UI gesture failed");
+    };
+
+    private final Runnable resumeAfterRefresh = () -> {
+        if (!refreshPaused) {
+            return;
+        }
+        refreshPaused = false;
+        enableRawDrawingIfAllowed("resume after refresh failed");
+    };
 
     private final RawInputCallback rawInputCallback = new RawInputCallback() {
         @Override
@@ -116,6 +138,97 @@ public class BooxPenBridge {
                 lastToolType = MotionEvent.TOOL_TYPE_FINGER;
             }
         }
+        // 笔悬停回书写区时提前恢复直写，避免等到物理落笔才重启导致首段丢点。
+        if ((action == MotionEvent.ACTION_HOVER_ENTER || action == MotionEvent.ACTION_HOVER_MOVE)
+                && !activeDrawingRects.isEmpty()) {
+            int hoverIndex = event.getActionIndex();
+            int toolType = event.getToolType(hoverIndex);
+            boolean stylus = toolType == MotionEvent.TOOL_TYPE_STYLUS
+                    || toolType == MotionEvent.TOOL_TYPE_ERASER;
+            if (stylus && wantEnabled
+                    && isInsideActiveDrawingRect(event.getX(hoverIndex), event.getY(hoverIndex))) {
+                resumeForDrawingGesture();
+            }
+        }
+        // 手势起点在书写区外时，在 WebView 分发 ACTION_DOWN 前暂停
+        // TouchHelper；画布内的手指/手掌不切换原生状态，避免影响随后落下的笔。
+        if (action == MotionEvent.ACTION_DOWN && !activeDrawingRects.isEmpty()) {
+            int toolType = event.getToolType(0);
+            boolean stylus = toolType == MotionEvent.TOOL_TYPE_STYLUS
+                    || toolType == MotionEvent.TOOL_TYPE_ERASER;
+            boolean insideDrawingRect = isInsideActiveDrawingRect(event.getX(), event.getY());
+            if (insideDrawingRect && wantEnabled) {
+                if (stylus) {
+                    resumeForDrawingGesture();
+                }
+            } else {
+                pauseForUiGesture();
+            }
+        } else if (action == MotionEvent.ACTION_POINTER_DOWN && !activeDrawingRects.isEmpty()) {
+            int pointerIndex = event.getActionIndex();
+            int toolType = event.getToolType(pointerIndex);
+            boolean stylus = toolType == MotionEvent.TOOL_TYPE_STYLUS
+                    || toolType == MotionEvent.TOOL_TYPE_ERASER;
+            if (stylus && wantEnabled
+                    && isInsideActiveDrawingRect(event.getX(pointerIndex), event.getY(pointerIndex))) {
+                resumeForDrawingGesture();
+            }
+        } else if ((action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_CANCEL)
+                && uiGesturePaused) {
+            mainHandler.removeCallbacks(resumeAfterUiGesture);
+            // click 在 ACTION_UP 后才由 WebView 派发，留出时间提交按钮/翻页 UI。
+            mainHandler.postDelayed(resumeAfterUiGesture, 260L);
+        }
+    }
+
+    private boolean isInsideActiveDrawingRect(float x, float y) {
+        int px = Math.round(x);
+        int py = Math.round(y);
+        for (Rect rect : activeDrawingRects) {
+            if (rect.contains(px, py)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void pauseForUiGesture() {
+        mainHandler.removeCallbacks(resumeAfterUiGesture);
+        uiGesturePaused = true;
+        try {
+            // UI 交接只关闭原生直渲染，不暂停 RawInputReader。
+            // 即使笔紧接着落到画布，原始点也不会因 UI 刷新而丢失。
+            touchHelper.setRawDrawingRenderEnabled(false);
+        } catch (Throwable t) {
+            Log.w(TAG, "pause for UI gesture failed", t);
+        }
+        webView.invalidate();
+    }
+
+    private void resumeForDrawingGesture() {
+        if ((!uiGesturePaused && !refreshPaused) || !wantEnabled || !activityResumed) {
+            return;
+        }
+        mainHandler.removeCallbacks(resumeAfterUiGesture);
+        mainHandler.removeCallbacks(resumeAfterRefresh);
+        uiGesturePaused = false;
+        refreshPaused = false;
+        enableRawDrawingIfAllowed("resume for drawing gesture failed");
+    }
+
+    private void enableRawDrawingIfAllowed(String failureMessage) {
+        if (!sdkAvailable || !wantEnabled || !activityResumed || uiGesturePaused || refreshPaused) {
+            return;
+        }
+        try {
+            if (touchHelper.isRawDrawingInputEnabled()) {
+                touchHelper.setRawDrawingRenderEnabled(true);
+            } else {
+                touchHelper.setRawDrawingEnabled(true);
+            }
+        } catch (Throwable t) {
+            Log.w(TAG, failureMessage, t);
+        }
     }
 
     /** 最近一次按下是否为触控笔（手写笔）。pointerType 缺失时 JS 侧据此判定。 */
@@ -131,7 +244,8 @@ public class BooxPenBridge {
     }
 
     /**
-     * json: {"rects":[[l,t,r,b],...], "width":4.5}，坐标为 WebView 视图内的物理像素。
+     * json: {"rects":[[l,t,r,b],...], "width":4.5, "enabled":true}，
+     * 坐标为 WebView 视图内的物理像素。enabled=false 时仅保留 UI/书写边界。
      */
     @JavascriptInterface
     public void setRects(final String json) {
@@ -162,21 +276,16 @@ public class BooxPenBridge {
             if (!wantEnabled) {
                 return;
             }
+            mainHandler.removeCallbacks(resumeAfterRefresh);
+            refreshPaused = true;
             try {
-                touchHelper.setRawDrawingEnabled(false);
+                // 只退出直渲染以让 WebView 内容上屏，保留原始笔输入。
+                touchHelper.setRawDrawingRenderEnabled(false);
             } catch (Throwable t) {
                 Log.w(TAG, "refresh disable failed", t);
             }
             webView.invalidate();
-            mainHandler.postDelayed(() -> {
-                if (wantEnabled) {
-                    try {
-                        touchHelper.setRawDrawingEnabled(true);
-                    } catch (Throwable t) {
-                        Log.w(TAG, "refresh enable failed", t);
-                    }
-                }
-            }, 260);
+            mainHandler.postDelayed(resumeAfterRefresh, 260L);
         });
     }
 
@@ -185,6 +294,7 @@ public class BooxPenBridge {
             JSONObject obj = new JSONObject(json);
             JSONArray arr = obj.getJSONArray("rects");
             float width = (float) obj.optDouble("width", 4.0);
+            boolean enabled = obj.optBoolean("enabled", true);
             List<Rect> rects = new ArrayList<>();
             for (int i = 0; i < arr.length(); i++) {
                 JSONArray r = arr.getJSONArray(i);
@@ -197,7 +307,14 @@ public class BooxPenBridge {
                 disableInternal();
                 return;
             }
+            activeDrawingRects.clear();
+            activeDrawingRects.addAll(rects);
             touchHelper.setRawDrawingEnabled(false);
+            if (!enabled) {
+                wantEnabled = false;
+                webView.invalidate();
+                return;
+            }
             touchHelper.setStrokeWidth(width).setLimitRect(rects, new ArrayList<>());
             if (!rawOpened) {
                 touchHelper.openRawDrawing();
@@ -209,8 +326,8 @@ public class BooxPenBridge {
             } else {
                 touchHelper.setSingleRegionMode();
             }
-            touchHelper.setRawDrawingEnabled(true);
             wantEnabled = true;
+            enableRawDrawingIfAllowed("enable after setRects failed");
         } catch (Throwable t) {
             Log.w(TAG, "setRects failed: " + json, t);
         }
@@ -218,6 +335,11 @@ public class BooxPenBridge {
 
     private void disableInternal() {
         wantEnabled = false;
+        uiGesturePaused = false;
+        refreshPaused = false;
+        mainHandler.removeCallbacks(resumeAfterUiGesture);
+        mainHandler.removeCallbacks(resumeAfterRefresh);
+        activeDrawingRects.clear();
         try {
             touchHelper.setRawDrawingEnabled(false);
         } catch (Throwable t) {
@@ -261,16 +383,12 @@ public class BooxPenBridge {
     }
 
     public void onResume() {
-        if (sdkAvailable && wantEnabled) {
-            try {
-                touchHelper.setRawDrawingEnabled(true);
-            } catch (Throwable t) {
-                Log.w(TAG, "onResume enable failed", t);
-            }
-        }
+        activityResumed = true;
+        enableRawDrawingIfAllowed("onResume enable failed");
     }
 
     public void onPause() {
+        activityResumed = false;
         if (sdkAvailable) {
             try {
                 touchHelper.setRawDrawingEnabled(false);
@@ -281,6 +399,8 @@ public class BooxPenBridge {
     }
 
     public void onDestroy() {
+        mainHandler.removeCallbacks(resumeAfterUiGesture);
+        mainHandler.removeCallbacks(resumeAfterRefresh);
         if (sdkAvailable && rawOpened) {
             try {
                 touchHelper.closeRawDrawing();

--- a/docs/index.html
+++ b/docs/index.html
@@ -4541,6 +4541,7 @@
             display: flex; align-items: center; justify-content: space-between;
             padding: 0 10px; gap: 8px; z-index: 3010;
         }
+        .nb-topbar button, .nb-leftbar button { touch-action: manipulation; }
         .nb-topbar-left { display: flex; align-items: center; gap: 8px; min-width: 0; flex: 1; }
         .nb-topbar-right { display: flex; align-items: center; gap: 4px; flex-shrink: 0; }
         .nb-title { font-size: 15px; font-weight: 700; color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 30vw; }
@@ -28317,6 +28318,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         window.__nbNativeWidth = 2;
         let _nbOpenRequestToken = 0;
         let _nbPageLoadToken = 0;
+        let _nbPageMutationPending = false;
 
         function nbCurrentNotebook() { return nbGetNotebook(nbState.notebookId); }
         function nbCurrentPage() {
@@ -28394,6 +28396,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             nbState.redoStack = [];
             Object.keys(nbThumbCache).forEach(k => { delete nbThumbCache[k]; });
             window.__nbNativeSuspend = false;
+            nbSyncNativeRegions();
             renderNotebooksPage();
             // 关闭笔记本时做一次可见同步
             nbSyncNotebookEvent('notebook_close', closingPageId);
@@ -28476,22 +28479,27 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         function nbPrevPage() { if (nbState.pageIndex > 0) nbLoadPage(nbState.pageIndex - 1); }
         async function nbNextPage() {
             const nb = nbCurrentNotebook();
-            if (!nb) return;
+            if (!nb || _nbPageMutationPending) return;
             if (nbState.pageIndex < nb.pages.length - 1) {
                 nbLoadPage(nbState.pageIndex + 1);
                 return;
             }
             // 已是最后一页 → 自动以当前页模板追加新页
-            await nbSavePageNow();
-            const cur = nbCurrentPage();
-            const now = new Date().toISOString();
-            const page = { id: nbUid('nbp'), template: (cur && cur.template) || nb.template || 'blank', createdAt: now, updatedAt: now };
-            nb.pages.push(page);
-            nbTouch(nb);
-            saveData();
-            nbSyncNotebookEvent('notebook_page_add', page.id);
-            nbLoadPage(nb.pages.length - 1);
-            showToast(i18n('page_created'));
+            _nbPageMutationPending = true;
+            try {
+                await nbSavePageNow();
+                const cur = nbCurrentPage();
+                const now = new Date().toISOString();
+                const page = { id: nbUid('nbp'), template: (cur && cur.template) || nb.template || 'blank', createdAt: now, updatedAt: now };
+                nb.pages.push(page);
+                nbTouch(nb);
+                saveData();
+                nbSyncNotebookEvent('notebook_page_add', page.id);
+                await nbLoadPage(nb.pages.length - 1);
+                showToast(i18n('page_created'));
+            } finally {
+                _nbPageMutationPending = false;
+            }
         }
 
         // ==================== 布局与渲染 ====================
@@ -28524,6 +28532,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             window.__nbNativeWidth = Math.max(1, Math.min(14, brush.mm * NB_MM * s));
             nbDrawBg();
             nbRedraw();
+            nbSyncNativeRegions();
         }
 
         function nbCtx(id) {
@@ -28752,6 +28761,13 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         // 非书写工具（含套索）、或有弹窗/抽屉盖在画布上时，挂起 Boox 原生直渲染，
         // 走标准指针事件（否则原生层按矩形抢笔，会穿透弹窗直接书写）。
         // 选中文本框/媒体期间挂起，保证拖动、四角缩放的指针事件实时到达 DOM。
+        function nbSyncNativeRegions() {
+            try {
+                if (window.__booxPen && typeof window.__booxPen.syncRegions === 'function') {
+                    window.__booxPen.syncRegions();
+                }
+            } catch (e) {}
+        }
         function nbUpdateNativeSuspend() {
             const overlayOpen =
                 document.getElementById('nbPanel')?.classList.contains('show') ||
@@ -28760,6 +28776,8 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 document.getElementById('nbQuizModal')?.classList.contains('show') ||
                 document.getElementById('nbQuizFullscreen')?.classList.contains('show');
             window.__nbNativeSuspend = (nbState.tool !== 'pen') || !!overlayOpen || !!nbState.selectedTextId;
+            // 工具/面板状态改变时立即交接输入，不等 350ms 轮询。
+            nbSyncNativeRegions();
         }
         function nbNativeRefresh() {
             try { window.__booxPen && window.__booxPen.refresh && window.__booxPen.refresh(); } catch (e) {}
@@ -28769,7 +28787,6 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             if (nbState.tool !== 'eraser') nbState.prevTool = nbState.tool;
             nbState.tool = tool;
             if (tool !== 'lasso') nbClearSelection();
-            nbUpdateNativeSuspend();
             document.getElementById('nbEraserBtn').classList.toggle('active', tool === 'eraser');
             document.getElementById('nbLassoBtn').classList.toggle('active', tool === 'lasso');
             document.getElementById('nbTextBtn').classList.toggle('active', tool === 'text');
@@ -28777,14 +28794,11 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             document.querySelectorAll('.nb-brush-btn').forEach((b, i) =>
                 b.classList.toggle('active', tool === 'pen' && i === nbState.brushIndex));
             document.body.classList.toggle('nb-text-mode', tool === 'text');
+            // 状态和按钮选中态都提交后再交接原生输入。
+            nbUpdateNativeSuspend();
         }
         function toggleNbEraser() {
             nbSetTool(nbState.tool === 'eraser' ? (nbState.prevTool || 'pen') : 'eraser');
-            // 原生区域平时每 350ms 轮询一次；橡皮必须立即释放/接管画布，
-            // 否则切换后的第一次落笔仍会被上一种模式处理。
-            if (window.__booxPen && typeof window.__booxPen.syncRegions === 'function') {
-                window.__booxPen.syncRegions();
-            }
         }
         // 单击 = 仅切换笔刷（永不弹窗，点当前笔刷也只是确保选中）；
         // 双击（同一笔刷 400ms 内第二次点击，手动计时判定，不依赖平台 dblclick）= 配置弹窗
@@ -28803,9 +28817,9 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         }
         function nbSelectBrush(i) {
             nbState.brushIndex = i;
-            nbSetTool('pen');
             const brush = nbState.brushes[i];
             window.__nbNativeWidth = Math.max(1, Math.min(14, brush.mm * NB_MM * nbDisplayScale()));
+            nbSetTool('pen');
             nbRenderBrushBtns();
             // Boox 原生直渲染激活期间屏幕冻结、不展示底层 UI 更新——
             // 书写开始后点笔刷其实切换成功了但看不见。这里主动刷新一次让高亮立即上屏。
@@ -29746,30 +29760,36 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 </div>`;
         }
         async function nbInsertPage(after) {
-            const notebookId = nbState.notebookId;
-            const anchorPageId = nbCurrentPage()?.id;
-            if (!notebookId || !anchorPageId) return;
-            await nbSavePageNow();
-            const nb = nbGetNotebook(notebookId);
-            if (!nb || nbState.notebookId !== notebookId) return;
-            const anchorIndex = (nb.pages || []).findIndex(page => page?.id === anchorPageId);
-            if (anchorIndex < 0) {
-                showToast(i18n('page_deleted'));
-                return;
+            if (_nbPageMutationPending) return;
+            _nbPageMutationPending = true;
+            try {
+                const notebookId = nbState.notebookId;
+                const anchorPageId = nbCurrentPage()?.id;
+                if (!notebookId || !anchorPageId) return;
+                await nbSavePageNow();
+                const nb = nbGetNotebook(notebookId);
+                if (!nb || nbState.notebookId !== notebookId) return;
+                const anchorIndex = (nb.pages || []).findIndex(page => page?.id === anchorPageId);
+                if (anchorIndex < 0) {
+                    showToast(i18n('page_deleted'));
+                    return;
+                }
+                const sel = document.getElementById('nbNewPageTpl');
+                const anchorPage = nb.pages[anchorIndex];
+                const tpl = (!sel || sel.value === '__cur__') ? (anchorPage.template || 'blank') : sel.value;
+                const now = new Date().toISOString();
+                const page = { id: nbUid('nbp'), template: tpl, createdAt: now, updatedAt: now };
+                const at = anchorIndex + (after ? 1 : 0);
+                nb.pages.splice(at, 0, page);
+                nbTouch(nb);
+                saveData();
+                nbHidePanel();
+                nbSyncNotebookEvent('notebook_page_add', page.id);
+                await nbLoadPage(at);
+                showToast(i18n('page_inserted'));
+            } finally {
+                _nbPageMutationPending = false;
             }
-            const sel = document.getElementById('nbNewPageTpl');
-            const anchorPage = nb.pages[anchorIndex];
-            const tpl = (!sel || sel.value === '__cur__') ? (anchorPage.template || 'blank') : sel.value;
-            const now = new Date().toISOString();
-            const page = { id: nbUid('nbp'), template: tpl, createdAt: now, updatedAt: now };
-            const at = anchorIndex + (after ? 1 : 0);
-            nb.pages.splice(at, 0, page);
-            nbTouch(nb);
-            saveData();
-            nbHidePanel();
-            nbSyncNotebookEvent('notebook_page_add', page.id);
-            nbLoadPage(at);
-            showToast(i18n('page_inserted'));
         }
         async function nbDeleteCurrentPage() {
             nbHidePanel();

--- a/docs/index.html
+++ b/docs/index.html
@@ -28780,6 +28780,11 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         }
         function toggleNbEraser() {
             nbSetTool(nbState.tool === 'eraser' ? (nbState.prevTool || 'pen') : 'eraser');
+            // 原生区域平时每 350ms 轮询一次；橡皮必须立即释放/接管画布，
+            // 否则切换后的第一次落笔仍会被上一种模式处理。
+            if (window.__booxPen && typeof window.__booxPen.syncRegions === 'function') {
+                window.__booxPen.syncRegions();
+            }
         }
         // 单击 = 仅切换笔刷（永不弹窗，点当前笔刷也只是确保选中）；
         // 双击（同一笔刷 400ms 内第二次点击，手动计时判定，不依赖平台 dblclick）= 配置弹窗


### PR DESCRIPTION
## 修复
- 以 `nbCanvas` 的物理区域作为原生书写边界：区域内保持低延迟直写，区域外的工具栏手势先释放 WebView 显示刷新
- 工具栏交接只暂停 Onyx 原生直渲染，不暂停 RawInputReader；画布内手指/手掌和连续 MOVE 不触发原生开关
- 触控笔悬停回画布时提前恢复直渲染，避免等到落笔后才恢复
- 橡皮、套索、文本、面板等明确非书写状态才完整关闭原生笔输入，同时保留当前边界，关闭界面的同一次手势不会中途抢回书写
- 工具、笔刷宽度、布局、开关面板和关闭笔记时立即同步原生状态，不再只等 350ms 轮询
- “下一页新建”和“插入页面”增加单次操作锁，避免界面刷新延迟下重复创建页面
- 同步更新网页与 APK 内置页面

## 风险控制
- 没有在笔迹 ACTION_MOVE 路径增加任何切换或计算
- 没有使用 SDK exclusion 区域，避免切换到其他画布后残留不可书写死区
- 无可写画布时清空原生边界和延迟回调

## 最小验证
- `docs/index.html` 与 APK 内置 `index.html` 完全一致
- `boox-pen.js` 及页面内联 JavaScript 语法检查通过
- `git diff --check` 通过
- Android APK 构建由本 PR 现有 build 检查验证（本地环境没有 Android SDK，因此未追加本地全量测试）

说明：代码层已确认 Onyx raw render 与 WebView UI 刷新存在交接竞态；没有 BOOX 真机事件日志，因此不把真机复现结果写成已证明。