### PR TITLE
Fix custom OpenAI-compatible Claude lectures

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -32,6 +32,7 @@ jobs:
           cmp app/src/main/assets/www/recording-storage.js docs/recording-storage.js
           cmp app/src/main/assets/www/classroom-storage.js docs/classroom-storage.js
           cmp app/src/main/assets/www/recording-ai.js docs/recording-ai.js
+          cmp app/src/main/assets/www/ai-response.js docs/ai-response.js
 
       - name: Calculate APK version
         id: version

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -24,6 +24,7 @@ jobs:
           cp app/src/main/assets/www/recording-storage.js docs/
           cp app/src/main/assets/www/classroom-storage.js docs/
           cp app/src/main/assets/www/recording-ai.js docs/
+          cp app/src/main/assets/www/ai-response.js docs/
           cp app/src/main/assets/www/pdf.min.js docs/
           cp app/src/main/assets/www/pdf.worker.min.js docs/
 

--- a/app/src/main/assets/www/ai-response.js
+++ b/app/src/main/assets/www/ai-response.js
@@ -1,0 +1,182 @@
+(function (root, factory) {
+    const api = factory();
+    if (typeof module === 'object' && module.exports) module.exports = api;
+    if (root) root.AIResponse = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+    'use strict';
+
+    const THINKING_PART_TYPES = new Set([
+        'analysis', 'reasoning', 'reasoning_content', 'thinking', 'thought'
+    ]);
+
+    function inferProtocol(config) {
+        config = config || {};
+        const provider = String(config.provider || '').toLowerCase();
+        const url = String(config.url || '').toLowerCase();
+
+        // An explicit endpoint shape is more reliable than the UI label. In particular,
+        // a custom endpoint ending in /chat/completions can still serve a Claude model.
+        if (/\/chat\/completions(?:[/?#]|$)/.test(url)) return 'openai';
+        if (/anthropic\.com/.test(url) || /\/messages(?:[/?#]|$)/.test(url)) return 'anthropic';
+        if (/generativelanguage\.googleapis\.com/.test(url) ||
+            /:generatecontent(?:[/?#]|$)/.test(url) ||
+            /\/(?:v1beta|v1alpha)(?:[/?#]|$)/.test(url)) return 'gemini';
+
+        if (provider === 'google') return 'gemini';
+        if (provider === 'claude') return 'anthropic';
+        return 'openai';
+    }
+
+    function isMaxThinkingModel(model) {
+        return /(?:^|[-_/\s])max[-_\s]?thinking(?:$|[-_/\s])/i.test(String(model || ''));
+    }
+
+    function outputTokenLimit(model, requested, fallback) {
+        const value = Number(requested);
+        const defaultValue = Number(fallback);
+        const base = Number.isFinite(value) && value > 0
+            ? Math.floor(value)
+            : Number.isFinite(defaultValue) && defaultValue > 0
+            ? Math.floor(defaultValue)
+            : null;
+        // maxthinking gateways commonly reserve up to 32K tokens for reasoning. Keep
+        // enough room for a roughly 12K-token lecture without asking ordinary models
+        // for an unnecessarily large completion.
+        return isMaxThinkingModel(model) ? Math.max(base || 0, 49152) : base;
+    }
+
+    function thinkingOnlyError(finishReason) {
+        const error = new Error('AI returned reasoning but no final answer');
+        error.code = 'AI_THINKING_ONLY';
+        error.finishReason = finishReason || '';
+        return error;
+    }
+
+    function isThinkingPart(part) {
+        if (!part || typeof part !== 'object') return false;
+        if (part.thought === true) return true;
+        return THINKING_PART_TYPES.has(String(part.type || '').toLowerCase());
+    }
+
+    function textFromPart(part) {
+        if (!part || typeof part !== 'object') return '';
+        if (typeof part.text === 'string') return part.text;
+        if (typeof part.content === 'string') return part.content;
+        if (part.text && typeof part.text.value === 'string') return part.text.value;
+        return '';
+    }
+
+    function removeEmbeddedThinking(value) {
+        let text = String(value || '');
+        let hadThinking = false;
+        text = text.replace(/<(?:think|thinking)>[\s\S]*?<\/(?:think|thinking)>/gi, function () {
+            hadThinking = true;
+            return '';
+        });
+        if (/<(?:think|thinking)>/i.test(text)) {
+            hadThinking = true;
+            text = text.replace(/<(?:think|thinking)>[\s\S]*$/i, '');
+        }
+        return { text, hadThinking };
+    }
+
+    function extractOpenAIText(data) {
+        const message = data && data.choices && data.choices[0] && data.choices[0].message;
+        if (!message) return null;
+
+        let answer = '';
+        let hadThinking = !!(message.reasoning_content || message.reasoning);
+        if (typeof message.content === 'string') {
+            const cleaned = removeEmbeddedThinking(message.content);
+            answer = cleaned.text;
+            hadThinking = hadThinking || cleaned.hadThinking;
+        } else if (Array.isArray(message.content)) {
+            const answerParts = [];
+            for (const part of message.content) {
+                const text = textFromPart(part);
+                if (isThinkingPart(part)) {
+                    if (text) hadThinking = true;
+                } else if (text) {
+                    answerParts.push(text);
+                }
+            }
+            answer = answerParts.join('');
+        }
+
+        if (answer.trim()) return answer;
+        if (hadThinking) throw thinkingOnlyError(data.choices[0].finish_reason);
+        return null;
+    }
+
+    function extractAnthropicText(data) {
+        if (!data || !Array.isArray(data.content)) return null;
+        const answer = data.content
+            .filter(function (part) { return !isThinkingPart(part); })
+            .map(textFromPart)
+            .join('');
+        if (answer.trim()) return answer;
+        const hadThinking = data.content.some(function (part) {
+            return isThinkingPart(part) && !!(textFromPart(part) || part.thinking);
+        });
+        if (hadThinking) throw thinkingOnlyError(data.stop_reason);
+        return null;
+    }
+
+    function extractGeminiText(data) {
+        const candidate = data && data.candidates && data.candidates[0];
+        const parts = candidate && candidate.content && candidate.content.parts;
+        if (!Array.isArray(parts) || parts.length === 0) return null;
+
+        const answer = parts
+            .filter(function (part) { return !isThinkingPart(part); })
+            .map(textFromPart)
+            .join('');
+        if (answer.trim()) return answer;
+        const hadThinking = parts.some(function (part) {
+            return isThinkingPart(part) && !!textFromPart(part);
+        });
+        if (hadThinking) throw thinkingOnlyError(candidate.finishReason);
+        return null;
+    }
+
+    function prependToLastUserMessage(messages, prefix) {
+        const out = Array.isArray(messages) ? messages.slice() : [];
+        let index = -1;
+        for (let i = out.length - 1; i >= 0; i--) {
+            if (out[i] && out[i].role === 'user') {
+                index = i;
+                break;
+            }
+        }
+        if (index < 0) {
+            out.push({ role: 'user', content: String(prefix || '') });
+            return out;
+        }
+
+        const message = out[index] || { role: 'user', content: '' };
+        if (Array.isArray(message.content)) {
+            out[index] = {
+                ...message,
+                content: [{ type: 'text', text: String(prefix || '') }, ...message.content]
+            };
+        } else {
+            const suffix = String(message.content || '');
+            out[index] = {
+                ...message,
+                content: String(prefix || '') + (suffix ? '\n\n---\n\n' + suffix : '')
+            };
+        }
+        return out;
+    }
+
+    return {
+        inferProtocol,
+        isMaxThinkingModel,
+        outputTokenLimit,
+        isThinkingPart,
+        extractOpenAIText,
+        extractAnthropicText,
+        extractGeminiText,
+        prependToLastUserMessage
+    };
+});

--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -6343,6 +6343,7 @@
     <script src="recording-storage.js"></script>
     <script src="classroom-storage.js"></script>
     <script src="recording-ai.js"></script>
+    <script src="ai-response.js"></script>
     <script>
         // ==================== Data Store ====================
         let appData = {
@@ -6955,7 +6956,7 @@
             edit_message_prompt:'编辑消息：', reader_chat_greeting:'正在阅读《{0}》。{1}', reader_chat_notes:'\n当前页笔记：{0}', reader_fallback_review:'请帮我复习这一页的重点。', reader_fallback_example:'请给一个相关例题。', reader_fallback_notes:'请整理当前内容的学习笔记。', reader_fallback_proof:'请详细解释相关证明。', request_failed:'请求失败：', unknown_error:'未知错误',
             chat_history_filename:'聊天记录', select_books:'选择书籍', select_papers:'选择论文', progress_label:'进度 {0}%', book_file_missing:'书籍文件不存在', bookmark_page_suffix:'（第 {0} 页）', no_chapter_bookmarks:'暂无章节书签', chapter_bookmarks_hint:'长按书籍可生成讲义与章节书签', page_label:'第 {0} 页', lecture_progress_suffix:' · 讲义 {0}%',
             generating_lecture_content:'正在生成讲义内容…', first_generation_time:'首次生成可能需要几分钟', generation_failed:'生成失败', network_api_retry:'请检查网络或 API 设置后重试', content_load_failed:'内容加载失败', lecture_content_not_found:'未找到讲义内容', lecture_not_generated:'讲义尚未生成', cannot_load_lecture:'无法加载讲义', download_lecture:'下载讲义',
-            fetch_models_http_error:'拉取模型失败（HTTP {0}）：{1}', fetch_models_failed:'拉取模型失败', all_apis_failed:'所有 API 均调用失败', configure_api_first:'请先配置 API', api_error:'API 错误（HTTP {0}）：{1}', claude_api_error:'Claude API 错误（HTTP {0}）：{1}', api_url_empty:'API URL 不能为空', select_model_required:'请选择模型', large_recording_requires_gemini:'长录音需要使用 Gemini 模型',
+            fetch_models_http_error:'拉取模型失败（HTTP {0}）：{1}', fetch_models_failed:'拉取模型失败', all_apis_failed:'所有 API 均调用失败', configure_api_first:'请先配置 API', api_error:'API 错误（HTTP {0}）：{1}', claude_api_error:'Claude API 错误（HTTP {0}）：{1}', api_url_empty:'API URL 不能为空', select_model_required:'请选择模型', large_recording_requires_gemini:'长录音需要使用 Gemini 模型', ai_thinking_only_response:'模型只返回了思考过程，没有最终正文；请检查 maxthinking 模型的输出上限',
             files_api_start_failed:'Files API 启动失败', files_api_no_upload_url:'Files API 未返回上传地址', files_api_upload_failed:'Files API 上传失败', files_api_processing_failed:'Files API 处理失败', pdf_text_extraction_failed:'PDF 文本提取失败', attached_pdf_text:'附件 PDF 文本：\n{0}',
             data_not_loaded_upload_blocked:'数据尚未安全加载，已阻止上传', cloud_metadata_busy:'云端元数据正在同步，请稍后重试', cloud_metadata_corrupt:'云端元数据损坏', empty_local_cloud_nonempty_blocked:'本地数据为空但云端非空，已阻止覆盖', r2_not_configured:'尚未配置 R2', r2_read_verification_failed:'R2 写入后读取校验失败', cloud_notebook_position_invalid:'云端笔记本位置数据无效', recording_not_committed:'录音尚未完整提交', cloud_metadata_not_committed:'云端元数据未成功提交',
             local_class_material_missing:'本地课堂素材缺失：{0}', class_material_index_changed:'课堂素材索引已变化：{0}', class_note_content_missing:'课堂讲义内容缺失：{0}', class_note_index_changed:'课堂讲义索引已变化：{0}', delete_cloud_class_material_failed:'删除云端课堂素材失败：{0}', delete_cloud_class_note_failed:'删除云端课堂讲义失败：{0}',
@@ -6974,7 +6975,7 @@
             edit_message_prompt:'Edit message:', reader_chat_greeting:'You are reading “{0}.”{1}', reader_chat_notes:'\nNotes on this page: {0}', reader_fallback_review:'Help me review the key points on this page.', reader_fallback_example:'Give me a related example problem.', reader_fallback_notes:'Turn the current content into study notes.', reader_fallback_proof:'Explain the relevant proof in detail.', request_failed:'Request failed: ', unknown_error:'Unknown error',
             chat_history_filename:'chat-history', select_books:'Select books', select_papers:'Select papers', progress_label:'Progress {0}%', book_file_missing:'The book file is missing', bookmark_page_suffix:' (page {0})', no_chapter_bookmarks:'No chapter bookmarks', chapter_bookmarks_hint:'Long-press a book to generate lectures and chapter bookmarks', page_label:'Page {0}', lecture_progress_suffix:' · Lecture {0}%',
             generating_lecture_content:'Generating lecture content…', first_generation_time:'The first generation may take a few minutes', generation_failed:'Generation failed', network_api_retry:'Check your network or API settings and try again', content_load_failed:'Failed to load content', lecture_content_not_found:'Lecture content was not found', lecture_not_generated:'This lecture has not been generated', cannot_load_lecture:'Unable to load the lecture', download_lecture:'Download lecture',
-            fetch_models_http_error:'Failed to fetch models (HTTP {0}): {1}', fetch_models_failed:'Failed to fetch models', all_apis_failed:'All API attempts failed', configure_api_first:'Configure an API first', api_error:'API error (HTTP {0}): {1}', claude_api_error:'Claude API error (HTTP {0}): {1}', api_url_empty:'API URL cannot be empty', select_model_required:'Select a model', large_recording_requires_gemini:'Long recordings require a Gemini model',
+            fetch_models_http_error:'Failed to fetch models (HTTP {0}): {1}', fetch_models_failed:'Failed to fetch models', all_apis_failed:'All API attempts failed', configure_api_first:'Configure an API first', api_error:'API error (HTTP {0}): {1}', claude_api_error:'Claude API error (HTTP {0}): {1}', api_url_empty:'API URL cannot be empty', select_model_required:'Select a model', large_recording_requires_gemini:'Long recordings require a Gemini model', ai_thinking_only_response:'The model returned reasoning but no final answer; check the maxthinking output limit',
             files_api_start_failed:'Failed to start the Files API upload', files_api_no_upload_url:'The Files API did not return an upload URL', files_api_upload_failed:'Files API upload failed', files_api_processing_failed:'Files API processing failed', pdf_text_extraction_failed:'Failed to extract PDF text', attached_pdf_text:'Attached PDF text:\n{0}',
             data_not_loaded_upload_blocked:'Data has not loaded safely; upload was blocked', cloud_metadata_busy:'Cloud metadata is syncing; try again shortly', cloud_metadata_corrupt:'Cloud metadata is corrupted', empty_local_cloud_nonempty_blocked:'Local data is empty while cloud data is not; overwrite was blocked', r2_not_configured:'R2 is not configured', r2_read_verification_failed:'R2 read-after-write verification failed', cloud_notebook_position_invalid:'Cloud notebook position data is invalid', recording_not_committed:'The recording has not been fully committed', cloud_metadata_not_committed:'Cloud metadata was not committed',
             local_class_material_missing:'Local class material is missing: {0}', class_material_index_changed:'The class material index changed: {0}', class_note_content_missing:'Class lecture content is missing: {0}', class_note_index_changed:'The class lecture index changed: {0}', delete_cloud_class_material_failed:'Failed to delete cloud class material: {0}', delete_cloud_class_note_failed:'Failed to delete cloud class lecture: {0}',
@@ -6993,7 +6994,7 @@
             edit_message_prompt:'Modifier le message :', reader_chat_greeting:'Vous lisez « {0} ».{1}', reader_chat_notes:'\nNotes de cette page : {0}', reader_fallback_review:'Aide-moi à réviser les points clés de cette page.', reader_fallback_example:'Donne-moi un exercice similaire.', reader_fallback_notes:'Transforme le contenu actuel en notes de révision.', reader_fallback_proof:'Explique en détail la démonstration correspondante.', request_failed:'Échec de la requête : ', unknown_error:'Erreur inconnue',
             chat_history_filename:'historique-discussion', select_books:'Sélectionner des livres', select_papers:'Sélectionner des articles', progress_label:'Progression {0} %', book_file_missing:'Le fichier du livre est introuvable', bookmark_page_suffix:' (page {0})', no_chapter_bookmarks:'Aucun signet de chapitre', chapter_bookmarks_hint:'Appuyez longuement sur un livre pour générer les cours et les signets', page_label:'Page {0}', lecture_progress_suffix:' · Cours {0} %',
             generating_lecture_content:'Génération du cours…', first_generation_time:'La première génération peut prendre quelques minutes', generation_failed:'Échec de la génération', network_api_retry:'Vérifiez le réseau ou les réglages API, puis réessayez', content_load_failed:'Échec du chargement du contenu', lecture_content_not_found:'Contenu du cours introuvable', lecture_not_generated:'Ce cours n’a pas encore été généré', cannot_load_lecture:'Impossible de charger le cours', download_lecture:'Télécharger le cours',
-            fetch_models_http_error:'Échec de récupération des modèles (HTTP {0}) : {1}', fetch_models_failed:'Échec de récupération des modèles', all_apis_failed:'Toutes les tentatives API ont échoué', configure_api_first:'Configurez d’abord une API', api_error:'Erreur API (HTTP {0}) : {1}', claude_api_error:'Erreur de l’API Claude (HTTP {0}) : {1}', api_url_empty:"L’URL de l’API ne peut pas être vide", select_model_required:'Sélectionnez un modèle', large_recording_requires_gemini:'Les enregistrements longs nécessitent un modèle Gemini',
+            fetch_models_http_error:'Échec de récupération des modèles (HTTP {0}) : {1}', fetch_models_failed:'Échec de récupération des modèles', all_apis_failed:'Toutes les tentatives API ont échoué', configure_api_first:'Configurez d’abord une API', api_error:'Erreur API (HTTP {0}) : {1}', claude_api_error:'Erreur de l’API Claude (HTTP {0}) : {1}', api_url_empty:"L’URL de l’API ne peut pas être vide", select_model_required:'Sélectionnez un modèle', large_recording_requires_gemini:'Les enregistrements longs nécessitent un modèle Gemini', ai_thinking_only_response:'Le modèle a renvoyé son raisonnement sans réponse finale ; vérifiez la limite de sortie maxthinking',
             files_api_start_failed:'Impossible de démarrer le téléversement Files API', files_api_no_upload_url:'Files API n’a renvoyé aucune URL de téléversement', files_api_upload_failed:'Échec du téléversement Files API', files_api_processing_failed:'Échec du traitement Files API', pdf_text_extraction_failed:"Échec de l’extraction du texte du PDF", attached_pdf_text:'Texte du PDF joint :\n{0}',
             data_not_loaded_upload_blocked:"Les données ne sont pas chargées de façon sûre ; l’envoi a été bloqué", cloud_metadata_busy:'Les métadonnées cloud sont en cours de synchronisation ; réessayez bientôt', cloud_metadata_corrupt:'Les métadonnées cloud sont corrompues', empty_local_cloud_nonempty_blocked:'Les données locales sont vides mais celles du cloud ne le sont pas ; remplacement bloqué', r2_not_configured:'R2 n’est pas configuré', r2_read_verification_failed:'Échec de la vérification R2 après écriture', cloud_notebook_position_invalid:'La position cloud du carnet est invalide', recording_not_committed:"L’enregistrement n’est pas entièrement validé", cloud_metadata_not_committed:'Les métadonnées cloud n’ont pas été validées',
             local_class_material_missing:'Support de cours local manquant : {0}', class_material_index_changed:"L’index des supports de cours a changé : {0}", class_note_content_missing:'Contenu du cours manquant : {0}', class_note_index_changed:"L’index des cours a changé : {0}", delete_cloud_class_material_failed:'Échec de suppression du support cloud : {0}', delete_cloud_class_note_failed:'Échec de suppression du cours cloud : {0}',
@@ -12414,7 +12415,7 @@
                 provider: settings.backupProvider || ''
             }];
             return candidates.find(config => config.url && config.key && config.model &&
-                (isGeminiUrl(config.url) || config.provider === 'custom')) || null;
+                window.AIResponse.inferProtocol(config) === 'gemini') || null;
         }
 
         async function fetchModels(type) {
@@ -18595,6 +18596,17 @@
         }
 
         // ==================== 通用AI调用 ====================
+        function parseAIResponse(extractor, data) {
+            try {
+                return extractor(data);
+            } catch (error) {
+                if (error?.code === 'AI_THINKING_ONLY') {
+                    throw new Error(i18n('ai_thinking_only_response'));
+                }
+                throw error;
+            }
+        }
+
         async function callAI(systemPrompt, messages, options = {}) {
             const s = appData.settings;
             
@@ -18645,25 +18657,26 @@
         }
         
         async function doAIRequest(config, systemPrompt, messages, options = {}) {
-            // Gemini 原生渠道，或用户指定的"自定义"渠道都走 Gemini 协议（按用户要求）
-            const useGemini = isGeminiUrl(config.url) || config.provider === 'custom';
-            if (useGemini) {
+            // 以端点格式而不是模型名称判断协议。自定义 /chat/completions 即使承载
+            // Claude 模型，也仍须使用 OpenAI 兼容请求和响应格式。
+            const protocol = window.AIResponse.inferProtocol(config);
+            if (protocol === 'gemini') {
                 return await doGeminiRequest(config, systemPrompt, messages, options);
             }
 
-            // OpenAI / DeepSeek / Claude / 其他 OpenAI 兼容：用 chat/completions 协议
-            // 这些渠道中只有 Claude 支持原生 PDF，其他需要靠文本预提取兜底
+            if (protocol === 'anthropic') {
+                const claudeMessages = options.pdfAttachment
+                    ? await embedPdfForClaude(messages, options.pdfAttachment)
+                    : messages;
+                return await doClaudeRequest(config, systemPrompt, claudeMessages, options);
+            }
+
+            // OpenAI / DeepSeek / 自定义 OpenAI 兼容端点：Chat Completions 没有
+            // 可移植的 PDF 内容块格式，因此提取每页正文并注入最后一条 user 消息。
             let finalMessages = messages;
             if (options.pdfAttachment) {
-                if (config.provider === 'claude' || /anthropic\.com/.test(config.url)) {
-                    // Claude Messages API: document 块
-                    finalMessages = await embedPdfForClaude(messages, options.pdfAttachment);
-                    return await doClaudeRequest(config, systemPrompt, finalMessages, options);
-                } else {
-                    // OpenAI / DeepSeek / 其他：不支持 PDF，回退文本提取
-                    const extractedText = await extractPdfTextAsFallback(options.pdfAttachment);
-                    finalMessages = injectPdfTextIntoLastUser(messages, extractedText);
-                }
+                const extractedText = await extractPdfTextAsFallback(options.pdfAttachment);
+                finalMessages = injectPdfTextIntoLastUser(messages, extractedText);
             }
 
             // 把内部统一的 audio 内容块转换为 OpenAI 的 input_audio 格式
@@ -18697,10 +18710,11 @@
                     { role: 'system', content: systemPrompt },
                     ...finalMessages
                 ],
-                max_tokens: options.maxTokens || 8192,
                 temperature: options.temperature || 0.7,
                 stream: options.stream || false
             };
+            const maxTokens = window.AIResponse.outputTokenLimit(config.model, options.maxTokens, 8192);
+            if (maxTokens) requestBody.max_tokens = maxTokens;
             
             const response = await fetch(config.url, {
                 method: 'POST',
@@ -18721,7 +18735,7 @@
             }
             
             const data = await response.json();
-            return data.choices?.[0]?.message?.content || null;
+            return parseAIResponse(window.AIResponse.extractOpenAIText, data);
         }
 
         // 把 PDF 文本提取，作为"附件文本"拼到 messages 最后一条 user 内容前
@@ -18738,32 +18752,28 @@
                     const pageText = tc.items.map(it => it.str).join(' ');
                     parts.push(`--- Page ${i} ---\n${pageText}`);
                 }
+                if (!parts.some(part => /\n\s*\S/.test(part))) {
+                    throw new Error(i18n('pdf_text_extraction_failed'));
+                }
                 return parts.join('\n\n');
             } catch (e) {
                 console.error('PDF 文本提取失败:', e);
-                return i18n('pdf_text_extraction_failed');
+                throw new Error(i18n('pdf_text_extraction_failed'));
             }
         }
 
         function injectPdfTextIntoLastUser(messages, extractedText) {
-            if (!messages || messages.length === 0) {
-                return [{ role: 'user', content: i18n('attached_pdf_text') + '\n' + extractedText }];
-            }
-            const out = messages.slice();
-            const lastIdx = out.length - 1;
-            const last = out[lastIdx];
-            out[lastIdx] = {
-                role: last.role,
-                content: i18n('attached_pdf_text') + '\n' + extractedText + '\n\n---\n\n' + String(last.content || '')
-            };
-            return out;
+            return window.AIResponse.prependToLastUserMessage(
+                messages,
+                i18n('attached_pdf_text', extractedText)
+            );
         }
 
-        // Claude Messages API 封装（仅用于带 PDF 附件的情形）
+        // Claude Messages API 封装
         async function doClaudeRequest(config, systemPrompt, messages, options = {}) {
             const body = {
                 model: config.model,
-                max_tokens: options.maxTokens || 8192,
+                max_tokens: window.AIResponse.outputTokenLimit(config.model, options.maxTokens, 8192),
                 temperature: options.temperature != null ? options.temperature : 0.7,
                 messages,
             };
@@ -18783,10 +18793,7 @@
                 throw new Error(i18n('claude_api_error', response.status, errText));
             }
             const data = await response.json();
-            if (Array.isArray(data.content)) {
-                return data.content.filter(x => x.type === 'text').map(x => x.text).join('');
-            }
-            return null;
+            return parseAIResponse(window.AIResponse.extractAnthropicText, data);
         }
 
         // 把 PDF 附件嵌入到 Claude messages 最后一条 user 消息里（document 块）
@@ -18896,10 +18903,12 @@
             const body = {
                 contents,
                 generationConfig: {
-                    temperature: options.temperature != null ? options.temperature : 0.7,
-                    maxOutputTokens: options.maxTokens || 8192
+                    temperature: options.temperature != null ? options.temperature : 0.7
                 }
             };
+            const maxOutputTokens = window.AIResponse.outputTokenLimit(
+                config.model, options.maxTokens, 8192);
+            if (maxOutputTokens) body.generationConfig.maxOutputTokens = maxOutputTokens;
             if (systemPrompt) {
                 body.systemInstruction = { parts: [{ text: String(systemPrompt) }] };
             }
@@ -18920,11 +18929,7 @@
             if (finishReason && finishReason !== 'STOP') {
                 console.warn('Gemini finishReason:', finishReason, '— 输出可能被截断');
             }
-            const parts = candidate?.content?.parts;
-            if (Array.isArray(parts) && parts.length > 0) {
-                return parts.map(p => p.text || '').join('');
-            }
-            return null;
+            return parseAIResponse(window.AIResponse.extractGeminiText, data);
         }
 
         // 构造 Gemini contents，带 PDF。超过 18MB 走 Files API。
@@ -19579,7 +19584,7 @@ ${i18n('prompt_lecture_gen')}`;
                 }
 
                 const result = await callAI(systemPrompt, [{ role: 'user', content: userMessage }], {
-                    maxTokens: 8192,
+                    maxTokens: 12288,
                     pdfAttachment
                 });
 

--- a/docs/ai-response.js
+++ b/docs/ai-response.js
@@ -1,0 +1,182 @@
+(function (root, factory) {
+    const api = factory();
+    if (typeof module === 'object' && module.exports) module.exports = api;
+    if (root) root.AIResponse = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+    'use strict';
+
+    const THINKING_PART_TYPES = new Set([
+        'analysis', 'reasoning', 'reasoning_content', 'thinking', 'thought'
+    ]);
+
+    function inferProtocol(config) {
+        config = config || {};
+        const provider = String(config.provider || '').toLowerCase();
+        const url = String(config.url || '').toLowerCase();
+
+        // An explicit endpoint shape is more reliable than the UI label. In particular,
+        // a custom endpoint ending in /chat/completions can still serve a Claude model.
+        if (/\/chat\/completions(?:[/?#]|$)/.test(url)) return 'openai';
+        if (/anthropic\.com/.test(url) || /\/messages(?:[/?#]|$)/.test(url)) return 'anthropic';
+        if (/generativelanguage\.googleapis\.com/.test(url) ||
+            /:generatecontent(?:[/?#]|$)/.test(url) ||
+            /\/(?:v1beta|v1alpha)(?:[/?#]|$)/.test(url)) return 'gemini';
+
+        if (provider === 'google') return 'gemini';
+        if (provider === 'claude') return 'anthropic';
+        return 'openai';
+    }
+
+    function isMaxThinkingModel(model) {
+        return /(?:^|[-_/\s])max[-_\s]?thinking(?:$|[-_/\s])/i.test(String(model || ''));
+    }
+
+    function outputTokenLimit(model, requested, fallback) {
+        const value = Number(requested);
+        const defaultValue = Number(fallback);
+        const base = Number.isFinite(value) && value > 0
+            ? Math.floor(value)
+            : Number.isFinite(defaultValue) && defaultValue > 0
+            ? Math.floor(defaultValue)
+            : null;
+        // maxthinking gateways commonly reserve up to 32K tokens for reasoning. Keep
+        // enough room for a roughly 12K-token lecture without asking ordinary models
+        // for an unnecessarily large completion.
+        return isMaxThinkingModel(model) ? Math.max(base || 0, 49152) : base;
+    }
+
+    function thinkingOnlyError(finishReason) {
+        const error = new Error('AI returned reasoning but no final answer');
+        error.code = 'AI_THINKING_ONLY';
+        error.finishReason = finishReason || '';
+        return error;
+    }
+
+    function isThinkingPart(part) {
+        if (!part || typeof part !== 'object') return false;
+        if (part.thought === true) return true;
+        return THINKING_PART_TYPES.has(String(part.type || '').toLowerCase());
+    }
+
+    function textFromPart(part) {
+        if (!part || typeof part !== 'object') return '';
+        if (typeof part.text === 'string') return part.text;
+        if (typeof part.content === 'string') return part.content;
+        if (part.text && typeof part.text.value === 'string') return part.text.value;
+        return '';
+    }
+
+    function removeEmbeddedThinking(value) {
+        let text = String(value || '');
+        let hadThinking = false;
+        text = text.replace(/<(?:think|thinking)>[\s\S]*?<\/(?:think|thinking)>/gi, function () {
+            hadThinking = true;
+            return '';
+        });
+        if (/<(?:think|thinking)>/i.test(text)) {
+            hadThinking = true;
+            text = text.replace(/<(?:think|thinking)>[\s\S]*$/i, '');
+        }
+        return { text, hadThinking };
+    }
+
+    function extractOpenAIText(data) {
+        const message = data && data.choices && data.choices[0] && data.choices[0].message;
+        if (!message) return null;
+
+        let answer = '';
+        let hadThinking = !!(message.reasoning_content || message.reasoning);
+        if (typeof message.content === 'string') {
+            const cleaned = removeEmbeddedThinking(message.content);
+            answer = cleaned.text;
+            hadThinking = hadThinking || cleaned.hadThinking;
+        } else if (Array.isArray(message.content)) {
+            const answerParts = [];
+            for (const part of message.content) {
+                const text = textFromPart(part);
+                if (isThinkingPart(part)) {
+                    if (text) hadThinking = true;
+                } else if (text) {
+                    answerParts.push(text);
+                }
+            }
+            answer = answerParts.join('');
+        }
+
+        if (answer.trim()) return answer;
+        if (hadThinking) throw thinkingOnlyError(data.choices[0].finish_reason);
+        return null;
+    }
+
+    function extractAnthropicText(data) {
+        if (!data || !Array.isArray(data.content)) return null;
+        const answer = data.content
+            .filter(function (part) { return !isThinkingPart(part); })
+            .map(textFromPart)
+            .join('');
+        if (answer.trim()) return answer;
+        const hadThinking = data.content.some(function (part) {
+            return isThinkingPart(part) && !!(textFromPart(part) || part.thinking);
+        });
+        if (hadThinking) throw thinkingOnlyError(data.stop_reason);
+        return null;
+    }
+
+    function extractGeminiText(data) {
+        const candidate = data && data.candidates && data.candidates[0];
+        const parts = candidate && candidate.content && candidate.content.parts;
+        if (!Array.isArray(parts) || parts.length === 0) return null;
+
+        const answer = parts
+            .filter(function (part) { return !isThinkingPart(part); })
+            .map(textFromPart)
+            .join('');
+        if (answer.trim()) return answer;
+        const hadThinking = parts.some(function (part) {
+            return isThinkingPart(part) && !!textFromPart(part);
+        });
+        if (hadThinking) throw thinkingOnlyError(candidate.finishReason);
+        return null;
+    }
+
+    function prependToLastUserMessage(messages, prefix) {
+        const out = Array.isArray(messages) ? messages.slice() : [];
+        let index = -1;
+        for (let i = out.length - 1; i >= 0; i--) {
+            if (out[i] && out[i].role === 'user') {
+                index = i;
+                break;
+            }
+        }
+        if (index < 0) {
+            out.push({ role: 'user', content: String(prefix || '') });
+            return out;
+        }
+
+        const message = out[index] || { role: 'user', content: '' };
+        if (Array.isArray(message.content)) {
+            out[index] = {
+                ...message,
+                content: [{ type: 'text', text: String(prefix || '') }, ...message.content]
+            };
+        } else {
+            const suffix = String(message.content || '');
+            out[index] = {
+                ...message,
+                content: String(prefix || '') + (suffix ? '\n\n---\n\n' + suffix : '')
+            };
+        }
+        return out;
+    }
+
+    return {
+        inferProtocol,
+        isMaxThinkingModel,
+        outputTokenLimit,
+        isThinkingPart,
+        extractOpenAIText,
+        extractAnthropicText,
+        extractGeminiText,
+        prependToLastUserMessage
+    };
+});

--- a/docs/index.html
+++ b/docs/index.html
@@ -6343,6 +6343,7 @@
     <script src="recording-storage.js"></script>
     <script src="classroom-storage.js"></script>
     <script src="recording-ai.js"></script>
+    <script src="ai-response.js"></script>
     <script>
         // ==================== Data Store ====================
         let appData = {
@@ -6955,7 +6956,7 @@
             edit_message_prompt:'编辑消息：', reader_chat_greeting:'正在阅读《{0}》。{1}', reader_chat_notes:'\n当前页笔记：{0}', reader_fallback_review:'请帮我复习这一页的重点。', reader_fallback_example:'请给一个相关例题。', reader_fallback_notes:'请整理当前内容的学习笔记。', reader_fallback_proof:'请详细解释相关证明。', request_failed:'请求失败：', unknown_error:'未知错误',
             chat_history_filename:'聊天记录', select_books:'选择书籍', select_papers:'选择论文', progress_label:'进度 {0}%', book_file_missing:'书籍文件不存在', bookmark_page_suffix:'（第 {0} 页）', no_chapter_bookmarks:'暂无章节书签', chapter_bookmarks_hint:'长按书籍可生成讲义与章节书签', page_label:'第 {0} 页', lecture_progress_suffix:' · 讲义 {0}%',
             generating_lecture_content:'正在生成讲义内容…', first_generation_time:'首次生成可能需要几分钟', generation_failed:'生成失败', network_api_retry:'请检查网络或 API 设置后重试', content_load_failed:'内容加载失败', lecture_content_not_found:'未找到讲义内容', lecture_not_generated:'讲义尚未生成', cannot_load_lecture:'无法加载讲义', download_lecture:'下载讲义',
-            fetch_models_http_error:'拉取模型失败（HTTP {0}）：{1}', fetch_models_failed:'拉取模型失败', all_apis_failed:'所有 API 均调用失败', configure_api_first:'请先配置 API', api_error:'API 错误（HTTP {0}）：{1}', claude_api_error:'Claude API 错误（HTTP {0}）：{1}', api_url_empty:'API URL 不能为空', select_model_required:'请选择模型', large_recording_requires_gemini:'长录音需要使用 Gemini 模型',
+            fetch_models_http_error:'拉取模型失败（HTTP {0}）：{1}', fetch_models_failed:'拉取模型失败', all_apis_failed:'所有 API 均调用失败', configure_api_first:'请先配置 API', api_error:'API 错误（HTTP {0}）：{1}', claude_api_error:'Claude API 错误（HTTP {0}）：{1}', api_url_empty:'API URL 不能为空', select_model_required:'请选择模型', large_recording_requires_gemini:'长录音需要使用 Gemini 模型', ai_thinking_only_response:'模型只返回了思考过程，没有最终正文；请检查 maxthinking 模型的输出上限',
             files_api_start_failed:'Files API 启动失败', files_api_no_upload_url:'Files API 未返回上传地址', files_api_upload_failed:'Files API 上传失败', files_api_processing_failed:'Files API 处理失败', pdf_text_extraction_failed:'PDF 文本提取失败', attached_pdf_text:'附件 PDF 文本：\n{0}',
             data_not_loaded_upload_blocked:'数据尚未安全加载，已阻止上传', cloud_metadata_busy:'云端元数据正在同步，请稍后重试', cloud_metadata_corrupt:'云端元数据损坏', empty_local_cloud_nonempty_blocked:'本地数据为空但云端非空，已阻止覆盖', r2_not_configured:'尚未配置 R2', r2_read_verification_failed:'R2 写入后读取校验失败', cloud_notebook_position_invalid:'云端笔记本位置数据无效', recording_not_committed:'录音尚未完整提交', cloud_metadata_not_committed:'云端元数据未成功提交',
             local_class_material_missing:'本地课堂素材缺失：{0}', class_material_index_changed:'课堂素材索引已变化：{0}', class_note_content_missing:'课堂讲义内容缺失：{0}', class_note_index_changed:'课堂讲义索引已变化：{0}', delete_cloud_class_material_failed:'删除云端课堂素材失败：{0}', delete_cloud_class_note_failed:'删除云端课堂讲义失败：{0}',
@@ -6974,7 +6975,7 @@
             edit_message_prompt:'Edit message:', reader_chat_greeting:'You are reading “{0}.”{1}', reader_chat_notes:'\nNotes on this page: {0}', reader_fallback_review:'Help me review the key points on this page.', reader_fallback_example:'Give me a related example problem.', reader_fallback_notes:'Turn the current content into study notes.', reader_fallback_proof:'Explain the relevant proof in detail.', request_failed:'Request failed: ', unknown_error:'Unknown error',
             chat_history_filename:'chat-history', select_books:'Select books', select_papers:'Select papers', progress_label:'Progress {0}%', book_file_missing:'The book file is missing', bookmark_page_suffix:' (page {0})', no_chapter_bookmarks:'No chapter bookmarks', chapter_bookmarks_hint:'Long-press a book to generate lectures and chapter bookmarks', page_label:'Page {0}', lecture_progress_suffix:' · Lecture {0}%',
             generating_lecture_content:'Generating lecture content…', first_generation_time:'The first generation may take a few minutes', generation_failed:'Generation failed', network_api_retry:'Check your network or API settings and try again', content_load_failed:'Failed to load content', lecture_content_not_found:'Lecture content was not found', lecture_not_generated:'This lecture has not been generated', cannot_load_lecture:'Unable to load the lecture', download_lecture:'Download lecture',
-            fetch_models_http_error:'Failed to fetch models (HTTP {0}): {1}', fetch_models_failed:'Failed to fetch models', all_apis_failed:'All API attempts failed', configure_api_first:'Configure an API first', api_error:'API error (HTTP {0}): {1}', claude_api_error:'Claude API error (HTTP {0}): {1}', api_url_empty:'API URL cannot be empty', select_model_required:'Select a model', large_recording_requires_gemini:'Long recordings require a Gemini model',
+            fetch_models_http_error:'Failed to fetch models (HTTP {0}): {1}', fetch_models_failed:'Failed to fetch models', all_apis_failed:'All API attempts failed', configure_api_first:'Configure an API first', api_error:'API error (HTTP {0}): {1}', claude_api_error:'Claude API error (HTTP {0}): {1}', api_url_empty:'API URL cannot be empty', select_model_required:'Select a model', large_recording_requires_gemini:'Long recordings require a Gemini model', ai_thinking_only_response:'The model returned reasoning but no final answer; check the maxthinking output limit',
             files_api_start_failed:'Failed to start the Files API upload', files_api_no_upload_url:'The Files API did not return an upload URL', files_api_upload_failed:'Files API upload failed', files_api_processing_failed:'Files API processing failed', pdf_text_extraction_failed:'Failed to extract PDF text', attached_pdf_text:'Attached PDF text:\n{0}',
             data_not_loaded_upload_blocked:'Data has not loaded safely; upload was blocked', cloud_metadata_busy:'Cloud metadata is syncing; try again shortly', cloud_metadata_corrupt:'Cloud metadata is corrupted', empty_local_cloud_nonempty_blocked:'Local data is empty while cloud data is not; overwrite was blocked', r2_not_configured:'R2 is not configured', r2_read_verification_failed:'R2 read-after-write verification failed', cloud_notebook_position_invalid:'Cloud notebook position data is invalid', recording_not_committed:'The recording has not been fully committed', cloud_metadata_not_committed:'Cloud metadata was not committed',
             local_class_material_missing:'Local class material is missing: {0}', class_material_index_changed:'The class material index changed: {0}', class_note_content_missing:'Class lecture content is missing: {0}', class_note_index_changed:'The class lecture index changed: {0}', delete_cloud_class_material_failed:'Failed to delete cloud class material: {0}', delete_cloud_class_note_failed:'Failed to delete cloud class lecture: {0}',
@@ -6993,7 +6994,7 @@
             edit_message_prompt:'Modifier le message :', reader_chat_greeting:'Vous lisez « {0} ».{1}', reader_chat_notes:'\nNotes de cette page : {0}', reader_fallback_review:'Aide-moi à réviser les points clés de cette page.', reader_fallback_example:'Donne-moi un exercice similaire.', reader_fallback_notes:'Transforme le contenu actuel en notes de révision.', reader_fallback_proof:'Explique en détail la démonstration correspondante.', request_failed:'Échec de la requête : ', unknown_error:'Erreur inconnue',
             chat_history_filename:'historique-discussion', select_books:'Sélectionner des livres', select_papers:'Sélectionner des articles', progress_label:'Progression {0} %', book_file_missing:'Le fichier du livre est introuvable', bookmark_page_suffix:' (page {0})', no_chapter_bookmarks:'Aucun signet de chapitre', chapter_bookmarks_hint:'Appuyez longuement sur un livre pour générer les cours et les signets', page_label:'Page {0}', lecture_progress_suffix:' · Cours {0} %',
             generating_lecture_content:'Génération du cours…', first_generation_time:'La première génération peut prendre quelques minutes', generation_failed:'Échec de la génération', network_api_retry:'Vérifiez le réseau ou les réglages API, puis réessayez', content_load_failed:'Échec du chargement du contenu', lecture_content_not_found:'Contenu du cours introuvable', lecture_not_generated:'Ce cours n’a pas encore été généré', cannot_load_lecture:'Impossible de charger le cours', download_lecture:'Télécharger le cours',
-            fetch_models_http_error:'Échec de récupération des modèles (HTTP {0}) : {1}', fetch_models_failed:'Échec de récupération des modèles', all_apis_failed:'Toutes les tentatives API ont échoué', configure_api_first:'Configurez d’abord une API', api_error:'Erreur API (HTTP {0}) : {1}', claude_api_error:'Erreur de l’API Claude (HTTP {0}) : {1}', api_url_empty:"L’URL de l’API ne peut pas être vide", select_model_required:'Sélectionnez un modèle', large_recording_requires_gemini:'Les enregistrements longs nécessitent un modèle Gemini',
+            fetch_models_http_error:'Échec de récupération des modèles (HTTP {0}) : {1}', fetch_models_failed:'Échec de récupération des modèles', all_apis_failed:'Toutes les tentatives API ont échoué', configure_api_first:'Configurez d’abord une API', api_error:'Erreur API (HTTP {0}) : {1}', claude_api_error:'Erreur de l’API Claude (HTTP {0}) : {1}', api_url_empty:"L’URL de l’API ne peut pas être vide", select_model_required:'Sélectionnez un modèle', large_recording_requires_gemini:'Les enregistrements longs nécessitent un modèle Gemini', ai_thinking_only_response:'Le modèle a renvoyé son raisonnement sans réponse finale ; vérifiez la limite de sortie maxthinking',
             files_api_start_failed:'Impossible de démarrer le téléversement Files API', files_api_no_upload_url:'Files API n’a renvoyé aucune URL de téléversement', files_api_upload_failed:'Échec du téléversement Files API', files_api_processing_failed:'Échec du traitement Files API', pdf_text_extraction_failed:"Échec de l’extraction du texte du PDF", attached_pdf_text:'Texte du PDF joint :\n{0}',
             data_not_loaded_upload_blocked:"Les données ne sont pas chargées de façon sûre ; l’envoi a été bloqué", cloud_metadata_busy:'Les métadonnées cloud sont en cours de synchronisation ; réessayez bientôt', cloud_metadata_corrupt:'Les métadonnées cloud sont corrompues', empty_local_cloud_nonempty_blocked:'Les données locales sont vides mais celles du cloud ne le sont pas ; remplacement bloqué', r2_not_configured:'R2 n’est pas configuré', r2_read_verification_failed:'Échec de la vérification R2 après écriture', cloud_notebook_position_invalid:'La position cloud du carnet est invalide', recording_not_committed:"L’enregistrement n’est pas entièrement validé", cloud_metadata_not_committed:'Les métadonnées cloud n’ont pas été validées',
             local_class_material_missing:'Support de cours local manquant : {0}', class_material_index_changed:"L’index des supports de cours a changé : {0}", class_note_content_missing:'Contenu du cours manquant : {0}', class_note_index_changed:"L’index des cours a changé : {0}", delete_cloud_class_material_failed:'Échec de suppression du support cloud : {0}', delete_cloud_class_note_failed:'Échec de suppression du cours cloud : {0}',
@@ -12414,7 +12415,7 @@
                 provider: settings.backupProvider || ''
             }];
             return candidates.find(config => config.url && config.key && config.model &&
-                (isGeminiUrl(config.url) || config.provider === 'custom')) || null;
+                window.AIResponse.inferProtocol(config) === 'gemini') || null;
         }
 
         async function fetchModels(type) {
@@ -18595,6 +18596,17 @@
         }
 
         // ==================== 通用AI调用 ====================
+        function parseAIResponse(extractor, data) {
+            try {
+                return extractor(data);
+            } catch (error) {
+                if (error?.code === 'AI_THINKING_ONLY') {
+                    throw new Error(i18n('ai_thinking_only_response'));
+                }
+                throw error;
+            }
+        }
+
         async function callAI(systemPrompt, messages, options = {}) {
             const s = appData.settings;
             
@@ -18645,25 +18657,26 @@
         }
         
         async function doAIRequest(config, systemPrompt, messages, options = {}) {
-            // Gemini 原生渠道，或用户指定的"自定义"渠道都走 Gemini 协议（按用户要求）
-            const useGemini = isGeminiUrl(config.url) || config.provider === 'custom';
-            if (useGemini) {
+            // 以端点格式而不是模型名称判断协议。自定义 /chat/completions 即使承载
+            // Claude 模型，也仍须使用 OpenAI 兼容请求和响应格式。
+            const protocol = window.AIResponse.inferProtocol(config);
+            if (protocol === 'gemini') {
                 return await doGeminiRequest(config, systemPrompt, messages, options);
             }
 
-            // OpenAI / DeepSeek / Claude / 其他 OpenAI 兼容：用 chat/completions 协议
-            // 这些渠道中只有 Claude 支持原生 PDF，其他需要靠文本预提取兜底
+            if (protocol === 'anthropic') {
+                const claudeMessages = options.pdfAttachment
+                    ? await embedPdfForClaude(messages, options.pdfAttachment)
+                    : messages;
+                return await doClaudeRequest(config, systemPrompt, claudeMessages, options);
+            }
+
+            // OpenAI / DeepSeek / 自定义 OpenAI 兼容端点：Chat Completions 没有
+            // 可移植的 PDF 内容块格式，因此提取每页正文并注入最后一条 user 消息。
             let finalMessages = messages;
             if (options.pdfAttachment) {
-                if (config.provider === 'claude' || /anthropic\.com/.test(config.url)) {
-                    // Claude Messages API: document 块
-                    finalMessages = await embedPdfForClaude(messages, options.pdfAttachment);
-                    return await doClaudeRequest(config, systemPrompt, finalMessages, options);
-                } else {
-                    // OpenAI / DeepSeek / 其他：不支持 PDF，回退文本提取
-                    const extractedText = await extractPdfTextAsFallback(options.pdfAttachment);
-                    finalMessages = injectPdfTextIntoLastUser(messages, extractedText);
-                }
+                const extractedText = await extractPdfTextAsFallback(options.pdfAttachment);
+                finalMessages = injectPdfTextIntoLastUser(messages, extractedText);
             }
 
             // 把内部统一的 audio 内容块转换为 OpenAI 的 input_audio 格式
@@ -18697,10 +18710,11 @@
                     { role: 'system', content: systemPrompt },
                     ...finalMessages
                 ],
-                max_tokens: options.maxTokens || 8192,
                 temperature: options.temperature || 0.7,
                 stream: options.stream || false
             };
+            const maxTokens = window.AIResponse.outputTokenLimit(config.model, options.maxTokens, 8192);
+            if (maxTokens) requestBody.max_tokens = maxTokens;
             
             const response = await fetch(config.url, {
                 method: 'POST',
@@ -18721,7 +18735,7 @@
             }
             
             const data = await response.json();
-            return data.choices?.[0]?.message?.content || null;
+            return parseAIResponse(window.AIResponse.extractOpenAIText, data);
         }
 
         // 把 PDF 文本提取，作为"附件文本"拼到 messages 最后一条 user 内容前
@@ -18738,32 +18752,28 @@
                     const pageText = tc.items.map(it => it.str).join(' ');
                     parts.push(`--- Page ${i} ---\n${pageText}`);
                 }
+                if (!parts.some(part => /\n\s*\S/.test(part))) {
+                    throw new Error(i18n('pdf_text_extraction_failed'));
+                }
                 return parts.join('\n\n');
             } catch (e) {
                 console.error('PDF 文本提取失败:', e);
-                return i18n('pdf_text_extraction_failed');
+                throw new Error(i18n('pdf_text_extraction_failed'));
             }
         }
 
         function injectPdfTextIntoLastUser(messages, extractedText) {
-            if (!messages || messages.length === 0) {
-                return [{ role: 'user', content: i18n('attached_pdf_text') + '\n' + extractedText }];
-            }
-            const out = messages.slice();
-            const lastIdx = out.length - 1;
-            const last = out[lastIdx];
-            out[lastIdx] = {
-                role: last.role,
-                content: i18n('attached_pdf_text') + '\n' + extractedText + '\n\n---\n\n' + String(last.content || '')
-            };
-            return out;
+            return window.AIResponse.prependToLastUserMessage(
+                messages,
+                i18n('attached_pdf_text', extractedText)
+            );
         }
 
-        // Claude Messages API 封装（仅用于带 PDF 附件的情形）
+        // Claude Messages API 封装
         async function doClaudeRequest(config, systemPrompt, messages, options = {}) {
             const body = {
                 model: config.model,
-                max_tokens: options.maxTokens || 8192,
+                max_tokens: window.AIResponse.outputTokenLimit(config.model, options.maxTokens, 8192),
                 temperature: options.temperature != null ? options.temperature : 0.7,
                 messages,
             };
@@ -18783,10 +18793,7 @@
                 throw new Error(i18n('claude_api_error', response.status, errText));
             }
             const data = await response.json();
-            if (Array.isArray(data.content)) {
-                return data.content.filter(x => x.type === 'text').map(x => x.text).join('');
-            }
-            return null;
+            return parseAIResponse(window.AIResponse.extractAnthropicText, data);
         }
 
         // 把 PDF 附件嵌入到 Claude messages 最后一条 user 消息里（document 块）
@@ -18896,10 +18903,12 @@
             const body = {
                 contents,
                 generationConfig: {
-                    temperature: options.temperature != null ? options.temperature : 0.7,
-                    maxOutputTokens: options.maxTokens || 8192
+                    temperature: options.temperature != null ? options.temperature : 0.7
                 }
             };
+            const maxOutputTokens = window.AIResponse.outputTokenLimit(
+                config.model, options.maxTokens, 8192);
+            if (maxOutputTokens) body.generationConfig.maxOutputTokens = maxOutputTokens;
             if (systemPrompt) {
                 body.systemInstruction = { parts: [{ text: String(systemPrompt) }] };
             }
@@ -18920,11 +18929,7 @@
             if (finishReason && finishReason !== 'STOP') {
                 console.warn('Gemini finishReason:', finishReason, '— 输出可能被截断');
             }
-            const parts = candidate?.content?.parts;
-            if (Array.isArray(parts) && parts.length > 0) {
-                return parts.map(p => p.text || '').join('');
-            }
-            return null;
+            return parseAIResponse(window.AIResponse.extractGeminiText, data);
         }
 
         // 构造 Gemini contents，带 PDF。超过 18MB 走 Files API。
@@ -19579,7 +19584,7 @@ ${i18n('prompt_lecture_gen')}`;
                 }
 
                 const result = await callAI(systemPrompt, [{ role: 'user', content: userMessage }], {
-                    maxTokens: 8192,
+                    maxTokens: 12288,
                     pdfAttachment
                 });
 

--- a/tests/ai-response.test.js
+++ b/tests/ai-response.test.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const AIResponse = require('../app/src/main/assets/www/ai-response.js');
+
+test('routes custom OpenAI-compatible Claude endpoints by URL protocol', () => {
+    assert.equal(AIResponse.inferProtocol({
+        provider: 'custom',
+        url: 'https://gateway.example/v1/chat/completions',
+        model: 'claude-opus-5-maxthinking'
+    }), 'openai');
+    assert.equal(AIResponse.inferProtocol({ provider: 'custom', url: 'https://gateway.example/v1beta' }),
+        'gemini');
+    assert.equal(AIResponse.inferProtocol({ provider: 'claude', url: 'https://api.anthropic.com/v1/messages' }),
+        'anthropic');
+});
+
+test('keeps final text separate from reasoning and rejects a reasoning-only response', () => {
+    const response = {
+        choices: [{
+            finish_reason: 'stop',
+            message: { reasoning_content: 'internal reasoning', content: '# Lecture\n\nBody' }
+        }]
+    };
+    assert.equal(AIResponse.extractOpenAIText(response), '# Lecture\n\nBody');
+    assert.equal(AIResponse.extractGeminiText({
+        candidates: [{ content: { parts: [
+            { thought: true, text: 'internal reasoning' },
+            { text: 'final answer' }
+        ] } }]
+    }), 'final answer');
+    assert.throws(() => AIResponse.extractOpenAIText({
+        choices: [{ finish_reason: 'length', message: {
+            reasoning_content: 'internal reasoning', content: ''
+        } }]
+    }), error => error.code === 'AI_THINKING_ONLY');
+});
+
+test('injects PDF text into the user message and reserves maxthinking output capacity', () => {
+    const messages = AIResponse.prependToLastUserMessage([
+        { role: 'user', content: [{ type: 'text', text: 'Generate the lecture.' }] }
+    ], 'Attached PDF text:\npage content');
+    assert.equal(messages[0].content[0].text, 'Attached PDF text:\npage content');
+    assert.equal(messages[0].content[1].text, 'Generate the lecture.');
+    assert.equal(AIResponse.outputTokenLimit('claude-opus-5-maxthinking', 12288, 8192), 49152);
+    assert.equal(AIResponse.outputTokenLimit('claude-opus-5', 12288, 8192), 12288);
+});


### PR DESCRIPTION
## Summary
- route custom `/chat/completions` endpoints through the OpenAI-compatible path even when the selected model is Claude
- extract PDF text page by page and inject it into the final user message for lecture generation
- save only final answer content, excluding reasoning/thinking fields and parts
- use 12,288 tokens for ordinary lecture output and 49,152 for `maxthinking` models so reasoning does not consume the final-answer budget
- leave all lecture prompts unchanged

## Verification
- `node --test tests/*.test.js` (5 passed)
- Android/PWA shared assets match
- `git diff --check` passed
- local Gradle build could not start because this host has no Java runtime; the existing Build APK workflow will provide the build check