### PR TITLE
自定义渠道改走 OpenAI 协议，并且只取正文不取思考

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -24,6 +24,7 @@ jobs:
           cp app/src/main/assets/www/recording-storage.js docs/
           cp app/src/main/assets/www/classroom-storage.js docs/
           cp app/src/main/assets/www/recording-ai.js docs/
+          cp app/src/main/assets/www/ai-response.js docs/
           cp app/src/main/assets/www/pdf.min.js docs/
           cp app/src/main/assets/www/pdf.worker.min.js docs/
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ This repository ships the current Math Reader web app as an Android APK. BOOX/E 
 - 套索问 AI、手写识别、习题识别和批改需要支持图片输入的视觉模型。
 - 课堂录音转写需要所选接口能够接收应用发送的音频内容；服务商的文件大小、格式和速率限制仍然适用。
 - 生成大纲/讲义会发送 PDF 或切分后的 PDF 页面，模型接口需要支持该调用方式。
+- 请求协议按服务地址判断：只有 Google 官方端点走 Gemini 原生协议并直接上传 PDF，Claude 用 document 块，DeepSeek/OpenAI/自定义渠道一律走 OpenAI 兼容的 chat/completions，PDF 会先在本地提取文本再随提示词发送。
+- 推理模型只取正文：thought 分段、reasoning_content 以及 `<think>` 标签内的内容都会被丢弃；若模型把输出预算全部用在思考上，应用会自动提高一次输出上限重试，仍无正文则报错而不会把思考过程存成讲义。
 
 API Key 保存在本机设置中，不会随 R2 元数据同步到云端；完整 ZIP 备份会包含本机设置，因此仍须把 ZIP 当作敏感文件保管。
 
@@ -97,7 +99,7 @@ API Key 保存在本机设置中，不会随 R2 元数据同步到云端；完�
 
 录音写入应用私有的持久化存储，覆盖升级和 WebView 重建不会主动删除，但卸载应用仍会清除录音。创建完整 ZIP 前应先停止正在进行的录音；若导出提示录音缺失，请检查 ZIP 中的 `recordings/missing.json`。
 
-iPhone/iPad PWA 中超过 5 分钟或 10 MB 的 AAC/M4A 长录音需要配置 Gemini 模型。应用会通过 Gemini Files API 直接处理压缩录音，避免在 iOS 页面内把 80～90 分钟音频整体解码为 PCM；纪要生成结束后会删除 Gemini 中的临时文件。
+iPhone/iPad PWA 中超过 5 分钟或 10 MB 的 AAC/M4A 长录音需要在主/备用 API 里配置 Google 官方 Gemini 端点（自定义渠道不能替代）。应用会通过 Gemini Files API 直接处理压缩录音，避免在 iOS 页面内把 80～90 分钟音频整体解码为 PCM；纪要生成结束后会删除 Gemini 中的临时文件。
 
 ### 6. 讲义与论文摘要
 
@@ -233,6 +235,8 @@ Open **Settings → API Setting**:
 5. Save the settings, test a text chat, and then test any image, audio, or PDF workflow you plan to use.
 
 Use a strong text/LaTeX model for chat, outlines, lectures, and abstracts. Lasso questions, handwriting indexing, exercise extraction, and grading require vision input. Classroom transcription requires an API that accepts the audio sent by the app. PDF outline and lecture generation require a provider compatible with the app's PDF attachment calls.
+
+The request protocol follows the endpoint, not the dropdown: only Google's own endpoint uses the native Gemini protocol and uploads the PDF directly; Claude uses document blocks; DeepSeek, OpenAI, and custom channels all use OpenAI-compatible chat/completions, where the PDF is converted to text locally before it is sent. Only the answer is kept from reasoning models — Gemini thought parts, `reasoning_content`, and `<think>` sections are discarded. If a model spends its whole output budget thinking, the app retries once with a larger limit and then reports an error instead of storing the monologue as lecture notes.
 
 API credentials stay local and are excluded from R2 metadata sync. A full ZIP contains local settings, so protect the ZIP as a sensitive file.
 

--- a/app/src/main/assets/www/ai-response.js
+++ b/app/src/main/assets/www/ai-response.js
@@ -1,0 +1,166 @@
+// AI 回复解析：只取正文，丢弃推理/思考内容。
+//
+// 背景：推理模型（Gemini thinking、DeepSeek-R1、各类聚合网关转发的模型）会把
+// “思考过程”和“正文”一起返回：
+//   - Gemini：candidates[0].content.parts 里带 thought:true 的 part 是思考摘要；
+//   - OpenAI 兼容：message.reasoning_content / message.reasoning 是思考内容；
+//   - 部分网关：把思考直接内联进正文，用 <think>…</think> 之类的标签包起来。
+// 如果不加区分地把这些拼在一起，用户拿到的“讲义”就会变成一整篇模型自言自语。
+// 本模块只负责纯解析，不发请求，便于用 node --test 回归。
+(function (root, factory) {
+    const api = factory();
+    if (typeof module === 'object' && module.exports) module.exports = api;
+    if (root) root.AIResponse = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+    'use strict';
+
+    const REASONING_TAGS = 'think|thinking|thought|thoughts|reasoning|reflection';
+    const REASONING_BLOCK_RE = new RegExp(
+        '<(' + REASONING_TAGS + ')(?:\\s[^>]*)?>([\\s\\S]*?)<\\/\\1\\s*>', 'gi');
+    const REASONING_OPEN_RE = new RegExp('<(' + REASONING_TAGS + ')(?:\\s[^>]*)?>', 'i');
+    const REASONING_CLOSE_RE = new RegExp('<\\/(' + REASONING_TAGS + ')\\s*>', 'gi');
+
+    function asText(value) {
+        return typeof value === 'string' ? value : '';
+    }
+
+    function joinReasoning(chunks) {
+        return chunks.map(asText).filter(function (chunk) {
+            return chunk.trim() !== '';
+        }).join('\n\n').trim();
+    }
+
+    // 把内联的思考标签从正文里摘出来。除了成对标签，还要处理两种残缺情况：
+    // 只有结束标签（思考先流式输出、正文接在后面）和只有开始标签（思考没写完就被截断）。
+    function splitReasoningMarkup(value) {
+        let text = asText(value);
+        const reasoning = [];
+
+        REASONING_BLOCK_RE.lastIndex = 0;
+        text = text.replace(REASONING_BLOCK_RE, function (match, tag, inner) {
+            reasoning.push(inner);
+            return '\n';
+        });
+
+        let closeStart = -1;
+        let closeEnd = -1;
+        let found;
+        REASONING_CLOSE_RE.lastIndex = 0;
+        while ((found = REASONING_CLOSE_RE.exec(text)) !== null) {
+            closeStart = found.index;
+            closeEnd = found.index + found[0].length;
+        }
+        if (closeStart >= 0) {
+            reasoning.push(text.slice(0, closeStart));
+            text = text.slice(closeEnd);
+        }
+
+        const open = text.match(REASONING_OPEN_RE);
+        if (open) {
+            reasoning.push(text.slice(open.index + open[0].length));
+            text = text.slice(0, open.index);
+        }
+
+        return { text: text.trim(), reasoning: joinReasoning(reasoning) };
+    }
+
+    // Gemini 的思考 part 标记为 thought:true。个别网关会发字符串 'true'/'false'。
+    function isThoughtPart(part) {
+        const flag = part.thought;
+        if (flag === undefined || flag === null || flag === false) return false;
+        if (typeof flag === 'string') {
+            const normalized = flag.trim().toLowerCase();
+            return normalized !== '' && normalized !== 'false';
+        }
+        return !!flag;
+    }
+
+    // 返回 { text, reasoning, finishReason, blockReason, hasCandidate }
+    // text 只包含正文；思考内容单独放在 reasoning 里，仅用于诊断，不给用户当结果。
+    function extractGeminiAnswer(data) {
+        const payload = data && typeof data === 'object' ? data : {};
+        const candidates = Array.isArray(payload.candidates) ? payload.candidates : [];
+        const candidate = candidates.length > 0 && candidates[0] && typeof candidates[0] === 'object'
+            ? candidates[0] : null;
+        const parts = candidate && candidate.content && Array.isArray(candidate.content.parts)
+            ? candidate.content.parts : [];
+
+        const answerChunks = [];
+        const thoughtChunks = [];
+        for (let i = 0; i < parts.length; i++) {
+            const part = parts[i];
+            if (!part || typeof part !== 'object') continue;
+            const text = asText(part.text);
+            if (text === '') continue;
+            if (isThoughtPart(part)) thoughtChunks.push(text);
+            else answerChunks.push(text);
+        }
+
+        const split = splitReasoningMarkup(answerChunks.join(''));
+        const feedback = payload.promptFeedback && typeof payload.promptFeedback === 'object'
+            ? payload.promptFeedback : {};
+        return {
+            text: split.text,
+            reasoning: joinReasoning([thoughtChunks.join('\n\n'), split.reasoning]),
+            finishReason: candidate ? asText(candidate.finishReason) : '',
+            blockReason: asText(feedback.blockReason),
+            hasCandidate: !!candidate
+        };
+    }
+
+    // content 可能是字符串，也可能是内容块数组；thinking / reasoning 块归到思考里。
+    function flattenOpenAiContent(content) {
+        if (typeof content === 'string') return { text: content, reasoning: '' };
+        if (!Array.isArray(content)) return { text: '', reasoning: '' };
+        const chunks = [];
+        const reasoning = [];
+        for (let i = 0; i < content.length; i++) {
+            const item = content[i];
+            if (typeof item === 'string') { chunks.push(item); continue; }
+            if (!item || typeof item !== 'object') continue;
+            const type = asText(item.type);
+            if (type === 'thinking' || type === 'reasoning') {
+                reasoning.push(asText(item.thinking) || asText(item.reasoning) || asText(item.text));
+                continue;
+            }
+            if (type === '' || type === 'text' || type === 'output_text') chunks.push(asText(item.text));
+        }
+        return { text: chunks.join(''), reasoning: joinReasoning(reasoning) };
+    }
+
+    // 返回 { text, reasoning, finishReason }
+    function extractOpenAiAnswer(data) {
+        const payload = data && typeof data === 'object' ? data : {};
+        const choices = Array.isArray(payload.choices) ? payload.choices : [];
+        const choice = choices.length > 0 && choices[0] && typeof choices[0] === 'object'
+            ? choices[0] : null;
+        const message = choice && choice.message && typeof choice.message === 'object'
+            ? choice.message : null;
+
+        const flattened = flattenOpenAiContent(message ? message.content : '');
+        const split = splitReasoningMarkup(flattened.text);
+        const declaredReasoning = message
+            ? [asText(message.reasoning_content), asText(message.reasoning)]
+            : [];
+        return {
+            text: split.text,
+            reasoning: joinReasoning(declaredReasoning.concat([flattened.reasoning, split.reasoning])),
+            finishReason: choice ? asText(choice.finish_reason) : ''
+        };
+    }
+
+    // 正文为空但确实产出了思考（或输出预算被思考吃光），说明这次请求“只想没说”，
+    // 值得抬高输出上限重试一次，而不是把思考当结果保存下来。
+    function isReasoningOnly(answer) {
+        if (!answer || answer.text) return false;
+        return !!answer.reasoning || answer.finishReason === 'MAX_TOKENS' ||
+            answer.finishReason === 'length';
+    }
+
+    return {
+        splitReasoningMarkup,
+        extractGeminiAnswer,
+        extractOpenAiAnswer,
+        isReasoningOnly
+    };
+});

