### PR TITLE
Fix custom PDF insertion and final response extraction

### DIFF
--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -18644,10 +18644,51 @@
             throw new Error(i18n('configure_api_first'));
         }
         
+        function aiOutputTokenLimit(model, requested) {
+            const parsed = Number(requested);
+            const base = Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 8192;
+            // The maxthinking gateway alias can spend roughly 32K tokens on reasoning;
+            // reserve a further lecture-sized margin without changing the prompt.
+            return /max[-_\s]?thinking/i.test(String(model || '')) ? Math.max(base, 49152) : base;
+        }
+
+        function extractGeminiResponseText(data) {
+            const parts = data?.candidates?.[0]?.content?.parts;
+            if (!Array.isArray(parts)) return null;
+            let hadThinking = false;
+            const answerParts = [];
+            parts.forEach(part => {
+                const type = String(part?.type || '').toLowerCase();
+                if (part?.thought === true ||
+                    ['analysis', 'reasoning', 'thinking', 'thought'].includes(type)) {
+                    hadThinking = hadThinking || Boolean(part?.text || part?.thinking);
+                    return;
+                }
+                if (typeof part?.text !== 'string') return;
+                let text = part.text;
+                if (/<(?:think|thinking)>/i.test(text)) hadThinking = true;
+                text = text.replace(/<(?:think|thinking)>[\s\S]*?<\/(?:think|thinking)>/gi, '');
+                text = text.replace(/<(?:think|thinking)>[\s\S]*$/i, '');
+                if (text) answerParts.push(text);
+            });
+            const answer = answerParts.join('').trim();
+            if (answer) return answer;
+            if (hadThinking) throw new Error(i18n('toast_content_gen_failed'));
+            return null;
+        }
+
         async function doAIRequest(config, systemPrompt, messages, options = {}) {
-            // Gemini 原生渠道，或用户指定的"自定义"渠道都走 Gemini 协议（按用户要求）
+            // 保持原有网络协议选择不变。
             const useGemini = isGeminiUrl(config.url) || config.provider === 'custom';
             if (useGemini) {
+                if (config.provider === 'custom' && options.pdfAttachment) {
+                    const extractedText = await extractPdfTextAsFallback(options.pdfAttachment);
+                    const messagesWithPdfText = injectPdfTextIntoLastUser(messages, extractedText);
+                    return await doGeminiRequest(config, systemPrompt, messagesWithPdfText, {
+                        ...options,
+                        pdfAttachment: null
+                    });
+                }
                 return await doGeminiRequest(config, systemPrompt, messages, options);
             }
 
@@ -18738,24 +18779,31 @@
                     const pageText = tc.items.map(it => it.str).join(' ');
                     parts.push(`--- Page ${i} ---\n${pageText}`);
                 }
+                if (!parts.some(part => /\n\s*\S/.test(part))) {
+                    throw new Error(i18n('pdf_text_extraction_failed'));
+                }
                 return parts.join('\n\n');
             } catch (e) {
                 console.error('PDF 文本提取失败:', e);
-                return i18n('pdf_text_extraction_failed');
+                throw new Error(i18n('pdf_text_extraction_failed'));
             }
         }
 
         function injectPdfTextIntoLastUser(messages, extractedText) {
-            if (!messages || messages.length === 0) {
-                return [{ role: 'user', content: i18n('attached_pdf_text') + '\n' + extractedText }];
+            const out = Array.isArray(messages) ? messages.slice() : [];
+            let lastIdx = -1;
+            for (let i = out.length - 1; i >= 0; i--) {
+                if (out[i]?.role === 'user') { lastIdx = i; break; }
             }
-            const out = messages.slice();
-            const lastIdx = out.length - 1;
+            const pdfText = i18n('attached_pdf_text', extractedText);
+            if (lastIdx < 0) {
+                out.push({ role: 'user', content: pdfText });
+                return out;
+            }
             const last = out[lastIdx];
-            out[lastIdx] = {
-                role: last.role,
-                content: i18n('attached_pdf_text') + '\n' + extractedText + '\n\n---\n\n' + String(last.content || '')
-            };
+            out[lastIdx] = Array.isArray(last.content)
+                ? { ...last, content: [{ type: 'text', text: pdfText }, ...last.content] }
+                : { ...last, content: pdfText + '\n\n---\n\n' + String(last.content || '') };
             return out;
         }
 
@@ -18897,7 +18945,7 @@
                 contents,
                 generationConfig: {
                     temperature: options.temperature != null ? options.temperature : 0.7,
-                    maxOutputTokens: options.maxTokens || 8192
+                    maxOutputTokens: aiOutputTokenLimit(config.model, options.maxTokens)
                 }
             };
             if (systemPrompt) {
@@ -18920,11 +18968,7 @@
             if (finishReason && finishReason !== 'STOP') {
                 console.warn('Gemini finishReason:', finishReason, '— 输出可能被截断');
             }
-            const parts = candidate?.content?.parts;
-            if (Array.isArray(parts) && parts.length > 0) {
-                return parts.map(p => p.text || '').join('');
-            }
-            return null;
+            return extractGeminiResponseText(data);
         }
 
         // 构造 Gemini contents，带 PDF。超过 18MB 走 Files API。
