### PR TITLE
修复笔记工具栏首次点按不生效

### DIFF
--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -4552,6 +4552,7 @@
         .nb-tb-btn svg { width: 21px; height: 21px; }
         .nb-tb-btn.active { background: var(--accent); color: #fff; }
         .nb-tb-btn:disabled { opacity: 0.35; cursor: default; }
+        .nb-topbar button, .nb-leftbar button { touch-action: manipulation; }
         .nb-tb-sep { width: 1px; height: 24px; background: var(--border-color, rgba(0,0,0,0.12)); margin: 0 4px; flex-shrink: 0; }
         .nb-brush-btn {
             width: 38px; height: 38px; border: none; background: none; border-radius: 10px;
@@ -28394,6 +28395,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             nbState.redoStack = [];
             Object.keys(nbThumbCache).forEach(k => { delete nbThumbCache[k]; });
             window.__nbNativeSuspend = false;
+            nbSyncNativeRegions();
             renderNotebooksPage();
             // 关闭笔记本时做一次可见同步
             nbSyncNotebookEvent('notebook_close', closingPageId);
@@ -28752,6 +28754,12 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         // 非书写工具（含套索）、或有弹窗/抽屉盖在画布上时，挂起 Boox 原生直渲染，
         // 走标准指针事件（否则原生层按矩形抢笔，会穿透弹窗直接书写）。
         // 选中文本框/媒体期间挂起，保证拖动、四角缩放的指针事件实时到达 DOM。
+        function nbSyncNativeRegions() {
+            try {
+                const pen = window.__booxPen;
+                if (pen && typeof pen.syncRegions === 'function') pen.syncRegions();
+            } catch (e) {}
+        }
         function nbUpdateNativeSuspend() {
             const overlayOpen =
                 document.getElementById('nbPanel')?.classList.contains('show') ||
@@ -28760,6 +28768,9 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 document.getElementById('nbQuizModal')?.classList.contains('show') ||
                 document.getElementById('nbQuizFullscreen')?.classList.contains('show');
             window.__nbNativeSuspend = (nbState.tool !== 'pen') || !!overlayOpen || !!nbState.selectedTextId;
+            // 不等 350ms 轮询：工具/面板状态变化后立即切换原生书写区域，
+            // 否则第一次点按后的 UI 与输入状态仍可能停留在旧模式。
+            nbSyncNativeRegions();
         }
         function nbNativeRefresh() {
             try { window.__booxPen && window.__booxPen.refresh && window.__booxPen.refresh(); } catch (e) {}
@@ -28769,7 +28780,6 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             if (nbState.tool !== 'eraser') nbState.prevTool = nbState.tool;
             nbState.tool = tool;
             if (tool !== 'lasso') nbClearSelection();
-            nbUpdateNativeSuspend();
             document.getElementById('nbEraserBtn').classList.toggle('active', tool === 'eraser');
             document.getElementById('nbLassoBtn').classList.toggle('active', tool === 'lasso');
             document.getElementById('nbTextBtn').classList.toggle('active', tool === 'text');
@@ -28777,6 +28787,8 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             document.querySelectorAll('.nb-brush-btn').forEach((b, i) =>
                 b.classList.toggle('active', tool === 'pen' && i === nbState.brushIndex));
             document.body.classList.toggle('nb-text-mode', tool === 'text');
+            // 先完成按钮高亮，再让原生层按新模式接管或释放画布。
+            nbUpdateNativeSuspend();
         }
         function toggleNbEraser() {
             nbSetTool(nbState.tool === 'eraser' ? (nbState.prevTool || 'pen') : 'eraser');
@@ -28802,6 +28814,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             const brush = nbState.brushes[i];
             window.__nbNativeWidth = Math.max(1, Math.min(14, brush.mm * NB_MM * nbDisplayScale()));
             nbRenderBrushBtns();
+            nbSyncNativeRegions();
             // Boox 原生直渲染激活期间屏幕冻结、不展示底层 UI 更新——
             // 书写开始后点笔刷其实切换成功了但看不见。这里主动刷新一次让高亮立即上屏。
             nbNativeRefresh();
@@ -31363,6 +31376,16 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 nbInitCanvasEvents();
                 nbInitFileInputs();
                 nbRenderBrushBtns();
+                // 原生直渲染会暂时冻结 WebView 画面。所有笔记工具栏按钮完成 click 后
+                // 主动同步区域并刷新，避免状态已经改变、视觉上却像第一次没点中。
+                document.getElementById('nbEditor')?.addEventListener('click', (e) => {
+                    const btn = e.target.closest?.('.nb-topbar button, .nb-leftbar button, .nb-float-toolbar button');
+                    if (!btn || btn.disabled) return;
+                    setTimeout(() => {
+                        nbSyncNativeRegions();
+                        nbNativeRefresh();
+                    }, 0);
+                });
                 // 面板打开时点击空白处（面板与其唤出按钮之外）自动关闭
                 document.addEventListener('pointerdown', (e) => {
                     const panel = document.getElementById('nbPanel');

--- a/docs/index.html
+++ b/docs/index.html
@@ -4552,6 +4552,7 @@
         .nb-tb-btn svg { width: 21px; height: 21px; }
         .nb-tb-btn.active { background: var(--accent); color: #fff; }
         .nb-tb-btn:disabled { opacity: 0.35; cursor: default; }
+        .nb-topbar button, .nb-leftbar button { touch-action: manipulation; }
         .nb-tb-sep { width: 1px; height: 24px; background: var(--border-color, rgba(0,0,0,0.12)); margin: 0 4px; flex-shrink: 0; }
         .nb-brush-btn {
             width: 38px; height: 38px; border: none; background: none; border-radius: 10px;
@@ -28394,6 +28395,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             nbState.redoStack = [];
             Object.keys(nbThumbCache).forEach(k => { delete nbThumbCache[k]; });
             window.__nbNativeSuspend = false;
+            nbSyncNativeRegions();
             renderNotebooksPage();
             // 关闭笔记本时做一次可见同步
             nbSyncNotebookEvent('notebook_close', closingPageId);
@@ -28752,6 +28754,12 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         // 非书写工具（含套索）、或有弹窗/抽屉盖在画布上时，挂起 Boox 原生直渲染，
         // 走标准指针事件（否则原生层按矩形抢笔，会穿透弹窗直接书写）。
         // 选中文本框/媒体期间挂起，保证拖动、四角缩放的指针事件实时到达 DOM。
+        function nbSyncNativeRegions() {
+            try {
+                const pen = window.__booxPen;
+                if (pen && typeof pen.syncRegions === 'function') pen.syncRegions();
+            } catch (e) {}
+        }
         function nbUpdateNativeSuspend() {
             const overlayOpen =
                 document.getElementById('nbPanel')?.classList.contains('show') ||
@@ -28760,6 +28768,9 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 document.getElementById('nbQuizModal')?.classList.contains('show') ||
                 document.getElementById('nbQuizFullscreen')?.classList.contains('show');
             window.__nbNativeSuspend = (nbState.tool !== 'pen') || !!overlayOpen || !!nbState.selectedTextId;
+            // 不等 350ms 轮询：工具/面板状态变化后立即切换原生书写区域，
+            // 否则第一次点按后的 UI 与输入状态仍可能停留在旧模式。
+            nbSyncNativeRegions();
         }
         function nbNativeRefresh() {
             try { window.__booxPen && window.__booxPen.refresh && window.__booxPen.refresh(); } catch (e) {}
@@ -28769,7 +28780,6 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             if (nbState.tool !== 'eraser') nbState.prevTool = nbState.tool;
             nbState.tool = tool;
             if (tool !== 'lasso') nbClearSelection();
-            nbUpdateNativeSuspend();
             document.getElementById('nbEraserBtn').classList.toggle('active', tool === 'eraser');
             document.getElementById('nbLassoBtn').classList.toggle('active', tool === 'lasso');
             document.getElementById('nbTextBtn').classList.toggle('active', tool === 'text');
@@ -28777,6 +28787,8 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             document.querySelectorAll('.nb-brush-btn').forEach((b, i) =>
                 b.classList.toggle('active', tool === 'pen' && i === nbState.brushIndex));
             document.body.classList.toggle('nb-text-mode', tool === 'text');
+            // 先完成按钮高亮，再让原生层按新模式接管或释放画布。
+            nbUpdateNativeSuspend();
         }
         function toggleNbEraser() {
             nbSetTool(nbState.tool === 'eraser' ? (nbState.prevTool || 'pen') : 'eraser');
@@ -28802,6 +28814,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             const brush = nbState.brushes[i];
             window.__nbNativeWidth = Math.max(1, Math.min(14, brush.mm * NB_MM * nbDisplayScale()));
             nbRenderBrushBtns();
+            nbSyncNativeRegions();
             // Boox 原生直渲染激活期间屏幕冻结、不展示底层 UI 更新——
             // 书写开始后点笔刷其实切换成功了但看不见。这里主动刷新一次让高亮立即上屏。
             nbNativeRefresh();
@@ -31363,6 +31376,16 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 nbInitCanvasEvents();
                 nbInitFileInputs();
                 nbRenderBrushBtns();
+                // 原生直渲染会暂时冻结 WebView 画面。所有笔记工具栏按钮完成 click 后
+                // 主动同步区域并刷新，避免状态已经改变、视觉上却像第一次没点中。
+                document.getElementById('nbEditor')?.addEventListener('click', (e) => {
+                    const btn = e.target.closest?.('.nb-topbar button, .nb-leftbar button, .nb-float-toolbar button');
+                    if (!btn || btn.disabled) return;
+                    setTimeout(() => {
+                        nbSyncNativeRegions();
+                        nbNativeRefresh();
+                    }, 0);
+                });
                 // 面板打开时点击空白处（面板与其唤出按钮之外）自动关闭
                 document.addEventListener('pointerdown', (e) => {
                     const panel = document.getElementById('nbPanel');


### PR DESCRIPTION
## 修复
- 笔记工具或面板状态变化时，立即同步 BOOX 原生书写区域，不再等待 350ms 轮询
- 先更新按钮高亮，再切换原生层的接管状态
- 笔记顶部、左侧及浮动工具栏按钮完成点击后主动刷新显示，避免第一次点击已经生效但画面仍停留在旧状态
- 为触控工具栏按钮启用单击操作优化
- 同步更新网页与 APK 内置页面

## 最小验证
- 内联 JavaScript 语法检查通过
- 两份 index.html 镜像完全一致
- git diff --check 通过