--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -6343,6 +6343,7 @@
     <script src="recording-storage.js"></script>
     <script src="classroom-storage.js"></script>
     <script src="recording-ai.js"></script>
+    <script src="ai-response.js"></script>
     <script>
         // ==================== Data Store ====================
         let appData = {
@@ -6461,7 +6462,7 @@
                 toast_outline_loaded:'已加载 {0} 节大纲',toast_gen_outline_first:'请先点击"生成大纲"',
                 toast_ai_generating_outline:'AI 正在生成大纲...',toast_ai_generating_outline_chunk:'AI 正在生成大纲（第 {0}/{1} 段，第 {2}-{3} 页）...',toast_ai_return_parse_fail:'AI 返回格式解析失败',
                 toast_ai_no_valid_outline:'AI 未返回有效大纲',toast_gen_failed:'生成失败: ',
-                toast_content_gen_failed:'内容生成失败',toast_generating_abstract:'正在生成摘要...',
+                toast_generating_abstract:'正在生成摘要...',
                 toast_abstract_generated:'摘要已生成，正在同步到云端...',toast_asking_ai:'正在询问AI...',
                 toast_note_added:'已添加笔记',toast_ai_request_failed:'AI请求失败: ',
                 toast_select_wrong:'请先选择错题',toast_local_file_lost:'本地文件丢失，正在从云端恢复…',
@@ -6487,7 +6488,6 @@
                 prompt_photo_or_file:'照片/截图',prompt_file:'文件',
                 prompt_seminar_extra:'\n\n注意：这是一个讲座的内容。请额外补充介绍该领域的相关基础知识，帮助读者理解讲座涉及的专业概念和背景。在笔记开头增加一个"背景知识"部分。',
                 edit_hint:'点击编辑',your_name:'你的名字',me:'我',
-                abstract_gen_failed:'摘要生成失败',
                 notification_abstract_done:'摘要生成完成',abstract_added:' 的摘要已添加',
                 exercise_task:'任务',exercise_click_redo:'点击重做',exercise_restore:'恢复',
                 wrong_archive:'归档此错题',wrong_delete:'删除此错题',wrong_restore:'恢复错题',
@@ -6648,7 +6648,7 @@
                 toast_outline_loaded:'Loaded {0} section outline',toast_gen_outline_first:'Please click "Generate Outline" first',
                 toast_ai_generating_outline:'AI is generating outline...',toast_ai_generating_outline_chunk:'AI is generating outline (part {0}/{1}, pages {2}-{3})...',toast_ai_return_parse_fail:'AI response parse failed',
                 toast_ai_no_valid_outline:'AI returned no valid outline',toast_gen_failed:'Generation failed: ',
-                toast_content_gen_failed:'Content generation failed',toast_generating_abstract:'Generating abstract...',
+                toast_generating_abstract:'Generating abstract...',
                 toast_abstract_generated:'Abstract generated, syncing to cloud...',toast_asking_ai:'Asking AI...',
                 toast_note_added:'Note added',toast_ai_request_failed:'AI request failed: ',
                 toast_select_wrong:'Please select wrong answers first',toast_local_file_lost:'Local file lost, recovering from cloud...',
@@ -6674,7 +6674,6 @@
                 prompt_photo_or_file:'photo/screenshot',prompt_file:'file',
                 prompt_seminar_extra:'\n\nNote: This is seminar content. Add a "Background Knowledge" section at the beginning.',
                 edit_hint:'Click to edit',your_name:'Your name',me:'Me',
-                abstract_gen_failed:'Abstract generation failed',
                 notification_abstract_done:'Abstract generated',abstract_added:' abstract added',
                 exercise_task:'Tasks',exercise_click_redo:'Click to redo',exercise_restore:'Restore',
                 wrong_archive:'Archive this question',wrong_delete:'Delete this question',wrong_restore:'Restore',
@@ -6835,7 +6834,7 @@
                 toast_outline_loaded:'{0} sections chargées',toast_gen_outline_first:'Cliquez d\'abord sur "Générer un plan"',
                 toast_ai_generating_outline:'L\'IA génère le plan...',toast_ai_generating_outline_chunk:'L\'IA génère le plan (partie {0}/{1}, pages {2}-{3})...',toast_ai_return_parse_fail:'Échec analyse réponse IA',
                 toast_ai_no_valid_outline:'Aucun plan valide',toast_gen_failed:'Échec : ',
-                toast_content_gen_failed:'Échec génération contenu',toast_generating_abstract:'Génération résumé...',
+                toast_generating_abstract:'Génération résumé...',
                 toast_abstract_generated:'Résumé généré, synchronisation...',toast_asking_ai:'Demande à l\'IA...',
                 toast_note_added:'Note ajoutée',toast_ai_request_failed:'Échec requête IA : ',
                 toast_select_wrong:'Sélectionnez d\'abord des erreurs',toast_local_file_lost:'Fichier local perdu, récupération...',
@@ -6861,7 +6860,6 @@
                 prompt_photo_or_file:'photo/capture',prompt_file:'fichier',
                 prompt_seminar_extra:'\n\nContenu de séminaire. Ajoute une section "Connaissances de base".',
                 edit_hint:'Cliquer pour modifier',your_name:'Votre nom',me:'Moi',
-                abstract_gen_failed:'Échec génération résumé',
                 notification_abstract_done:'Résumé généré',abstract_added:' résumé ajouté',
                 exercise_task:'Tâches',exercise_click_redo:'Refaire',exercise_restore:'Restaurer',
                 wrong_archive:'Archiver cette erreur',wrong_delete:'Supprimer cette erreur',wrong_restore:'Restaurer',
@@ -7093,6 +7091,21 @@
             prompt_review_quiz_system:'Tu es un coach expérimenté en apprentissage des mathématiques. Conçois un quiz de répétition espacée à partir des notes manuscrites de l’élève. Les notes ne sont qu’un résumé : mobilise le corpus associé et étends les questions aux théorèmes importants, réciproques, corollaires, cas limites, notions proches et variantes courantes. Les questions doivent demander de la réflexion, pas une simple récitation. Commence directement par la première question, sans salutation, réponse ni indice. Utilise Markdown et LaTeX.', prompt_review_quiz_extra:'L’élève a retardé la révision précédente et a besoin d’une consolidation. Crée 3–4 questions à partir de cette page : au moins une extension du même thème et au moins un calcul ou une preuve en plusieurs étapes. Consolide les bases sans question triviale. Renvoie uniquement les questions, sans réponses.', prompt_review_quiz_tonight:'Voici les notes de mathématiques prises aujourd’hui. Crée un quiz « Ce soir » de 4–5 questions : 1–2 questions de compréhension conceptuelle, 1–2 applications directes de calcul ou de preuve, et une extension liée à un théorème, une réciproque, un cas particulier ou une connexion. Renvoie uniquement les questions, sans réponses.', prompt_review_quiz_advanced:'L’élève a étudié ces notes il y a {0} jours. Il s’agit de la révision espacée {1} ({2}). Crée un quiz avancé de 4–5 questions : une distinction conceptuelle, 1–2 variantes, une application intégrée et un défi. Va plus loin que la révision précédente sans répéter les types de questions. Renvoie uniquement les questions, sans réponses.', prompt_previous_quiz:'\n\nQuiz précédent (évite toute répétition et va plus loin) :\n{0}', prompt_previous_quiz_result:'\n\nUtilise la notation IA précédente pour concevoir le prochain quiz. Cible les lacunes et erreurs avec des variantes progressives, réduis la répétition mécanique des acquis et ne révèle aucune réponse.\nNote globale : {0}/10', prompt_ai_feedback:'\nCommentaire IA :\n{0}', prompt_recognized_note:'\n\nTexte reconnu des notes :\n{0}',
             write_answer_first:'Écrivez d’abord votre réponse sur la zone de dessin', grading:'Notation…', grading_in_progress:'Notation en cours…', ai_grading_empty:'L’IA n’a renvoyé aucune notation', per_question_review_heading:'**Vérification question par question :**\n', solutions_missing:'L’IA n’a pas renvoyé les bonnes réponses et les démonstrations complètes', solutions_section:'**✦ Bonnes réponses et démonstrations complètes :**\n{0}', grading_failed:'Échec de la notation : {0}', grading_complete_practice:'Notation terminée ; génération d’un exercice de consolidation…', grading_complete_next:'Notation terminée ; génération du quiz avancé pour {0}…', all_reviews_complete:'Toutes les révisions sont terminées !',
             prompt_review_grade_system:'Tu es un correcteur et solveur de mathématiques strict et professionnel. Résous d’abord chaque question du quiz, puis vérifie la copie manuscrite dans l’ordre. Note globale sur 10 : exactitude et complétude 6, rigueur 2, clarté 2. Couvre chaque question ; même une réponse absente, incomplète ou illisible exige la bonne réponse et une solution complète. per_question évalue uniquement et précisément le travail de l’élève. solutions donne, pour chaque question, une réponse ou conclusion explicite et une démonstration complète sans omettre les étapes clés. N’invente aucune condition et n’ajoute aucun encouragement générique. Renvoie uniquement un JSON valide pour JSON.parse : {"score":nombre de 0 à 10,"per_question":[{"q":"numéro ou résumé","correct":booléen,"comment":"vérification précise"}],"solutions":"bonne réponse et démonstration complète pour chaque question"}. Utilise LaTeX et un échappement JSON valide.', prompt_review_grade_user:'Questions du quiz :\n\n{0}\n\nVérifie la copie manuscrite de l’image dans l’ordre. Pour chaque question, donne une bonne réponse explicite et une démonstration mathématique complète ; ne te contente pas de signaler les erreurs.'
+        });
+        Object.assign(I18N.zh, {
+            ai_reasoning_only:'模型只返回了思考过程，没有正文；请提高输出上限或更换模型',
+            ai_blocked:'请求被模型安全策略拦截（{0}）',
+            ai_empty_reply:'模型返回了空内容'
+        });
+        Object.assign(I18N.en, {
+            ai_reasoning_only:'The model returned only its reasoning, without an answer. Raise the output limit or switch models.',
+            ai_blocked:'The request was blocked by the model safety policy ({0})',
+            ai_empty_reply:'The model returned an empty response'
+        });
+        Object.assign(I18N.fr, {
+            ai_reasoning_only:'Le modèle n’a renvoyé que son raisonnement, sans réponse. Augmentez la limite de sortie ou changez de modèle.',
+            ai_blocked:'La requête a été bloquée par la politique de sécurité du modèle ({0})',
+            ai_empty_reply:'Le modèle a renvoyé une réponse vide'
         });
         let currentLang = 'en';
         function i18n(key, ...args) {
@@ -12395,7 +12408,9 @@
             }
         }
         