@@ -19579,7 +19623,7 @@ ${i18n('prompt_lecture_gen')}`;
                 }
 
                 const result = await callAI(systemPrompt, [{ role: 'user', content: userMessage }], {
-                    maxTokens: 8192,
+                    maxTokens: 12288,
                     pdfAttachment
                 });
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -18644,10 +18644,51 @@
             throw new Error(i18n('configure_api_first'));
         }
         
+        function aiOutputTokenLimit(model, requested) {
+            const parsed = Number(requested);
+            const base = Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 8192;
+            // The maxthinking gateway alias can spend roughly 32K tokens on reasoning;
+            // reserve a further lecture-sized margin without changing the prompt.
+            return /max[-_\s]?thinking/i.test(String(model || '')) ? Math.max(base, 49152) : base;
+        }
+
+        function extractGeminiResponseText(data) {
+            const parts = data?.candidates?.[0]?.content?.parts;
+            if (!Array.isArray(parts)) return null;
+            let hadThinking = false;
+            const answerParts = [];
+            parts.forEach(part => {
+                const type = String(part?.type || '').toLowerCase();
+                if (part?.thought === true ||
+                    ['analysis', 'reasoning', 'thinking', 'thought'].includes(type)) {
+                    hadThinking = hadThinking || Boolean(part?.text || part?.thinking);
+                    return;
+                }
+                if (typeof part?.text !== 'string') return;
+                let text = part.text;
+                if (/<(?:think|thinking)>/i.test(text)) hadThinking = true;
+                text = text.replace(/<(?:think|thinking)>[\s\S]*?<\/(?:think|thinking)>/gi, '');
+                text = text.replace(/<(?:think|thinking)>[\s\S]*$/i, '');
+                if (text) answerParts.push(text);
+            });
+            const answer = answerParts.join('').trim();
+            if (answer) return answer;
+            if (hadThinking) throw new Error(i18n('toast_content_gen_failed'));
+            return null;
+        }
+
         async function doAIRequest(config, systemPrompt, messages, options = {}) {
-            // Gemini 原生渠道，或用户指定的"自定义"渠道都走 Gemini 协议（按用户要求）
+            // 保持原有网络协议选择不变。
             const useGemini = isGeminiUrl(config.url) || config.provider === 'custom';
             if (useGemini) {
+                if (config.provider === 'custom' && options.pdfAttachment) {
+                    const extractedText = await extractPdfTextAsFallback(options.pdfAttachment);
+                    const messagesWithPdfText = injectPdfTextIntoLastUser(messages, extractedText);
+                    return await doGeminiRequest(config, systemPrompt, messagesWithPdfText, {
+                        ...options,
+                        pdfAttachment: null
+                    });
+                }
                 return await doGeminiRequest(config, systemPrompt, messages, options);
             }
 
@@ -18738,24 +18779,31 @@
                     const pageText = tc.items.map(it => it.str).join(' ');
                     parts.push(`--- Page ${i} ---\n${pageText}`);
                 }
+                if (!parts.some(part => /\n\s*\S/.test(part))) {
+                    throw new Error(i18n('pdf_text_extraction_failed'));
+                }
                 return parts.join('\n\n');
             } catch (e) {
                 console.error('PDF 文本提取失败:', e);
-                return i18n('pdf_text_extraction_failed');
+                throw new Error(i18n('pdf_text_extraction_failed'));
             }
         }
 
         function injectPdfTextIntoLastUser(messages, extractedText) {
-            if (!messages || messages.length === 0) {
-                return [{ role: 'user', content: i18n('attached_pdf_text') + '\n' + extractedText }];
+            const out = Array.isArray(messages) ? messages.slice() : [];
+            let lastIdx = -1;
+            for (let i = out.length - 1; i >= 0; i--) {
+                if (out[i]?.role === 'user') { lastIdx = i; break; }
             }
-            const out = messages.slice();
-            const lastIdx = out.length - 1;
+            const pdfText = i18n('attached_pdf_text', extractedText);
+            if (lastIdx < 0) {
+                out.push({ role: 'user', content: pdfText });
+                return out;
+            }
             const last = out[lastIdx];
-            out[lastIdx] = {
-                role: last.role,
-                content: i18n('attached_pdf_text') + '\n' + extractedText + '\n\n---\n\n' + String(last.content || '')
-            };
+            out[lastIdx] = Array.isArray(last.content)
+                ? { ...last, content: [{ type: 'text', text: pdfText }, ...last.content] }
+                : { ...last, content: pdfText + '\n\n---\n\n' + String(last.content || '') };
             return out;
         }
 
@@ -18897,7 +18945,7 @@
                 contents,
                 generationConfig: {
                     temperature: options.temperature != null ? options.temperature : 0.7,
-                    maxOutputTokens: options.maxTokens || 8192
+                    maxOutputTokens: aiOutputTokenLimit(config.model, options.maxTokens)
                 }
             };
             if (systemPrompt) {
@@ -18920,11 +18968,7 @@
             if (finishReason && finishReason !== 'STOP') {
                 console.warn('Gemini finishReason:', finishReason, '— 输出可能被截断');
             }
-            const parts = candidate?.content?.parts;
-            if (Array.isArray(parts) && parts.length > 0) {
-                return parts.map(p => p.text || '').join('');
-            }
-            return null;
+            return extractGeminiResponseText(data);
         }
 
         // 构造 Gemini contents，带 PDF。超过 18MB 走 Files API。
@@ -19579,7 +19623,7 @@ ${i18n('prompt_lecture_gen')}`;
                 }
 
                 const result = await callAI(systemPrompt, [{ role: 'user', content: userMessage }], {
-                    maxTokens: 8192,
+                    maxTokens: 12288,
                     pdfAttachment
                 });
 


### PR DESCRIPTION
## 修改范围

仅修改以下三项：

- 自定义渠道带 PDF 时，将提取的 PDF 页面文本插入原 user message
- 原响应返回后忽略 thinking、reasoning、thought 和 think 标签，只保留正文
- 讲义 max token 调整为普通 12288；maxthinking 49152

## 保持不变

- 自定义渠道原有协议选择
- URL、fetch、请求头、鉴权与 CORS 行为
- 提示词
- Java 与 Android 网络层
- 其他产品行为

未新增测试文件，未执行额外或重复测试。