### PR TITLE
消除 BOOX 笔记工具栏延迟并隔离书写区

### DIFF
--- a/app/src/main/assets/boox-pen.js
+++ b/app/src/main/assets/boox-pen.js
@@ -99,16 +99,25 @@
     var hasNative = false;
     try { hasNative = !!(native && native.isAvailable()); } catch (e) { /* 非 Boox 设备 */ }
 
-    window.__booxPen = { active: hasNative, onStroke: function () {}, refresh: function () {} };
+    window.__booxPen = {
+        active: hasNative,
+        onStroke: function () {},
+        refresh: function () {},
+        syncRegions: function () {},
+        commitUi: function () {}
+    };
     if (!hasNative) {
         console.log('boox-pen: native pen SDK not available, PWA runs unmodified');
         return;
     }
     console.log('boox-pen: native pen SDK active');
     // PWA 可主动请求重绘，清掉原生直渲染层的残留墨迹（套索轨迹、点按墨点等）
-    window.__booxPen.refresh = function () { scheduleRefresh(150); };
-
-    var DPR = window.devicePixelRatio || 1;
+    window.__booxPen.refresh = function () {
+        try { native.refresh(); } catch (e) {}
+    };
+    window.__booxPen.commitUi = function () {
+        try { native.commitUi(); } catch (e) {}
+    };
 
     // 可手写画布注册表，按优先级排列（覆盖层在前）。
     // eraserBtn: 对应橡皮按钮（active 时挂起原生直渲染，走 PWA 默认事件路径）
@@ -208,24 +217,29 @@
         activeEls = found.els;
         for (var g = 0; g < activeEls.length; g++) { installFingerGuard(activeEls[g]); }
         var vw = window.innerWidth, vh = window.innerHeight;
+        var dpr = window.devicePixelRatio || 1;
         var rects = found.els.map(function (el) {
             var r = el.getBoundingClientRect();
             return [
-                Math.round(Math.max(r.left, 0) * DPR),
-                Math.round(Math.max(r.top, 0) * DPR),
-                Math.round(Math.min(r.right, vw) * DPR),
-                Math.round(Math.min(r.bottom, vh) * DPR)
+                Math.round(Math.max(r.left, 0) * dpr),
+                Math.round(Math.max(r.top, 0) * dpr),
+                Math.round(Math.min(r.right, vw) * dpr),
+                Math.round(Math.min(r.bottom, vh) * dpr)
             ];
         });
         var cssW = found.cfg.cssWidth || 2;
         if (found.cfg.widthFlag && Number(window[found.cfg.widthFlag]) > 0) {
             cssW = Number(window[found.cfg.widthFlag]);
         }
-        setNative({ rects: rects, width: cssW * DPR });
+        setNative({ rects: rects, width: cssW * dpr });
     }
 
-    // 模式按钮切换后立即重算原生区域，避免等待轮询期间首笔仍落到旧画布。
-    window.__booxPen.syncRegions = tick;
+    // 模式按钮切换后立即重算原生区域；同时通知原生侧
+    // DOM 已提交，恢复时机由 visual-state + 真实 onDraw 决定。
+    window.__booxPen.syncRegions = function () {
+        tick();
+        window.__booxPen.commitUi();
+    };
 
     var tickTimer = setInterval(tick, 350);
     var nudgeTimer = null;
@@ -259,21 +273,15 @@
     }
 
     /* -------- 撤销/重做/清空 后强制重绘，清掉原生层残留笔迹 -------- */
-    var refreshTimer = null;
-    function scheduleRefresh(delay) {
-        if (refreshTimer) { clearTimeout(refreshTimer); }
-        refreshTimer = setTimeout(function () {
-            refreshTimer = null;
-            try { native.refresh(); } catch (e) {}
-        }, delay);
-    }
     document.addEventListener('click', function (e) {
         if (lastKey === 'off') { return; }
         var btn = e.target && e.target.closest ? e.target.closest('button') : null;
         if (!btn) { return; }
         var sig = (btn.id || '') + ' ' + (btn.getAttribute('onclick') || '') + ' ' + (btn.className || '');
-        if (/undo|redo|clear|清空|清除/i.test(sig)) { scheduleRefresh(350); }
-    }, true);
+        if (/undo|redo|clear|清空|清除/i.test(sig)) {
+            try { native.refresh(); } catch (err) {}
+        }
+    });
 
     /* -------- 原生笔迹回放 -------- */
     function dispatchPointer(el, type, x, y, pressure, buttons) {
@@ -304,8 +312,9 @@
     // points: [[viewPxX, viewPxY, pressure], ...]，erase: 笔侧橡皮
     window.__booxPen.onStroke = function (points, erase) {
         if (!activeEls.length || !points || !points.length) { return; }
+        var dpr = window.devicePixelRatio || 1;
         var pts = points.map(function (p) {
-            return [p[0] / DPR, p[1] / DPR, p[2] || 0.5];
+            return [p[0] / dpr, p[1] / dpr, p[2] || 0.5];
         });
         var x0 = pts[0][0], y0 = pts[0][1];
         var target = null;
@@ -332,6 +341,8 @@
             }
         }
         // 橡皮：画布内容已变，但原生层在直渲染时不展示底层更新，需要重绘