-        // 判断一个 URL 是否为 Google Gemini 端点（用 host 判断，不依赖下拉框）
+        // 判断一个 URL 是否为 Google Gemini 端点（用 host 判断，不依赖下拉框）。
+        // 只有真正的 Gemini 端点才走 Gemini 原生协议：自定义渠道即使填了 Gemini 风格的
+        // 模型名，也按 OpenAI 兼容协议请求，PDF 走文本提取兜底而不是 Gemini 附件。
         function isGeminiUrl(url) {
             return typeof url === 'string' && url.indexOf('generativelanguage.googleapis.com') !== -1;
         }
@@ -12413,8 +12428,9 @@
                 model: settings.backupModel,
                 provider: settings.backupProvider || ''
             }];
+            // 长录音要用 Gemini Files API，只有真正的 Gemini 端点能接；自定义渠道不算。
             return candidates.find(config => config.url && config.key && config.model &&
-                (isGeminiUrl(config.url) || config.provider === 'custom')) || null;
+                isGeminiUrl(config.url)) || null;
         }
 
         async function fetchModels(type) {
@@ -18645,13 +18661,13 @@
         }
         
         async function doAIRequest(config, systemPrompt, messages, options = {}) {
-            // Gemini 原生渠道，或用户指定的"自定义"渠道都走 Gemini 协议（按用户要求）
-            const useGemini = isGeminiUrl(config.url) || config.provider === 'custom';
-            if (useGemini) {
+            // 只有 URL 指向 Google 官方端点时才走 Gemini 原生协议。
+            // 自定义渠道按 OpenAI 兼容协议请求，PDF 也不走 Gemini 的附件/Files API。
+            if (isGeminiUrl(config.url)) {
                 return await doGeminiRequest(config, systemPrompt, messages, options);
             }
 
-            // OpenAI / DeepSeek / Claude / 其他 OpenAI 兼容：用 chat/completions 协议
+            // OpenAI / DeepSeek / Claude / 自定义等 OpenAI 兼容：用 chat/completions 协议
             // 这些渠道中只有 Claude 支持原生 PDF，其他需要靠文本预提取兜底
             let finalMessages = messages;
             if (options.pdfAttachment) {
@@ -18660,7 +18676,7 @@
                     finalMessages = await embedPdfForClaude(messages, options.pdfAttachment);
                     return await doClaudeRequest(config, systemPrompt, finalMessages, options);
                 } else {
-                    // OpenAI / DeepSeek / 其他：不支持 PDF，回退文本提取
+                    // OpenAI / DeepSeek / 自定义 / 其他：不支持 PDF，回退文本提取
                     const extractedText = await extractPdfTextAsFallback(options.pdfAttachment);
                     finalMessages = injectPdfTextIntoLastUser(messages, extractedText);
                 }
@@ -18691,37 +18707,63 @@
                 };
             }));
 
-            const requestBody = {
-                model: config.model,
-                messages: [
-                    { role: 'system', content: systemPrompt },
-                    ...finalMessages
-                ],
-                max_tokens: options.maxTokens || 8192,
-                temperature: options.temperature || 0.7,
-                stream: options.stream || false
+            const baseMaxTokens = options.maxTokens || 8192;
+            const sendChatCompletion = async (maxTokens) => {
+                const requestBody = {
+                    model: config.model,
+                    messages: [
+                        { role: 'system', content: systemPrompt },
+                        ...finalMessages
+                    ],
+                    max_tokens: maxTokens,
+                    temperature: options.temperature || 0.7,
+                    stream: options.stream || false
+                };
+
+                const response = await fetch(config.url, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Authorization': 'Bearer ' + config.key
+                    },
+                    body: JSON.stringify(requestBody)
+                });
+
+                if (!response.ok) {
+                    const errText = await response.text().catch(() => '');
+                    throw new Error(i18n('api_error', response.status, errText));
+                }
+                return response;
             };
-            
-            const response = await fetch(config.url, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': 'Bearer ' + config.key
-                },
-                body: JSON.stringify(requestBody)
-            });
-            
-            if (!response.ok) {
-                const errText = await response.text().catch(() => '');
-                throw new Error(i18n('api_error', response.status, errText));
-            }
-            
+
+            const response = await sendChatCompletion(baseMaxTokens);
             if (options.stream) {
                 return response;
             }
-            
-            const data = await response.json();
-            return data.choices?.[0]?.message?.content || null;
+
+            // 推理模型会把思考放在 reasoning_content 里，或用 <think> 内联进正文：
+            // 只取正文，思考一律丢掉，不能当成结果保存。
+            let answer = AIResponse.extractOpenAiAnswer(await response.json());
+            if (AIResponse.isReasoningOnly(answer)) {
+                // 思考把 max_tokens 吃光，正文是空的：抬高输出上限重试一次。
+                console.warn('渠道只返回了思考内容，提高 max_tokens 重试:', answer.finishReason);
+                const retryMaxTokens = reasoningRetryMaxTokens(baseMaxTokens);
+                if (retryMaxTokens > baseMaxTokens) {
+                    try {
+                        answer = AIResponse.extractOpenAiAnswer(
+                            await (await sendChatCompletion(retryMaxTokens)).json());
+                    } catch (e) {
+                        console.warn('提高 max_tokens 重试失败:', e);
+                    }
+                }
+                if (!answer.text) throw new Error(i18n('ai_reasoning_only'));
+            }
+            return answer.text || null;
+        }
+
+        // 正文被思考挤掉时的重试预算：翻倍，但至少 16K、最多 32K。
+        function reasoningRetryMaxTokens(baseMaxTokens) {
+            return Math.min(Math.max(baseMaxTokens * 2, 16384), 32768);
         }
 
         // 把 PDF 文本提取，作为"附件文本"拼到 messages 最后一条 user 内容前
@@ -18784,7 +18826,9 @@
             }
             const data = await response.json();
             if (Array.isArray(data.content)) {
-                return data.content.filter(x => x.type === 'text').map(x => x.text).join('');
+                // thinking 块不是正文，只取 text 块，再清掉可能内联的思考标签。
+                const text = data.content.filter(x => x.type === 'text').map(x => x.text || '').join('');
+                return AIResponse.splitReasoningMarkup(text).text || null;
             }
             return null;
         }
@@ -18893,36 +18937,61 @@
                 }
             }
 
-            const body = {
-                contents,
-                generationConfig: {
-                    temperature: options.temperature != null ? options.temperature : 0.7,
-                    maxOutputTokens: options.maxTokens || 8192
-                }
-            };
-            if (systemPrompt) {
-                body.systemInstruction = { parts: [{ text: String(systemPrompt) }] };
-            }
-
             const url = base + '/models/' + encodeURIComponent(modelName) + ':generateContent?key=' + encodeURIComponent(config.key);
-            const response = await fetch(url, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(body)
-            });
-            if (!response.ok) {
-                const errText = await response.text().catch(() => '');
-                throw new Error(i18n('api_error', response.status, errText));
+            const baseMaxTokens = options.maxTokens || 8192;
+            const sendGenerateContent = async (generationConfig) => {
+                const body = {
+                    contents,
+                    generationConfig: Object.assign({
+                        temperature: options.temperature != null ? options.temperature : 0.7
+                    }, generationConfig)
+                };
+                if (systemPrompt) {
+                    body.systemInstruction = { parts: [{ text: String(systemPrompt) }] };
+                }
+                const response = await fetch(url, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(body)
+                });
+                if (!response.ok) {
+                    const errText = await response.text().catch(() => '');
+                    throw new Error(i18n('api_error', response.status, errText));
+                }
+                // 思考模型会额外返回 thought:true 的 part，那是思考摘要不是正文。
+                return AIResponse.extractGeminiAnswer(await response.json());
+            };
+
+            let answer = await sendGenerateContent({ maxOutputTokens: baseMaxTokens });
+            if (answer.finishReason && answer.finishReason !== 'STOP') {
+                console.warn('Gemini finishReason:', answer.finishReason, '— 输出可能被截断');
             }
-            const data = await response.json();
-            const candidate = data.candidates?.[0];
-            const finishReason = candidate?.finishReason;
-            if (finishReason && finishReason !== 'STOP') {
-                console.warn('Gemini finishReason:', finishReason, '— 输出可能被截断');
+            if (AIResponse.isReasoningOnly(answer)) {
+                // 思考计入 maxOutputTokens，正文一个字都没剩：抬高上限、压缩思考预算重试一次。
+                console.warn('Gemini 只返回了思考内容，提高 maxOutputTokens 重试:', answer.finishReason);
+                const retryMaxTokens = reasoningRetryMaxTokens(baseMaxTokens);
+                const retryConfig = { maxOutputTokens: retryMaxTokens };
+                try {
+                    answer = await sendGenerateContent(Object.assign({}, retryConfig, {
+                        thinkingConfig: {
+                            includeThoughts: false,
+                            thinkingBudget: Math.min(8192, Math.floor(retryMaxTokens / 2))
+                        }
+                    }));
+                } catch (e) {
+                    // 旧模型或代理端点可能不认 thinkingConfig，退回只抬高上限。
+                    console.warn('thinkingConfig 重试失败，仅提高 maxOutputTokens 重试:', e);
+                    try {
+                        answer = await sendGenerateContent(retryConfig);
+                    } catch (e2) {
+                        console.warn('提高 maxOutputTokens 重试失败:', e2);
+                    }
+                }
             }
-            const parts = candidate?.content?.parts;
-            if (Array.isArray(parts) && parts.length > 0) {
-                return parts.map(p => p.text || '').join('');
+            if (answer.text) return answer.text;
+            if (answer.blockReason) throw new Error(i18n('ai_blocked', answer.blockReason));
+            if (answer.reasoning || answer.finishReason === 'MAX_TOKENS') {
+                throw new Error(i18n('ai_reasoning_only'));
             }
             return null;
         }
@@ -19583,7 +19652,9 @@ ${i18n('prompt_lecture_gen')}`;
                     pdfAttachment
                 });
 
-                const contentText = result || i18n('toast_content_gen_failed');
+                // 空回复不能当讲义存下来（否则章节会被标记为已生成，用户只能手动重生成）
+                const contentText = typeof result === 'string' ? result.trim() : '';
+                if (!contentText) throw new Error(i18n('ai_empty_reply'));
                 chapter.status = 'ready';
                 chapter.generatedAt = new Date().toISOString();
                 chapter.updatedAt = chapter.generatedAt;
@@ -21649,7 +21720,9 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 paper = appData.papers.find(p => p.id === paperId);
                 if (!paper) return;
 
-                const abstractText = result || i18n('abstract_gen_failed');
+                // 同讲义：空回复不能当摘要存下来，否则会被标记为“已生成”
+                const abstractText = typeof result === 'string' ? result.trim() : '';
+                if (!abstractText) throw new Error(i18n('ai_empty_reply'));
                 await saveAbstractContent(paperId, abstractText);
                 paper._abstractCache = abstractText;
                 paper.hasAiAbstract = true;

--- a/docs/ai-response.js
+++ b/docs/ai-response.js
@@ -1,0 +1,166 @@
+// AI 回复解析：只取正文，丢弃推理/思考内容。
+//
+// 背景：推理模型（Gemini thinking、DeepSeek-R1、各类聚合网关转发的模型）会把
+// “思考过程”和“正文”一起返回：
+//   - Gemini：candidates[0].content.parts 里带 thought:true 的 part 是思考摘要；
+//   - OpenAI 兼容：message.reasoning_content / message.reasoning 是思考内容；
+//   - 部分网关：把思考直接内联进正文，用 <think>…</think> 之类的标签包起来。
+// 如果不加区分地把这些拼在一起，用户拿到的“讲义”就会变成一整篇模型自言自语。
+// 本模块只负责纯解析，不发请求，便于用 node --test 回归。
+(function (root, factory) {
+    const api = factory();
+    if (typeof module === 'object' && module.exports) module.exports = api;
+    if (root) root.AIResponse = api;
+})(typeof globalThis !== 'undefined' ? globalThis : this, function () {
+    'use strict';
+
+    const REASONING_TAGS = 'think|thinking|thought|thoughts|reasoning|reflection';
+    const REASONING_BLOCK_RE = new RegExp(
+        '<(' + REASONING_TAGS + ')(?:\\s[^>]*)?>([\\s\\S]*?)<\\/\\1\\s*>', 'gi');
+    const REASONING_OPEN_RE = new RegExp('<(' + REASONING_TAGS + ')(?:\\s[^>]*)?>', 'i');
+    const REASONING_CLOSE_RE = new RegExp('<\\/(' + REASONING_TAGS + ')\\s*>', 'gi');
+
+    function asText(value) {
+        return typeof value === 'string' ? value : '';
+    }
+
+    function joinReasoning(chunks) {
+        return chunks.map(asText).filter(function (chunk) {
+            return chunk.trim() !== '';
+        }).join('\n\n').trim();
+    }
+
+    // 把内联的思考标签从正文里摘出来。除了成对标签，还要处理两种残缺情况：
+    // 只有结束标签（思考先流式输出、正文接在后面）和只有开始标签（思考没写完就被截断）。
+    function splitReasoningMarkup(value) {
+        let text = asText(value);
+        const reasoning = [];
+
+        REASONING_BLOCK_RE.lastIndex = 0;
+        text = text.replace(REASONING_BLOCK_RE, function (match, tag, inner) {
+            reasoning.push(inner);
+            return '\n';
+        });
+
+        let closeStart = -1;
+        let closeEnd = -1;
+        let found;
+        REASONING_CLOSE_RE.lastIndex = 0;
+        while ((found = REASONING_CLOSE_RE.exec(text)) !== null) {
+            closeStart = found.index;
+            closeEnd = found.index + found[0].length;
+        }
+        if (closeStart >= 0) {
+            reasoning.push(text.slice(0, closeStart));
+            text = text.slice(closeEnd);
+        }
+
+        const open = text.match(REASONING_OPEN_RE);
+        if (open) {
+            reasoning.push(text.slice(open.index + open[0].length));
+            text = text.slice(0, open.index);
+        }
+
+        return { text: text.trim(), reasoning: joinReasoning(reasoning) };
+    }
+
+    // Gemini 的思考 part 标记为 thought:true。个别网关会发字符串 'true'/'false'。
+    function isThoughtPart(part) {
+        const flag = part.thought;
+        if (flag === undefined || flag === null || flag === false) return false;
+        if (typeof flag === 'string') {
+            const normalized = flag.trim().toLowerCase();
+            return normalized !== '' && normalized !== 'false';
+        }
+        return !!flag;
+    }
+
+    // 返回 { text, reasoning, finishReason, blockReason, hasCandidate }
+    // text 只包含正文；思考内容单独放在 reasoning 里，仅用于诊断，不给用户当结果。
+    function extractGeminiAnswer(data) {
+        const payload = data && typeof data === 'object' ? data : {};
+        const candidates = Array.isArray(payload.candidates) ? payload.candidates : [];
+        const candidate = candidates.length > 0 && candidates[0] && typeof candidates[0] === 'object'
+            ? candidates[0] : null;
+        const parts = candidate && candidate.content && Array.isArray(candidate.content.parts)
+            ? candidate.content.parts : [];
+
+        const answerChunks = [];
+        const thoughtChunks = [];
+        for (let i = 0; i < parts.length; i++) {
+            const part = parts[i];
+            if (!part || typeof part !== 'object') continue;
+            const text = asText(part.text);
+            if (text === '') continue;
+            if (isThoughtPart(part)) thoughtChunks.push(text);
+            else answerChunks.push(text);
+        }
+
+        const split = splitReasoningMarkup(answerChunks.join(''));
+        const feedback = payload.promptFeedback && typeof payload.promptFeedback === 'object'
+            ? payload.promptFeedback : {};
+        return {
+            text: split.text,
+            reasoning: joinReasoning([thoughtChunks.join('\n\n'), split.reasoning]),
+            finishReason: candidate ? asText(candidate.finishReason) : '',
+            blockReason: asText(feedback.blockReason),
+            hasCandidate: !!candidate
+        };
+    }
+
+    // content 可能是字符串，也可能是内容块数组；thinking / reasoning 块归到思考里。
+    function flattenOpenAiContent(content) {
+        if (typeof content === 'string') return { text: content, reasoning: '' };
+        if (!Array.isArray(content)) return { text: '', reasoning: '' };
+        const chunks = [];
+        const reasoning = [];
+        for (let i = 0; i < content.length; i++) {
+            const item = content[i];
+            if (typeof item === 'string') { chunks.push(item); continue; }
+            if (!item || typeof item !== 'object') continue;
+            const type = asText(item.type);
+            if (type === 'thinking' || type === 'reasoning') {
+                reasoning.push(asText(item.thinking) || asText(item.reasoning) || asText(item.text));
+                continue;
+            }
+            if (type === '' || type === 'text' || type === 'output_text') chunks.push(asText(item.text));
+        }
+        return { text: chunks.join(''), reasoning: joinReasoning(reasoning) };
+    }
+
+    // 返回 { text, reasoning, finishReason }
+    function extractOpenAiAnswer(data) {
+        const payload = data && typeof data === 'object' ? data : {};
+        const choices = Array.isArray(payload.choices) ? payload.choices : [];
+        const choice = choices.length > 0 && choices[0] && typeof choices[0] === 'object'
+            ? choices[0] : null;
+        const message = choice && choice.message && typeof choice.message === 'object'
+            ? choice.message : null;
+
+        const flattened = flattenOpenAiContent(message ? message.content : '');
+        const split = splitReasoningMarkup(flattened.text);
+        const declaredReasoning = message
+            ? [asText(message.reasoning_content), asText(message.reasoning)]
+            : [];
+        return {
+            text: split.text,
+            reasoning: joinReasoning(declaredReasoning.concat([flattened.reasoning, split.reasoning])),
+            finishReason: choice ? asText(choice.finish_reason) : ''
+        };
+    }
+
+    // 正文为空但确实产出了思考（或输出预算被思考吃光），说明这次请求“只想没说”，
+    // 值得抬高输出上限重试一次，而不是把思考当结果保存下来。
+    function isReasoningOnly(answer) {
+        if (!answer || answer.text) return false;
+        return !!answer.reasoning || answer.finishReason === 'MAX_TOKENS' ||
+            answer.finishReason === 'length';
+    }
+
+    return {
+        splitReasoningMarkup,
+        extractGeminiAnswer,
+        extractOpenAiAnswer,
+        isReasoningOnly
+    };
+});

--- a/docs/index.html
+++ b/docs/index.html
@@ -6343,6 +6343,7 @@
     <script src="recording-storage.js"></script>
     <script src="classroom-storage.js"></script>
     <script src="recording-ai.js"></script>
+    <script src="ai-response.js"></script>
     <script>
         // ==================== Data Store ====================
         let appData = {
@@ -6461,7 +6462,7 @@
                 toast_outline_loaded:'已加载 {0} 节大纲',toast_gen_outline_first:'请先点击"生成大纲"',
                 toast_ai_generating_outline:'AI 正在生成大纲...',toast_ai_generating_outline_chunk:'AI 正在生成大纲（第 {0}/{1} 段，第 {2}-{3} 页）...',toast_ai_return_parse_fail:'AI 返回格式解析失败',
                 toast_ai_no_valid_outline:'AI 未返回有效大纲',toast_gen_failed:'生成失败: ',
-                toast_content_gen_failed:'内容生成失败',toast_generating_abstract:'正在生成摘要...',
+                toast_generating_abstract:'正在生成摘要...',
                 toast_abstract_generated:'摘要已生成，正在同步到云端...',toast_asking_ai:'正在询问AI...',
                 toast_note_added:'已添加笔记',toast_ai_request_failed:'AI请求失败: ',
                 toast_select_wrong:'请先选择错题',toast_local_file_lost:'本地文件丢失，正在从云端恢复…',
@@ -6487,7 +6488,6 @@
                 prompt_photo_or_file:'照片/截图',prompt_file:'文件',
                 prompt_seminar_extra:'\n\n注意：这是一个讲座的内容。请额外补充介绍该领域的相关基础知识，帮助读者理解讲座涉及的专业概念和背景。在笔记开头增加一个"背景知识"部分。',
                 edit_hint:'点击编辑',your_name:'你的名字',me:'我',
-                abstract_gen_failed:'摘要生成失败',
                 notification_abstract_done:'摘要生成完成',abstract_added:' 的摘要已添加',
                 exercise_task:'任务',exercise_click_redo:'点击重做',exercise_restore:'恢复',
                 wrong_archive:'归档此错题',wrong_delete:'删除此错题',wrong_restore:'恢复错题',
@@ -6648,7 +6648,7 @@
                 toast_outline_loaded:'Loaded {0} section outline',toast_gen_outline_first:'Please click "Generate Outline" first',
                 toast_ai_generating_outline:'AI is generating outline...',toast_ai_generating_outline_chunk:'AI is generating outline (part {0}/{1}, pages {2}-{3})...',toast_ai_return_parse_fail:'AI response parse failed',
                 toast_ai_no_valid_outline:'AI returned no valid outline',toast_gen_failed:'Generation failed: ',
-                toast_content_gen_failed:'Content generation failed',toast_generating_abstract:'Generating abstract...',
+                toast_generating_abstract:'Generating abstract...',
                 toast_abstract_generated:'Abstract generated, syncing to cloud...',toast_asking_ai:'Asking AI...',
                 toast_note_added:'Note added',toast_ai_request_failed:'AI request failed: ',
                 toast_select_wrong:'Please select wrong answers first',toast_local_file_lost:'Local file lost, recovering from cloud...',
@@ -6674,7 +6674,6 @@
                 prompt_photo_or_file:'photo/screenshot',prompt_file:'file',
                 prompt_seminar_extra:'\n\nNote: This is seminar content. Add a "Background Knowledge" section at the beginning.',
                 edit_hint:'Click to edit',your_name:'Your name',me:'Me',
-                abstract_gen_failed:'Abstract generation failed',
                 notification_abstract_done:'Abstract generated',abstract_added:' abstract added',
                 exercise_task:'Tasks',exercise_click_redo:'Click to redo',exercise_restore:'Restore',
                 wrong_archive:'Archive this question',wrong_delete:'Delete this question',wrong_restore:'Restore',
@@ -6835,7 +6834,7 @@
                 toast_outline_loaded:'{0} sections chargées',toast_gen_outline_first:'Cliquez d\'abord sur "Générer un plan"',
                 toast_ai_generating_outline:'L\'IA génère le plan...',toast_ai_generating_outline_chunk:'L\'IA génère le plan (partie {0}/{1}, pages {2}-{3})...',toast_ai_return_parse_fail:'Échec analyse réponse IA',
                 toast_ai_no_valid_outline:'Aucun plan valide',toast_gen_failed:'Échec : ',
-                toast_content_gen_failed:'Échec génération contenu',toast_generating_abstract:'Génération résumé...',
+                toast_generating_abstract:'Génération résumé...',
                 toast_abstract_generated:'Résumé généré, synchronisation...',toast_asking_ai:'Demande à l\'IA...',
                 toast_note_added:'Note ajoutée',toast_ai_request_failed:'Échec requête IA : ',
                 toast_select_wrong:'Sélectionnez d\'abord des erreurs',toast_local_file_lost:'Fichier local perdu, récupération...',
@@ -6861,7 +6860,6 @@
                 prompt_photo_or_file:'photo/capture',prompt_file:'fichier',
                 prompt_seminar_extra:'\n\nContenu de séminaire. Ajoute une section "Connaissances de base".',
                 edit_hint:'Cliquer pour modifier',your_name:'Votre nom',me:'Moi',
-                abstract_gen_failed:'Échec génération résumé',
                 notification_abstract_done:'Résumé généré',abstract_added:' résumé ajouté',
                 exercise_task:'Tâches',exercise_click_redo:'Refaire',exercise_restore:'Restaurer',
                 wrong_archive:'Archiver cette erreur',wrong_delete:'Supprimer cette erreur',wrong_restore:'Restaurer',
@@ -7093,6 +7091,21 @@
             prompt_review_quiz_system:'Tu es un coach expérimenté en apprentissage des mathématiques. Conçois un quiz de répétition espacée à partir des notes manuscrites de l’élève. Les notes ne sont qu’un résumé : mobilise le corpus associé et étends les questions aux théorèmes importants, réciproques, corollaires, cas limites, notions proches et variantes courantes. Les questions doivent demander de la réflexion, pas une simple récitation. Commence directement par la première question, sans salutation, réponse ni indice. Utilise Markdown et LaTeX.', prompt_review_quiz_extra:'L’élève a retardé la révision précédente et a besoin d’une consolidation. Crée 3–4 questions à partir de cette page : au moins une extension du même thème et au moins un calcul ou une preuve en plusieurs étapes. Consolide les bases sans question triviale. Renvoie uniquement les questions, sans réponses.', prompt_review_quiz_tonight:'Voici les notes de mathématiques prises aujourd’hui. Crée un quiz « Ce soir » de 4–5 questions : 1–2 questions de compréhension conceptuelle, 1–2 applications directes de calcul ou de preuve, et une extension liée à un théorème, une réciproque, un cas particulier ou une connexion. Renvoie uniquement les questions, sans réponses.', prompt_review_quiz_advanced:'L’élève a étudié ces notes il y a {0} jours. Il s’agit de la révision espacée {1} ({2}). Crée un quiz avancé de 4–5 questions : une distinction conceptuelle, 1–2 variantes, une application intégrée et un défi. Va plus loin que la révision précédente sans répéter les types de questions. Renvoie uniquement les questions, sans réponses.', prompt_previous_quiz:'\n\nQuiz précédent (évite toute répétition et va plus loin) :\n{0}', prompt_previous_quiz_result:'\n\nUtilise la notation IA précédente pour concevoir le prochain quiz. Cible les lacunes et erreurs avec des variantes progressives, réduis la répétition mécanique des acquis et ne révèle aucune réponse.\nNote globale : {0}/10', prompt_ai_feedback:'\nCommentaire IA :\n{0}', prompt_recognized_note:'\n\nTexte reconnu des notes :\n{0}',
             write_answer_first:'Écrivez d’abord votre réponse sur la zone de dessin', grading:'Notation…', grading_in_progress:'Notation en cours…', ai_grading_empty:'L’IA n’a renvoyé aucune notation', per_question_review_heading:'**Vérification question par question :**\n', solutions_missing:'L’IA n’a pas renvoyé les bonnes réponses et les démonstrations complètes', solutions_section:'**✦ Bonnes réponses et démonstrations complètes :**\n{0}', grading_failed:'Échec de la notation : {0}', grading_complete_practice:'Notation terminée ; génération d’un exercice de consolidation…', grading_complete_next:'Notation terminée ; génération du quiz avancé pour {0}…', all_reviews_complete:'Toutes les révisions sont terminées !',
             prompt_review_grade_system:'Tu es un correcteur et solveur de mathématiques strict et professionnel. Résous d’abord chaque question du quiz, puis vérifie la copie manuscrite dans l’ordre. Note globale sur 10 : exactitude et complétude 6, rigueur 2, clarté 2. Couvre chaque question ; même une réponse absente, incomplète ou illisible exige la bonne réponse et une solution complète. per_question évalue uniquement et précisément le travail de l’élève. solutions donne, pour chaque question, une réponse ou conclusion explicite et une démonstration complète sans omettre les étapes clés. N’invente aucune condition et n’ajoute aucun encouragement générique. Renvoie uniquement un JSON valide pour JSON.parse : {"score":nombre de 0 à 10,"per_question":[{"q":"numéro ou résumé","correct":booléen,"comment":"vérification précise"}],"solutions":"bonne réponse et démonstration complète pour chaque question"}. Utilise LaTeX et un échappement JSON valide.', prompt_review_grade_user:'Questions du quiz :\n\n{0}\n\nVérifie la copie manuscrite de l’image dans l’ordre. Pour chaque question, donne une bonne réponse explicite et une démonstration mathématique complète ; ne te contente pas de signaler les erreurs.'
+        });
+        Object.assign(I18N.zh, {
+            ai_reasoning_only:'模型只返回了思考过程，没有正文；请提高输出上限或更换模型',
+            ai_blocked:'请求被模型安全策略拦截（{0}）',
+            ai_empty_reply:'模型返回了空内容'
+        });
+        Object.assign(I18N.en, {
+            ai_reasoning_only:'The model returned only its reasoning, without an answer. Raise the output limit or switch models.',
+            ai_blocked:'The request was blocked by the model safety policy ({0})',
+            ai_empty_reply:'The model returned an empty response'
+        });
+        Object.assign(I18N.fr, {
+            ai_reasoning_only:'Le modèle n’a renvoyé que son raisonnement, sans réponse. Augmentez la limite de sortie ou changez de modèle.',
+            ai_blocked:'La requête a été bloquée par la politique de sécurité du modèle ({0})',
+            ai_empty_reply:'Le modèle a renvoyé une réponse vide'
         });
         let currentLang = 'en';
         function i18n(key, ...args) {
@@ -12395,7 +12408,9 @@
             }
         }
         
-        // 判断一个 URL 是否为 Google Gemini 端点（用 host 判断，不依赖下拉框）
+        // 判断一个 URL 是否为 Google Gemini 端点（用 host 判断，不依赖下拉框）。
+        // 只有真正的 Gemini 端点才走 Gemini 原生协议：自定义渠道即使填了 Gemini 风格的
+        // 模型名，也按 OpenAI 兼容协议请求，PDF 走文本提取兜底而不是 Gemini 附件。
         function isGeminiUrl(url) {
             return typeof url === 'string' && url.indexOf('generativelanguage.googleapis.com') !== -1;
         }
@@ -12413,8 +12428,9 @@
                 model: settings.backupModel,
                 provider: settings.backupProvider || ''
             }];
+            // 长录音要用 Gemini Files API，只有真正的 Gemini 端点能接；自定义渠道不算。
             return candidates.find(config => config.url && config.key && config.model &&
-                (isGeminiUrl(config.url) || config.provider === 'custom')) || null;
+                isGeminiUrl(config.url)) || null;
         }
 
         async function fetchModels(type) {
@@ -18645,13 +18661,13 @@
         }
         
         async function doAIRequest(config, systemPrompt, messages, options = {}) {
-            // Gemini 原生渠道，或用户指定的"自定义"渠道都走 Gemini 协议（按用户要求）
-            const useGemini = isGeminiUrl(config.url) || config.provider === 'custom';
-            if (useGemini) {
+            // 只有 URL 指向 Google 官方端点时才走 Gemini 原生协议。
+            // 自定义渠道按 OpenAI 兼容协议请求，PDF 也不走 Gemini 的附件/Files API。
+            if (isGeminiUrl(config.url)) {
                 return await doGeminiRequest(config, systemPrompt, messages, options);
             }
 
-            // OpenAI / DeepSeek / Claude / 其他 OpenAI 兼容：用 chat/completions 协议
+            // OpenAI / DeepSeek / Claude / 自定义等 OpenAI 兼容：用 chat/completions 协议
             // 这些渠道中只有 Claude 支持原生 PDF，其他需要靠文本预提取兜底
             let finalMessages = messages;
             if (options.pdfAttachment) {
@@ -18660,7 +18676,7 @@
                     finalMessages = await embedPdfForClaude(messages, options.pdfAttachment);
                     return await doClaudeRequest(config, systemPrompt, finalMessages, options);
                 } else {
-                    // OpenAI / DeepSeek / 其他：不支持 PDF，回退文本提取
+                    // OpenAI / DeepSeek / 自定义 / 其他：不支持 PDF，回退文本提取
                     const extractedText = await extractPdfTextAsFallback(options.pdfAttachment);
                     finalMessages = injectPdfTextIntoLastUser(messages, extractedText);
                 }
@@ -18691,37 +18707,63 @@
                 };
             }));
 
-            const requestBody = {
-                model: config.model,
-                messages: [
-                    { role: 'system', content: systemPrompt },
-                    ...finalMessages
-                ],
-                max_tokens: options.maxTokens || 8192,
-                temperature: options.temperature || 0.7,
-                stream: options.stream || false
+            const baseMaxTokens = options.maxTokens || 8192;
+            const sendChatCompletion = async (maxTokens) => {
+                const requestBody = {
+                    model: config.model,
+                    messages: [
+                        { role: 'system', content: systemPrompt },
+                        ...finalMessages
+                    ],
+                    max_tokens: maxTokens,
+                    temperature: options.temperature || 0.7,
+                    stream: options.stream || false
+                };
+
+                const response = await fetch(config.url, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'Authorization': 'Bearer ' + config.key
+                    },
+                    body: JSON.stringify(requestBody)
+                });
+
+                if (!response.ok) {
+                    const errText = await response.text().catch(() => '');
+                    throw new Error(i18n('api_error', response.status, errText));
+                }
+                return response;
             };
-            
-            const response = await fetch(config.url, {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Authorization': 'Bearer ' + config.key
-                },
-                body: JSON.stringify(requestBody)
-            });
-            
-            if (!response.ok) {
-                const errText = await response.text().catch(() => '');
-                throw new Error(i18n('api_error', response.status, errText));
-            }
-            
+
+            const response = await sendChatCompletion(baseMaxTokens);
             if (options.stream) {
                 return response;
             }
-            
-            const data = await response.json();
-            return data.choices?.[0]?.message?.content || null;
+
+            // 推理模型会把思考放在 reasoning_content 里，或用 <think> 内联进正文：
+            // 只取正文，思考一律丢掉，不能当成结果保存。
+            let answer = AIResponse.extractOpenAiAnswer(await response.json());
+            if (AIResponse.isReasoningOnly(answer)) {
+                // 思考把 max_tokens 吃光，正文是空的：抬高输出上限重试一次。
+                console.warn('渠道只返回了思考内容，提高 max_tokens 重试:', answer.finishReason);
+                const retryMaxTokens = reasoningRetryMaxTokens(baseMaxTokens);
+                if (retryMaxTokens > baseMaxTokens) {
+                    try {
+                        answer = AIResponse.extractOpenAiAnswer(
+                            await (await sendChatCompletion(retryMaxTokens)).json());
+                    } catch (e) {
+                        console.warn('提高 max_tokens 重试失败:', e);
+                    }
+                }
+                if (!answer.text) throw new Error(i18n('ai_reasoning_only'));
+            }
+            return answer.text || null;
+        }
+
+        // 正文被思考挤掉时的重试预算：翻倍，但至少 16K、最多 32K。
+        function reasoningRetryMaxTokens(baseMaxTokens) {
+            return Math.min(Math.max(baseMaxTokens * 2, 16384), 32768);
         }
 
         // 把 PDF 文本提取，作为"附件文本"拼到 messages 最后一条 user 内容前
@@ -18784,7 +18826,9 @@
             }
             const data = await response.json();
             if (Array.isArray(data.content)) {
-                return data.content.filter(x => x.type === 'text').map(x => x.text).join('');
+                // thinking 块不是正文，只取 text 块，再清掉可能内联的思考标签。
+                const text = data.content.filter(x => x.type === 'text').map(x => x.text || '').join('');
+                return AIResponse.splitReasoningMarkup(text).text || null;
             }
             return null;
         }
@@ -18893,36 +18937,61 @@
                 }
             }
 
-            const body = {
-                contents,
-                generationConfig: {
-                    temperature: options.temperature != null ? options.temperature : 0.7,
-                    maxOutputTokens: options.maxTokens || 8192
-                }
-            };
-            if (systemPrompt) {
-                body.systemInstruction = { parts: [{ text: String(systemPrompt) }] };
-            }
-
             const url = base + '/models/' + encodeURIComponent(modelName) + ':generateContent?key=' + encodeURIComponent(config.key);
-            const response = await fetch(url, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(body)
-            });
-            if (!response.ok) {
-                const errText = await response.text().catch(() => '');
-                throw new Error(i18n('api_error', response.status, errText));
+            const baseMaxTokens = options.maxTokens || 8192;
+            const sendGenerateContent = async (generationConfig) => {
+                const body = {
+                    contents,
+                    generationConfig: Object.assign({
+                        temperature: options.temperature != null ? options.temperature : 0.7
+                    }, generationConfig)
+                };
+                if (systemPrompt) {
+                    body.systemInstruction = { parts: [{ text: String(systemPrompt) }] };
+                }
+                const response = await fetch(url, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(body)
+                });
+                if (!response.ok) {
+                    const errText = await response.text().catch(() => '');
+                    throw new Error(i18n('api_error', response.status, errText));
+                }
+                // 思考模型会额外返回 thought:true 的 part，那是思考摘要不是正文。
+                return AIResponse.extractGeminiAnswer(await response.json());
+            };
+
+            let answer = await sendGenerateContent({ maxOutputTokens: baseMaxTokens });
+            if (answer.finishReason && answer.finishReason !== 'STOP') {
+                console.warn('Gemini finishReason:', answer.finishReason, '— 输出可能被截断');
             }
-            const data = await response.json();
-            const candidate = data.candidates?.[0];
-            const finishReason = candidate?.finishReason;
-            if (finishReason && finishReason !== 'STOP') {
-                console.warn('Gemini finishReason:', finishReason, '— 输出可能被截断');
+            if (AIResponse.isReasoningOnly(answer)) {
+                // 思考计入 maxOutputTokens，正文一个字都没剩：抬高上限、压缩思考预算重试一次。
+                console.warn('Gemini 只返回了思考内容，提高 maxOutputTokens 重试:', answer.finishReason);
+                const retryMaxTokens = reasoningRetryMaxTokens(baseMaxTokens);
+                const retryConfig = { maxOutputTokens: retryMaxTokens };
+                try {
+                    answer = await sendGenerateContent(Object.assign({}, retryConfig, {
+                        thinkingConfig: {
+                            includeThoughts: false,
+                            thinkingBudget: Math.min(8192, Math.floor(retryMaxTokens / 2))
+                        }
+                    }));
+                } catch (e) {
+                    // 旧模型或代理端点可能不认 thinkingConfig，退回只抬高上限。
+                    console.warn('thinkingConfig 重试失败，仅提高 maxOutputTokens 重试:', e);
+                    try {
+                        answer = await sendGenerateContent(retryConfig);
+                    } catch (e2) {
+                        console.warn('提高 maxOutputTokens 重试失败:', e2);
+                    }
+                }
             }
-            const parts = candidate?.content?.parts;
-            if (Array.isArray(parts) && parts.length > 0) {
-                return parts.map(p => p.text || '').join('');
+            if (answer.text) return answer.text;
+            if (answer.blockReason) throw new Error(i18n('ai_blocked', answer.blockReason));
+            if (answer.reasoning || answer.finishReason === 'MAX_TOKENS') {
+                throw new Error(i18n('ai_reasoning_only'));
             }
             return null;
         }
@@ -19583,7 +19652,9 @@ ${i18n('prompt_lecture_gen')}`;
                     pdfAttachment
                 });
 