-        if (erase) { scheduleRefresh(200); }
+        if (erase) {
+            try { native.refresh(); } catch (e) {}
+        }
     };
 })();

--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -28317,6 +28317,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         window.__nbNativeWidth = 2;
         let _nbOpenRequestToken = 0;
         let _nbPageLoadToken = 0;
+        let _nbPageMutationPending = false;
 
         function nbCurrentNotebook() { return nbGetNotebook(nbState.notebookId); }
         function nbCurrentPage() {
@@ -28394,6 +28395,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             nbState.redoStack = [];
             Object.keys(nbThumbCache).forEach(k => { delete nbThumbCache[k]; });
             window.__nbNativeSuspend = false;
+            nbSyncNativeRegions();
             renderNotebooksPage();
             // 关闭笔记本时做一次可见同步
             nbSyncNotebookEvent('notebook_close', closingPageId);
@@ -28476,22 +28478,27 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         function nbPrevPage() { if (nbState.pageIndex > 0) nbLoadPage(nbState.pageIndex - 1); }
         async function nbNextPage() {
             const nb = nbCurrentNotebook();
-            if (!nb) return;
+            if (!nb || _nbPageMutationPending) return;
             if (nbState.pageIndex < nb.pages.length - 1) {
                 nbLoadPage(nbState.pageIndex + 1);
                 return;
             }
             // 已是最后一页 → 自动以当前页模板追加新页
-            await nbSavePageNow();
-            const cur = nbCurrentPage();
-            const now = new Date().toISOString();
-            const page = { id: nbUid('nbp'), template: (cur && cur.template) || nb.template || 'blank', createdAt: now, updatedAt: now };
-            nb.pages.push(page);
-            nbTouch(nb);
-            saveData();
-            nbSyncNotebookEvent('notebook_page_add', page.id);
-            nbLoadPage(nb.pages.length - 1);
-            showToast(i18n('page_created'));
+            _nbPageMutationPending = true;
+            try {
+                await nbSavePageNow();
+                const cur = nbCurrentPage();
+                const now = new Date().toISOString();
+                const page = { id: nbUid('nbp'), template: (cur && cur.template) || nb.template || 'blank', createdAt: now, updatedAt: now };
+                nb.pages.push(page);
+                nbTouch(nb);
+                saveData();
+                nbSyncNotebookEvent('notebook_page_add', page.id);
+                await nbLoadPage(nb.pages.length - 1);
+                showToast(i18n('page_created'));
+            } finally {
+                _nbPageMutationPending = false;
+            }
         }
 
         // ==================== 布局与渲染 ====================
@@ -28524,6 +28531,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             window.__nbNativeWidth = Math.max(1, Math.min(14, brush.mm * NB_MM * s));
             nbDrawBg();
             nbRedraw();
+            nbSyncNativeRegions();
         }
 
         function nbCtx(id) {
@@ -28752,6 +28760,11 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         // 非书写工具（含套索）、或有弹窗/抽屉盖在画布上时，挂起 Boox 原生直渲染，
         // 走标准指针事件（否则原生层按矩形抢笔，会穿透弹窗直接书写）。
         // 选中文本框/媒体期间挂起，保证拖动、四角缩放的指针事件实时到达 DOM。
+        function nbSyncNativeRegions() {
+            try {
+                window.__booxPen?.syncRegions?.();
+            } catch (e) {}
+        }
         function nbUpdateNativeSuspend() {
             const overlayOpen =
                 document.getElementById('nbPanel')?.classList.contains('show') ||
@@ -28760,6 +28773,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 document.getElementById('nbQuizModal')?.classList.contains('show') ||
                 document.getElementById('nbQuizFullscreen')?.classList.contains('show');
             window.__nbNativeSuspend = (nbState.tool !== 'pen') || !!overlayOpen || !!nbState.selectedTextId;
+            nbSyncNativeRegions();
         }
         function nbNativeRefresh() {
             try { window.__booxPen && window.__booxPen.refresh && window.__booxPen.refresh(); } catch (e) {}
@@ -28769,7 +28783,6 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             if (nbState.tool !== 'eraser') nbState.prevTool = nbState.tool;
             nbState.tool = tool;
             if (tool !== 'lasso') nbClearSelection();
-            nbUpdateNativeSuspend();
             document.getElementById('nbEraserBtn').classList.toggle('active', tool === 'eraser');
             document.getElementById('nbLassoBtn').classList.toggle('active', tool === 'lasso');
             document.getElementById('nbTextBtn').classList.toggle('active', tool === 'text');
@@ -28777,6 +28790,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             document.querySelectorAll('.nb-brush-btn').forEach((b, i) =>
                 b.classList.toggle('active', tool === 'pen' && i === nbState.brushIndex));
             document.body.classList.toggle('nb-text-mode', tool === 'text');
+            nbUpdateNativeSuspend();
         }
         function toggleNbEraser() {
             nbSetTool(nbState.tool === 'eraser' ? (nbState.prevTool || 'pen') : 'eraser');
@@ -28798,9 +28812,9 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         }
         function nbSelectBrush(i) {
             nbState.brushIndex = i;
-            nbSetTool('pen');
             const brush = nbState.brushes[i];
             window.__nbNativeWidth = Math.max(1, Math.min(14, brush.mm * NB_MM * nbDisplayScale()));
+            nbSetTool('pen');
             nbRenderBrushBtns();
             // Boox 原生直渲染激活期间屏幕冻结、不展示底层 UI 更新——
             // 书写开始后点笔刷其实切换成功了但看不见。这里主动刷新一次让高亮立即上屏。
@@ -29741,30 +29755,36 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 </div>`;
         }
         async function nbInsertPage(after) {
-            const notebookId = nbState.notebookId;
-            const anchorPageId = nbCurrentPage()?.id;
-            if (!notebookId || !anchorPageId) return;
-            await nbSavePageNow();
-            const nb = nbGetNotebook(notebookId);
-            if (!nb || nbState.notebookId !== notebookId) return;
-            const anchorIndex = (nb.pages || []).findIndex(page => page?.id === anchorPageId);
-            if (anchorIndex < 0) {
-                showToast(i18n('page_deleted'));
-                return;
+            if (_nbPageMutationPending) return;
+            _nbPageMutationPending = true;
+            try {
+                const notebookId = nbState.notebookId;
+                const anchorPageId = nbCurrentPage()?.id;
+                if (!notebookId || !anchorPageId) return;
+                await nbSavePageNow();
+                const nb = nbGetNotebook(notebookId);
+                if (!nb || nbState.notebookId !== notebookId) return;
+                const anchorIndex = (nb.pages || []).findIndex(page => page?.id === anchorPageId);
+                if (anchorIndex < 0) {
+                    showToast(i18n('page_deleted'));
+                    return;
+                }
+                const sel = document.getElementById('nbNewPageTpl');
+                const anchorPage = nb.pages[anchorIndex];
+                const tpl = (!sel || sel.value === '__cur__') ? (anchorPage.template || 'blank') : sel.value;
+                const now = new Date().toISOString();
+                const page = { id: nbUid('nbp'), template: tpl, createdAt: now, updatedAt: now };
+                const at = anchorIndex + (after ? 1 : 0);
+                nb.pages.splice(at, 0, page);
+                nbTouch(nb);
+                saveData();
+                nbHidePanel();
+                nbSyncNotebookEvent('notebook_page_add', page.id);
+                await nbLoadPage(at);
+                showToast(i18n('page_inserted'));
+            } finally {
+                _nbPageMutationPending = false;
             }
-            const sel = document.getElementById('nbNewPageTpl');
-            const anchorPage = nb.pages[anchorIndex];
-            const tpl = (!sel || sel.value === '__cur__') ? (anchorPage.template || 'blank') : sel.value;
-            const now = new Date().toISOString();
-            const page = { id: nbUid('nbp'), template: tpl, createdAt: now, updatedAt: now };
-            const at = anchorIndex + (after ? 1 : 0);
-            nb.pages.splice(at, 0, page);
-            nbTouch(nb);
-            saveData();
-            nbHidePanel();
-            nbSyncNotebookEvent('notebook_page_add', page.id);
-            nbLoadPage(at);
-            showToast(i18n('page_inserted'));
         }
         async function nbDeleteCurrentPage() {
             nbHidePanel();

--- a/app/src/main/java/com/mathreader/boox/BooxPenBridge.java
+++ b/app/src/main/java/com/mathreader/boox/BooxPenBridge.java
@@ -41,6 +41,18 @@ public class BooxPenBridge {
     private boolean rawOpened;
     // JS 侧期望的开关状态，onPause/onResume 时据此恢复
     private volatile boolean wantEnabled;
+    // TouchHelper 的物理书写区。区域内专属书写，区域外专属 WebView UI。
+    private final List<Rect> activeDrawingRects = new ArrayList<>();
+    private volatile boolean rawStrokeActive;
+    private String pendingRectsJson;
+    private boolean refreshDeferred;
+    private boolean activityResumed;
+    private boolean uiGesturePaused;
+    private boolean refreshPaused;
+    private int uiPointerId = -1;
+    // 用于丢弃快速连点期间过期的 WebView 视觉提交回调。
+    private long visualCommitToken;
+    private boolean resumeAfterNextDraw;
     // 最近一次按下的输入工具类型（手指 / 触控笔），供阅读界面区分翻页与套索。
     // 默认手指：检测失败时退化为"点触翻页"，不会误吞翻页操作。
     private volatile int lastToolType = MotionEvent.TOOL_TYPE_FINGER;
@@ -48,10 +60,12 @@ public class BooxPenBridge {
     private final RawInputCallback rawInputCallback = new RawInputCallback() {
         @Override
         public void onBeginRawDrawing(boolean b, TouchPoint touchPoint) {
+            rawStrokeActive = true;
         }
 
         @Override
         public void onEndRawDrawing(boolean b, TouchPoint touchPoint) {
+            finishRawStroke();
         }
 
         @Override
@@ -65,10 +79,12 @@ public class BooxPenBridge {
 
         @Override
         public void onBeginRawErasing(boolean b, TouchPoint touchPoint) {
+            rawStrokeActive = true;
         }
 
         @Override
         public void onEndRawErasing(boolean b, TouchPoint touchPoint) {
+            finishRawStroke();
         }
 
         @Override
@@ -116,6 +132,169 @@ public class BooxPenBridge {
                 lastToolType = MotionEvent.TOOL_TYPE_FINGER;
             }
         }
+        if ((action == MotionEvent.ACTION_HOVER_ENTER || action == MotionEvent.ACTION_HOVER_MOVE)
+                && uiPointerId == -1 && wantEnabled && !activeDrawingRects.isEmpty()) {
+            int index = event.getActionIndex();
+            int toolType = event.getToolType(index);
+            if (isStylusTool(toolType)
+                    && isInsideActiveDrawingRect(event.getX(index), event.getY(index))) {
+                resumeForDrawingGesture();
+            }
+            return;
+        }
+        if (action == MotionEvent.ACTION_DOWN && wantEnabled && !activeDrawingRects.isEmpty()) {
+            boolean inside = isInsideActiveDrawingRect(event.getX(), event.getY());
+            int toolType = event.getToolType(0);
+            if (inside) {
+                // 画布内的手指/手掌不切换 TouchHelper；笔则可抢先恢复直写。
+                if (isStylusTool(toolType)) {
+                    resumeForDrawingGesture();
+                }
+            } else if (!rawStrokeActive) {
+                pauseForUiGesture(event.getPointerId(0));
+            }
+        } else if (action == MotionEvent.ACTION_POINTER_DOWN && uiPointerId == -1
+                && wantEnabled && !activeDrawingRects.isEmpty()) {
+            int index = event.getActionIndex();
+            if (isStylusTool(event.getToolType(index))
+                    && isInsideActiveDrawingRect(event.getX(index), event.getY(index))) {
+                resumeForDrawingGesture();
+            }
+        }
+    }
+
+    /** 在 WebView 已完成本次输入分发后调用，确保 click/onclick 先于视觉提交。 */
+    public void onWebViewTouchEventDispatched(MotionEvent event) {
+        if (event == null || uiPointerId == -1) {
+            return;
+        }
+        int action = event.getActionMasked();
+        boolean finished = action == MotionEvent.ACTION_CANCEL || action == MotionEvent.ACTION_UP;
+        if (action == MotionEvent.ACTION_POINTER_UP) {
+            finished = event.getPointerId(event.getActionIndex()) == uiPointerId;
+        }
+        if (!finished) {
+            return;
+        }
+        uiPointerId = -1;
+        if (uiGesturePaused) {
+            requestVisualCommit();
+        }
+    }
+
+    /** WebView 已经真正执行完一次 draw；下一个主线程任务再恢复 Onyx 直写。 */
+    public void onWebViewDrawn() {
+        if (!resumeAfterNextDraw) {
+            return;
+        }
+        final long token = visualCommitToken;
+        resumeAfterNextDraw = false;
+        mainHandler.post(() -> {
+            if (token != visualCommitToken) {
+                return;
+            }
+            uiGesturePaused = false;
+            refreshPaused = false;
+            enableRawDrawingIfAllowed("resume after WebView draw failed");
+        });
+    }
+
+    private static boolean isStylusTool(int toolType) {
+        return toolType == MotionEvent.TOOL_TYPE_STYLUS
+                || toolType == MotionEvent.TOOL_TYPE_ERASER;
+    }
+
+    private boolean isInsideActiveDrawingRect(float x, float y) {
+        int px = Math.round(x);
+        int py = Math.round(y);
+        for (Rect rect : activeDrawingRects) {
+            if (rect.contains(px, py)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void pauseForUiGesture(int pointerId) {
+        invalidateVisualCommit();
+        uiPointerId = pointerId;
+        uiGesturePaused = true;
+        try {
+            // Onyx raw mode 会冻结 WebView 刷新；UI 手势必须完整退出 raw mode。
+            touchHelper.setRawDrawingEnabled(false);
+        } catch (Throwable t) {
+            Log.w(TAG, "pause for UI gesture failed", t);
+        }
+        webView.invalidate();
+    }
+
+    private void resumeForDrawingGesture() {
+        if (uiPointerId != -1 || !wantEnabled || !activityResumed) {
+            return;
+        }
+        if (!uiGesturePaused && !refreshPaused && !resumeAfterNextDraw) {
+            return;
+        }
+        invalidateVisualCommit();
+        uiGesturePaused = false;
+        refreshPaused = false;
+        enableRawDrawingIfAllowed("resume for drawing gesture failed");
+    }
+
+    private void enableRawDrawingIfAllowed(String failureMessage) {
+        if (!sdkAvailable || !wantEnabled || !activityResumed
+                || uiGesturePaused || refreshPaused || uiPointerId != -1) {
+            return;
+        }
+        try {
+            // 明确同时恢复 render 和 RawInputReader，不依赖 SDK 内部旧标志。
+            touchHelper.setRawDrawingRenderEnabled(true);
+            touchHelper.setRawDrawingEnabled(true);
+        } catch (Throwable t) {
+            Log.w(TAG, failureMessage, t);
+        }
+    }
+
+    private void invalidateVisualCommit() {
+        visualCommitToken++;
+        resumeAfterNextDraw = false;
+    }
+
+    private void requestVisualCommit() {
+        final long token = ++visualCommitToken;
+        resumeAfterNextDraw = false;
+        try {
+            webView.postVisualStateCallback(token, new WebView.VisualStateCallback() {
+                @Override
+                public void onComplete(long requestId) {
+                    if (requestId != visualCommitToken) {
+                        return;
+                    }
+                    resumeAfterNextDraw = true;
+                    webView.invalidate();
+                }
+            });
+        } catch (Throwable t) {
+            Log.w(TAG, "visual state callback failed", t);
+            // 不用固定延时兜底；至少等待一次真实 onDraw。
+            resumeAfterNextDraw = true;
+            webView.invalidate();
+        }
+    }
+
+    private void finishRawStroke() {
+        rawStrokeActive = false;
+        mainHandler.post(() -> {
+            if (pendingRectsJson != null) {
+                String json = pendingRectsJson;
+                pendingRectsJson = null;
+                applyRects(json);
+            }
+            if (refreshDeferred) {
+                refreshDeferred = false;
+                beginVisualRefresh();
+            }
+        });
     }
 
     /** 最近一次按下是否为触控笔（手写笔）。pointerType 缺失时 JS 侧据此判定。 */
@@ -149,6 +328,19 @@ public class BooxPenBridge {
         mainHandler.post(this::disableInternal);
     }
 
+    /** JS 在同步完工具状态/DOM 后调用，补充异步 UI 的精确提交点。 */
+    @JavascriptInterface
+    public void commitUi() {
+        if (!sdkAvailable) {
+            return;
+        }
+        mainHandler.post(() -> {
+            if (uiGesturePaused || refreshPaused) {
+                requestVisualCommit();
+            }
+        });
+    }
+
     /**
      * 短暂退出直渲染并强制重绘，让 WebView 中已提交的笔迹内容刷新上屏
      * （撤销/清空/橡皮擦除后调用）。
@@ -162,25 +354,33 @@ public class BooxPenBridge {
             if (!wantEnabled) {
                 return;
             }
-            try {
-                touchHelper.setRawDrawingEnabled(false);
-            } catch (Throwable t) {
-                Log.w(TAG, "refresh disable failed", t);
+            if (rawStrokeActive) {
+                refreshDeferred = true;
+                return;
             }
-            webView.invalidate();
-            mainHandler.postDelayed(() -> {
-                if (wantEnabled) {
-                    try {
-                        touchHelper.setRawDrawingEnabled(true);
-                    } catch (Throwable t) {
-                        Log.w(TAG, "refresh enable failed", t);
-                    }
-                }
-            }, 260);
+            beginVisualRefresh();
         });
     }
 
+    private void beginVisualRefresh() {
+        if (!wantEnabled) {
+            return;
+        }
+        try {
+            touchHelper.setRawDrawingEnabled(false);
+        } catch (Throwable t) {
+            Log.w(TAG, "refresh disable failed", t);
+        }
+        refreshPaused = true;
+        requestVisualCommit();
+        webView.invalidate();
+    }
+
     private void applyRects(String json) {
+        if (rawStrokeActive) {
+            pendingRectsJson = json;
+            return;
+        }
         try {
             JSONObject obj = new JSONObject(json);
             JSONArray arr = obj.getJSONArray("rects");
@@ -197,6 +397,8 @@ public class BooxPenBridge {
                 disableInternal();
                 return;
             }
+            activeDrawingRects.clear();
+            activeDrawingRects.addAll(rects);
             touchHelper.setRawDrawingEnabled(false);
             touchHelper.setStrokeWidth(width).setLimitRect(rects, new ArrayList<>());
             if (!rawOpened) {
@@ -209,8 +411,10 @@ public class BooxPenBridge {
             } else {
                 touchHelper.setSingleRegionMode();
             }
-            touchHelper.setRawDrawingEnabled(true);
             wantEnabled = true;
+            refreshPaused = true;
+            requestVisualCommit();
+            webView.invalidate();
         } catch (Throwable t) {
             Log.w(TAG, "setRects failed: " + json, t);
         }
@@ -218,6 +422,10 @@ public class BooxPenBridge {
 
     private void disableInternal() {
         wantEnabled = false;
+        refreshPaused = false;
+        refreshDeferred = false;
+        pendingRectsJson = null;
+        activeDrawingRects.clear();
         try {
             touchHelper.setRawDrawingEnabled(false);
         } catch (Throwable t) {
@@ -261,16 +469,23 @@ public class BooxPenBridge {
     }
 
     public void onResume() {
-        if (sdkAvailable && wantEnabled) {
-            try {
-                touchHelper.setRawDrawingEnabled(true);
-            } catch (Throwable t) {
-                Log.w(TAG, "onResume enable failed", t);
-            }
+        activityResumed = true;
+        if (resumeAfterNextDraw || uiGesturePaused || refreshPaused) {
+            webView.invalidate();
+        } else {
+            enableRawDrawingIfAllowed("onResume enable failed");
         }
     }
 
     public void onPause() {
+        activityResumed = false;
+        uiPointerId = -1;
+        uiGesturePaused = false;
+        refreshPaused = false;
+        refreshDeferred = false;
+        rawStrokeActive = false;
+        pendingRectsJson = null;
+        invalidateVisualCommit();
         if (sdkAvailable) {
             try {
                 touchHelper.setRawDrawingEnabled(false);
@@ -281,6 +496,7 @@ public class BooxPenBridge {
     }
 
     public void onDestroy() {
+        invalidateVisualCommit();
         if (sdkAvailable && rawOpened) {
             try {
                 touchHelper.closeRawDrawing();

--- a/app/src/main/java/com/mathreader/boox/MainActivity.java
+++ b/app/src/main/java/com/mathreader/boox/MainActivity.java
@@ -67,7 +67,19 @@ public class MainActivity extends AppCompatActivity {
                 if (penBridge != null) {
                     penBridge.onWebViewTouchEvent(event);
                 }
-                return super.dispatchTouchEvent(event);
+                boolean handled = super.dispatchTouchEvent(event);
+                if (penBridge != null) {
+                    penBridge.onWebViewTouchEventDispatched(event);
+                }
+                return handled;
+            }
+
+            @Override
+            protected void onDraw(android.graphics.Canvas canvas) {
+                super.onDraw(canvas);
+                if (penBridge != null) {
+                    penBridge.onWebViewDrawn();
+                }
             }
         };
         setContentView(webView);

--- a/docs/index.html
+++ b/docs/index.html
@@ -28317,6 +28317,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         window.__nbNativeWidth = 2;
         let _nbOpenRequestToken = 0;
         let _nbPageLoadToken = 0;
+        let _nbPageMutationPending = false;
 
         function nbCurrentNotebook() { return nbGetNotebook(nbState.notebookId); }
         function nbCurrentPage() {
@@ -28394,6 +28395,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             nbState.redoStack = [];
             Object.keys(nbThumbCache).forEach(k => { delete nbThumbCache[k]; });
             window.__nbNativeSuspend = false;
+            nbSyncNativeRegions();
             renderNotebooksPage();
             // 关闭笔记本时做一次可见同步
             nbSyncNotebookEvent('notebook_close', closingPageId);
@@ -28476,22 +28478,27 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         function nbPrevPage() { if (nbState.pageIndex > 0) nbLoadPage(nbState.pageIndex - 1); }
         async function nbNextPage() {
             const nb = nbCurrentNotebook();
-            if (!nb) return;
+            if (!nb || _nbPageMutationPending) return;
             if (nbState.pageIndex < nb.pages.length - 1) {
                 nbLoadPage(nbState.pageIndex + 1);
                 return;
             }
             // 已是最后一页 → 自动以当前页模板追加新页
-            await nbSavePageNow();
-            const cur = nbCurrentPage();
-            const now = new Date().toISOString();
-            const page = { id: nbUid('nbp'), template: (cur && cur.template) || nb.template || 'blank', createdAt: now, updatedAt: now };
-            nb.pages.push(page);
-            nbTouch(nb);
-            saveData();
-            nbSyncNotebookEvent('notebook_page_add', page.id);
-            nbLoadPage(nb.pages.length - 1);
-            showToast(i18n('page_created'));
+            _nbPageMutationPending = true;
+            try {
+                await nbSavePageNow();
+                const cur = nbCurrentPage();
+                const now = new Date().toISOString();
+                const page = { id: nbUid('nbp'), template: (cur && cur.template) || nb.template || 'blank', createdAt: now, updatedAt: now };
+                nb.pages.push(page);
+                nbTouch(nb);
+                saveData();
+                nbSyncNotebookEvent('notebook_page_add', page.id);
+                await nbLoadPage(nb.pages.length - 1);
+                showToast(i18n('page_created'));
+            } finally {
+                _nbPageMutationPending = false;
+            }
         }
 
         // ==================== 布局与渲染 ====================
@@ -28524,6 +28531,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             window.__nbNativeWidth = Math.max(1, Math.min(14, brush.mm * NB_MM * s));
             nbDrawBg();
             nbRedraw();
+            nbSyncNativeRegions();
         }
 
         function nbCtx(id) {
@@ -28752,6 +28760,11 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         // 非书写工具（含套索）、或有弹窗/抽屉盖在画布上时，挂起 Boox 原生直渲染，
         // 走标准指针事件（否则原生层按矩形抢笔，会穿透弹窗直接书写）。
         // 选中文本框/媒体期间挂起，保证拖动、四角缩放的指针事件实时到达 DOM。
+        function nbSyncNativeRegions() {
+            try {
+                window.__booxPen?.syncRegions?.();
+            } catch (e) {}
+        }
         function nbUpdateNativeSuspend() {
             const overlayOpen =
                 document.getElementById('nbPanel')?.classList.contains('show') ||
@@ -28760,6 +28773,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 document.getElementById('nbQuizModal')?.classList.contains('show') ||
                 document.getElementById('nbQuizFullscreen')?.classList.contains('show');
             window.__nbNativeSuspend = (nbState.tool !== 'pen') || !!overlayOpen || !!nbState.selectedTextId;
+            nbSyncNativeRegions();
         }
         function nbNativeRefresh() {
             try { window.__booxPen && window.__booxPen.refresh && window.__booxPen.refresh(); } catch (e) {}
@@ -28769,7 +28783,6 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             if (nbState.tool !== 'eraser') nbState.prevTool = nbState.tool;
             nbState.tool = tool;
             if (tool !== 'lasso') nbClearSelection();
-            nbUpdateNativeSuspend();
             document.getElementById('nbEraserBtn').classList.toggle('active', tool === 'eraser');
             document.getElementById('nbLassoBtn').classList.toggle('active', tool === 'lasso');
             document.getElementById('nbTextBtn').classList.toggle('active', tool === 'text');
@@ -28777,6 +28790,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             document.querySelectorAll('.nb-brush-btn').forEach((b, i) =>
                 b.classList.toggle('active', tool === 'pen' && i === nbState.brushIndex));
             document.body.classList.toggle('nb-text-mode', tool === 'text');
+            nbUpdateNativeSuspend();
         }
         function toggleNbEraser() {
             nbSetTool(nbState.tool === 'eraser' ? (nbState.prevTool || 'pen') : 'eraser');
@@ -28798,9 +28812,9 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         }
         function nbSelectBrush(i) {
             nbState.brushIndex = i;
-            nbSetTool('pen');
             const brush = nbState.brushes[i];
             window.__nbNativeWidth = Math.max(1, Math.min(14, brush.mm * NB_MM * nbDisplayScale()));
+            nbSetTool('pen');
             nbRenderBrushBtns();
             // Boox 原生直渲染激活期间屏幕冻结、不展示底层 UI 更新——
             // 书写开始后点笔刷其实切换成功了但看不见。这里主动刷新一次让高亮立即上屏。
@@ -29741,30 +29755,36 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 </div>`;
         }
         async function nbInsertPage(after) {
-            const notebookId = nbState.notebookId;
-            const anchorPageId = nbCurrentPage()?.id;
-            if (!notebookId || !anchorPageId) return;
-            await nbSavePageNow();
-            const nb = nbGetNotebook(notebookId);
-            if (!nb || nbState.notebookId !== notebookId) return;
-            const anchorIndex = (nb.pages || []).findIndex(page => page?.id === anchorPageId);
-            if (anchorIndex < 0) {
-                showToast(i18n('page_deleted'));
-                return;
+            if (_nbPageMutationPending) return;
+            _nbPageMutationPending = true;
+            try {
+                const notebookId = nbState.notebookId;
+                const anchorPageId = nbCurrentPage()?.id;
+                if (!notebookId || !anchorPageId) return;
+                await nbSavePageNow();
+                const nb = nbGetNotebook(notebookId);
+                if (!nb || nbState.notebookId !== notebookId) return;
+                const anchorIndex = (nb.pages || []).findIndex(page => page?.id === anchorPageId);
+                if (anchorIndex < 0) {
+                    showToast(i18n('page_deleted'));
+                    return;
+                }
+                const sel = document.getElementById('nbNewPageTpl');
+                const anchorPage = nb.pages[anchorIndex];
+                const tpl = (!sel || sel.value === '__cur__') ? (anchorPage.template || 'blank') : sel.value;
+                const now = new Date().toISOString();
+                const page = { id: nbUid('nbp'), template: tpl, createdAt: now, updatedAt: now };
+                const at = anchorIndex + (after ? 1 : 0);
+                nb.pages.splice(at, 0, page);
+                nbTouch(nb);
+                saveData();
+                nbHidePanel();
+                nbSyncNotebookEvent('notebook_page_add', page.id);
+                await nbLoadPage(at);
+                showToast(i18n('page_inserted'));
+            } finally {
+                _nbPageMutationPending = false;
             }
-            const sel = document.getElementById('nbNewPageTpl');
-            const anchorPage = nb.pages[anchorIndex];
-            const tpl = (!sel || sel.value === '__cur__') ? (anchorPage.template || 'blank') : sel.value;
-            const now = new Date().toISOString();
-            const page = { id: nbUid('nbp'), template: tpl, createdAt: now, updatedAt: now };
-            const at = anchorIndex + (after ? 1 : 0);
-            nb.pages.splice(at, 0, page);
-            nbTouch(nb);
-            saveData();
-            nbHidePanel();
-            nbSyncNotebookEvent('notebook_page_add', page.id);
-            nbLoadPage(at);
-            showToast(i18n('page_inserted'));
         }
         async function nbDeleteCurrentPage() {
             nbHidePanel();


### PR DESCRIPTION
## 基线
- 从 `main@0da2cb97eab3` 创建，即 PR #29 与 PR #31 均已 revert 后的最新主分支
- 不包含两次被撤回方案

## 已确认的问题
- 原路径依赖 350ms 轮询同步工具状态
- 笔刷刷新叠加 150ms + 260ms，撤销/清空叠加 350ms + 260ms，橡皮回放叠加 200ms + 260ms
- 固定等待既产生明显延迟，也不能证明 BOOX 屏幕已经显示新帧

## 修复
- 以原生 canvas 物理矩形划分手势：画布内保持书写，画布外在 WebView 分发前完整退出 Onyx raw mode
- 不再按毫秒恢复；顺序改为 `click/DOM 完成 → WebView VisualStateCallback → 实际 onDraw 完成 → 下一主线程任务恢复 raw mode`
- 快速连点用 generation 丢弃旧回调，避免旧回调提前重新冻结 UI
- 触控笔 hover/落笔回到画布可立即恢复，书写中的区域重配和刷新延后到抬笔后，避免断笔
- 画布内手指/手掌与 ACTION_MOVE 不切换原生状态
- 橡皮、笔刷宽度、面板、布局、翻页立即同步，不再把 350ms polling 当正常交互路径
- 删除 150/200/260/350ms 的工具栏/刷新等待；轮询仅作为其他画布状态变化的兜底
- 新建下一页与插入页面增加单次操作锁，避免重复创建
- 网页与 APK 内置页面同步更新

## 最小验证
- 两份 `index.html` 完全一致
- `boox-pen.js` 与页面内联 JavaScript 语法通过
- `git diff --check` 通过
- Android 编译交给本 PR 现有 build 门禁，本地未追加全量测试

说明：这是针对已确认定时链与 Onyx raw-mode 刷新冻结的代码修复；真机体感仍以 BOOX 实测为准，不把未做的真机验证写成已通过。