-                const contentText = result || i18n('toast_content_gen_failed');
+                // 空回复不能当讲义存下来（否则章节会被标记为已生成，用户只能手动重生成）
+                const contentText = typeof result === 'string' ? result.trim() : '';
+                if (!contentText) throw new Error(i18n('ai_empty_reply'));
                 chapter.status = 'ready';
                 chapter.generatedAt = new Date().toISOString();
                 chapter.updatedAt = chapter.generatedAt;
@@ -21649,7 +21720,9 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 paper = appData.papers.find(p => p.id === paperId);
                 if (!paper) return;
 
-                const abstractText = result || i18n('abstract_gen_failed');
+                // 同讲义：空回复不能当摘要存下来，否则会被标记为“已生成”
+                const abstractText = typeof result === 'string' ? result.trim() : '';
+                if (!abstractText) throw new Error(i18n('ai_empty_reply'));
                 await saveAbstractContent(paperId, abstractText);
                 paper._abstractCache = abstractText;
                 paper.hasAiAbstract = true;

--- a/tests/ai-response.test.js
+++ b/tests/ai-response.test.js
@@ -1,0 +1,112 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const AIResponse = require('../app/src/main/assets/www/ai-response.js');
+
+test('keeps the answer and drops Gemini thought parts', () => {
+    const answer = AIResponse.extractGeminiAnswer({
+        candidates: [{
+            content: {
+                parts: [
+                    { text: 'I am trying to recall arXiv:1506.07113 ...', thought: true },
+                    { text: '## 一、预习\n\n设 $f_c(z)=z^2+c$。' }
+                ]
+            },
+            finishReason: 'STOP'
+        }]
+    });
+    assert.equal(answer.text, '## 一、预习\n\n设 $f_c(z)=z^2+c$。');
+    assert.equal(answer.reasoning, 'I am trying to recall arXiv:1506.07113 ...');
+    assert.equal(AIResponse.isReasoningOnly(answer), false);
+});
+
+test('reports a thought-only Gemini reply instead of returning the monologue', () => {
+    // 思考把 maxOutputTokens 吃光，正文一个字都没写：不能当讲义保存。
+    const answer = AIResponse.extractGeminiAnswer({
+        candidates: [{
+            content: { parts: [{ text: 'Let me reconsider with a cleaner argument.', thought: 'true' }] },
+            finishReason: 'MAX_TOKENS'
+        }]
+    });
+    assert.equal(answer.text, '');
+    assert.equal(answer.reasoning, 'Let me reconsider with a cleaner argument.');
+    assert.equal(answer.finishReason, 'MAX_TOKENS');
+    assert.equal(AIResponse.isReasoningOnly(answer), true);
+});
+
+test('treats thought:false parts as answer text and surfaces block reasons', () => {
+    const answer = AIResponse.extractGeminiAnswer({
+        candidates: [{ content: { parts: [{ text: '正文', thought: false }] }, finishReason: 'STOP' }],
+        promptFeedback: { blockReason: 'SAFETY' }
+    });
+    assert.equal(answer.text, '正文');
+    assert.equal(answer.blockReason, 'SAFETY');
+    assert.equal(answer.hasCandidate, true);
+});
+
+test('survives empty and malformed Gemini payloads', () => {
+    for (const payload of [null, {}, { candidates: [] }, { candidates: [{}] }]) {
+        const answer = AIResponse.extractGeminiAnswer(payload);
+        assert.equal(answer.text, '');
+        assert.equal(answer.reasoning, '');
+    }
+    assert.equal(AIResponse.extractGeminiAnswer({ candidates: [{}] }).hasCandidate, true);
+    assert.equal(AIResponse.extractGeminiAnswer({}).hasCandidate, false);
+});
+
+test('drops OpenAI-compatible reasoning_content and keeps the answer', () => {
+    const answer = AIResponse.extractOpenAiAnswer({
+        choices: [{
+            message: { content: '## 二、大纲', reasoning_content: 'first I check the fixed points' },
+            finish_reason: 'stop'
+        }]
+    });
+    assert.equal(answer.text, '## 二、大纲');
+    assert.equal(answer.reasoning, 'first I check the fixed points');
+    assert.equal(AIResponse.isReasoningOnly(answer), false);
+});
+
+test('flags a reasoning-only OpenAI-compatible reply', () => {
+    const answer = AIResponse.extractOpenAiAnswer({
+        choices: [{ message: { content: '', reasoning_content: 'thinking...' }, finish_reason: 'length' }]
+    });
+    assert.equal(answer.text, '');
+    assert.equal(answer.finishReason, 'length');
+    assert.equal(AIResponse.isReasoningOnly(answer), true);
+});
+
+test('reads OpenAI content blocks and ignores thinking blocks', () => {
+    const answer = AIResponse.extractOpenAiAnswer({
+        choices: [{
+            message: {
+                content: [
+                    { type: 'thinking', thinking: 'internal' },
+                    { type: 'text', text: 'Theorem 1. ' },
+                    { type: 'text', text: 'Proof.' }
+                ]
+            }
+        }]
+    });
+    assert.equal(answer.text, 'Theorem 1. Proof.');
+    assert.equal(answer.reasoning, 'internal');
+});
+
+test('strips inline reasoning tags gateways inject into the body', () => {
+    assert.deepEqual(
+        AIResponse.splitReasoningMarkup('<think>weighing options</think>\n\n# 讲义'),
+        { text: '# 讲义', reasoning: 'weighing options' });
+    // 思考先流式输出、只留下一个结束标签
+    assert.deepEqual(
+        AIResponse.splitReasoningMarkup('recalling the lemma</thinking>\n# 讲义'),
+        { text: '# 讲义', reasoning: 'recalling the lemma' });
+    // 思考没写完就被截断：整段都不是正文
+    assert.deepEqual(
+        AIResponse.splitReasoningMarkup('# 讲义\n<reasoning>still unsure about'),
+        { text: '# 讲义', reasoning: 'still unsure about' });
+});
+
+test('leaves ordinary lecture text untouched', () => {
+    const lecture = '## 一、预习\n\n若 $|\\lambda| < 1$，则 $c = \\lambda/2 - \\lambda^2/4$。';
+    assert.deepEqual(AIResponse.splitReasoningMarkup(lecture), { text: lecture, reasoning: '' });
+});

--- a/tests/ai-routing.test.js
+++ b/tests/ai-routing.test.js
@@ -1,0 +1,152 @@
+'use strict';
+
+// index.html 是单文件应用，没法直接 require。这里按函数名把渠道路由相关的函数原样抠出来，
+// 配上假的 fetch 跑一遍，保证“自定义渠道不走 Gemini”“不把思考当正文”这两条不被改回去。
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const WWW = path.join(__dirname, '..', 'app', 'src', 'main', 'assets', 'www');
+const AIResponse = require(path.join(WWW, 'ai-response.js'));
+const html = fs.readFileSync(path.join(WWW, 'index.html'), 'utf8');
+
+function extractFunction(name) {
+    const match = html.match(new RegExp('^ *(?:async )?function ' + name + '\\(', 'm'));
+    assert.ok(match, 'index.html 里找不到函数 ' + name);
+    const start = match.index;
+    // 先跳过参数表，避免把 `options = {}` 的默认值当成函数体
+    let i = html.indexOf('(', start);
+    let parens = 0;
+    for (; i < html.length; i++) {
+        if (html[i] === '(') parens++;
+        else if (html[i] === ')' && --parens === 0) { i++; break; }
+    }
+    let depth = 0;
+    let quote = null;
+    for (i = html.indexOf('{', i); i < html.length; i++) {
+        const ch = html[i];
+        if (quote) {
+            if (ch === '\\') i++;
+            else if (ch === quote) quote = null;
+            continue;
+        }
+        if (ch === '"' || ch === "'" || ch === '`') quote = ch;
+        else if (ch === '{') depth++;
+        else if (ch === '}' && --depth === 0) return html.slice(start, i + 1);
+    }
+    throw new Error('函数括号不配对: ' + name);
+}
+
+const SOURCE = [
+    'doAIRequest', 'doGeminiRequest', 'doClaudeRequest', 'reasoningRetryMaxTokens', 'isGeminiUrl',
+    'extractPdfTextAsFallback', 'injectPdfTextIntoLastUser', 'buildGeminiContentsWithPdf',
+    'embedPdfForClaude', 'uint8ToBase64', 'base64ToUint8'
+].map(extractFunction).join('\n\n');
+
+const load = new Function('AIResponse', 'i18n', 'fetch', 'window', 'pdfjsLib', 'console',
+    SOURCE + '\nreturn { doAIRequest, doGeminiRequest };');
+
+// respond(url, body, callIndex) -> { json } 或 { ok:false, status, json }
+function sandbox(respond, pdfjsLib) {
+    const calls = [];
+    const fetchStub = async (url, init) => {
+        const body = init && init.body ? JSON.parse(init.body) : null;
+        calls.push({ url, body });
+        const result = respond(url, body, calls.length - 1);
+        return {
+            ok: result.ok !== false,
+            status: result.status || 200,
+            json: async () => result.json,
+            text: async () => JSON.stringify(result.json)
+        };
+    };
+    const i18n = (key, ...args) => (args.length ? key + ':' + args.join(',') : key);
+    const quietConsole = { warn() {}, error() {}, log() {} };
+    const api = load(AIResponse, i18n, fetchStub, { RecordingAI: null }, pdfjsLib || null, quietConsole);
+    return { api, calls };
+}
+
+const GEMINI = { url: 'https://generativelanguage.googleapis.com/v1beta', key: 'k', model: 'gemini-2.5-pro' };
+const CUSTOM = { url: 'https://gateway.example.com/v1/chat/completions', key: 'k', model: 'gemini-3-pro', provider: 'custom' };
+const ONE_PAGE_PDF = {
+    getDocument: () => ({ promise: Promise.resolve({
+        numPages: 1,
+        getPage: async () => ({ getTextContent: async () => ({ items: [{ str: 'Section 7 Fatou–Julia' }] }) })
+    }) })
+};
+
+function geminiReply(parts, finishReason) {
+    return { json: { candidates: [{ finishReason: finishReason || 'STOP', content: { parts } }] } };
+}
+
+test('custom channel uses the OpenAI protocol and sends the PDF as extracted text', async () => {
+    const { api, calls } = sandbox(
+        () => ({ json: { choices: [{ message: { content: '# 讲义' } }] } }), ONE_PAGE_PDF);
+    const result = await api.doAIRequest(CUSTOM, 'sys', [{ role: 'user', content: '生成讲义' }], {
+        maxTokens: 8192,
+        pdfAttachment: { bytes: new Uint8Array([1, 2, 3]), base64: 'AQID', name: 'ch1.pdf' }
+    });
+    assert.equal(result, '# 讲义');
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, CUSTOM.url);
+    assert.doesNotMatch(calls[0].url, /generateContent|generativelanguage/);
+    assert.ok(!calls[0].body.contents, 'Gemini 的 contents 字段不应出现');
+    const lastMessage = calls[0].body.messages[calls[0].body.messages.length - 1].content;
+    assert.match(lastMessage, /Section 7 Fatou–Julia/);
+});
+
+test('Gemini reply keeps the answer part and drops the thought part', async () => {
+    const { api, calls } = sandbox(() => geminiReply([
+        { text: "I'm trying to recall the specific arXiv paper 1506.07113", thought: true },
+        { text: '## 一、预习' }
+    ]));
+    assert.equal(await api.doGeminiRequest(GEMINI, 'sys', [{ role: 'user', content: 'go' }], { maxTokens: 8192 }),
+        '## 一、预习');
+    assert.equal(calls.length, 1);
+});
+
+test('a thought-only Gemini reply is retried with a bigger output budget', async () => {
+    const { api, calls } = sandbox((url, body, index) => index === 0
+        ? geminiReply([{ text: 'Let me reconsider with a cleaner argument.', thought: true }], 'MAX_TOKENS')
+        : geminiReply([{ text: '## 一、预习' }]));
+    assert.equal(await api.doGeminiRequest(GEMINI, 'sys', [{ role: 'user', content: 'go' }], { maxTokens: 8192 }),
+        '## 一、预习');
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].body.generationConfig.maxOutputTokens, 8192);
+    assert.equal(calls[1].body.generationConfig.maxOutputTokens, 16384);
+    assert.equal(calls[1].body.generationConfig.thinkingConfig.includeThoughts, false);
+});
+
+test('the retry drops thinkingConfig when the endpoint rejects it', async () => {
+    const { api, calls } = sandbox((url, body, index) => {
+        if (index === 0) return geminiReply([{ text: 'thinking…', thought: true }], 'MAX_TOKENS');
+        if (body.generationConfig.thinkingConfig) return { ok: false, status: 400, json: 'unknown field' };
+        return geminiReply([{ text: '正文' }]);
+    });
+    assert.equal(await api.doGeminiRequest(GEMINI, 'sys', [{ role: 'user', content: 'go' }], { maxTokens: 8192 }),
+        '正文');
+    assert.equal(calls.length, 3);
+    assert.equal(calls[2].body.generationConfig.maxOutputTokens, 16384);
+    assert.ok(!calls[2].body.generationConfig.thinkingConfig);
+});
+
+test('an all-thinking Gemini reply fails instead of returning the monologue', async () => {
+    const { api } = sandbox(() => geminiReply(
+        [{ text: "I'm working through the immediate basin argument", thought: true }], 'MAX_TOKENS'));
+    await assert.rejects(
+        () => api.doGeminiRequest(GEMINI, 'sys', [{ role: 'user', content: 'go' }], { maxTokens: 8192 }),
+        /ai_reasoning_only/);
+});
+
+test('an OpenAI-compatible reasoning-only reply is retried, then stripped of <think>', async () => {
+    const { api, calls } = sandbox((url, body, index) => index === 0
+        ? ({ json: { choices: [{ finish_reason: 'length', message: { content: '', reasoning_content: '…' } }] } })
+        : ({ json: { choices: [{ finish_reason: 'stop', message: { content: '<think>…</think>\n\n# 讲义' } }] } }));
+    assert.equal(await api.doAIRequest(CUSTOM, 'sys', [{ role: 'user', content: 'go' }], { maxTokens: 8192 }),
+        '# 讲义');
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].body.max_tokens, 8192);
+    assert.equal(calls[1].body.max_tokens, 16384);
+});


### PR DESCRIPTION
## 问题

自定义渠道生成出来的「讲义」整篇是模型的思考独白，而且在句子中间断掉：

> I'm trying to recall the specific arXiv paper 1506.07113 and pin down what Section 7 …
> Let me reconsider with a cleaner argument. …

两个原因叠在一起：

1. `doAIRequest` 把 `provider === 'custom'` 也判成 Gemini 原生协议（`isGeminiUrl(url) || provider === 'custom'`），自定义渠道的 PDF 直接按 Gemini 的 `inline_data` / Files API 发出去。顺带一提，`fetchModels` 对自定义渠道用的是 OpenAI 的 `/models`，拉模型和发请求本来就不是同一套协议。
2. `doGeminiRequest` 把 `candidates[0].content.parts` 全部拼起来返回，其中 `thought: true` 的 part 是思考摘要不是正文。思考还要计入 `maxOutputTokens`，讲义用的 8192 预算被思考吃光后（`finishReason: MAX_TOKENS`）parts 里只剩思考，于是整篇思考被 `generateChapterContent` 当讲义存进 IndexedDB，章节还被标记成 `ready`。

## 改动

**渠道协议只看服务地址。** 只有 `generativelanguage.googleapis.com` 走 Gemini 原生协议；自定义渠道走 OpenAI 兼容的 `chat/completions`，PDF 先用 pdf.js 在本地提取文本再随提示词发送，不再碰 Gemini 的附件和 Files API。长录音选取 Gemini Files API 配置时（`_configuredGeminiRecordingConfig`）同样不再把自定义渠道当 Gemini。

**只提取正文，不提取思考。** 新增 `ai-response.js`（UMD，可单测）统一解析回复：

- Gemini：丢掉 `thought: true` 的 part，只留正文 part；
- OpenAI 兼容：忽略 `reasoning_content` / `reasoning` 和 `thinking` 内容块；
- 网关内联的 `<think>` / `<thinking>` / `<reasoning>` 标签一律剥掉，包括只有开始或只有结束半边标签的截断情况；
- Claude 的 `thinking` 块本来就已按 `type === 'text'` 过滤，这里补上标签清理。

**正文被思考挤空时重试一次。** 判定为「只有思考没有正文」（thought-only、`MAX_TOKENS`、`length`）时，把输出上限翻倍到至少 16K 后重试一次；Gemini 的重试同时带上 `thinkingConfig`（`includeThoughts: false` + 压缩 `thinkingBudget`），端点不认这个字段就退回只提高上限的重试。重试后仍然没有正文就抛错，交给备用 API 接手，绝不把思考当结果返回。

**空回复不再落盘。** 讲义和摘要原来会把空回复写成「内容生成失败」/「摘要生成失败」并标记为已生成，用户只能手动重新生成；现在直接抛错走失败分支，章节状态是 `error`。两个只剩定义的 i18n key 一并删掉，新增 `ai_reasoning_only` / `ai_blocked` / `ai_empty_reply` 三个 key（zh/en/fr）。

## 测试

`node --test tests/*.test.js`，17 个用例全部通过（CI 里 build-apk 会跑）。

- `tests/ai-response.test.js`：解析层单测，覆盖 thought part、`reasoning_content`、内联标签、残缺标签、畸形响应。
- `tests/ai-routing.test.js`：按函数名从 `index.html` 里抠出 `doAIRequest` / `doGeminiRequest` 等函数，配假 `fetch` 跑真实逻辑，验证自定义渠道不会打到 Gemini、PDF 走文本提取、thought-only 会带更大预算重试、`thinkingConfig` 被拒时的退化路径，以及全是思考时抛错而不是返回独白。

`docs/` 按 sync-docs 的清单同步了 `index.html` 和新增的 `ai-response.js`，workflow 里也补了这个文件的 `cp`。

## 影响

如果自定义渠道填的是 Gemini 风格的地址（例如 `https://host/v1beta`），现在需要改成该网关的 OpenAI 兼容地址（`https://host/v1/chat/completions`）；想继续用 Gemini 原生协议就把地址填成 Google 官方端点。README 的中英文说明都补了这条。

---
_Generated by [Claude Code](https://claude.ai/code/session_017sPHLsuqXz519de97LXKhM)_