### PR TITLE
讲义只取正文不取思考，自定义渠道的 PDF 改发提取文本

### DIFF
--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -18648,6 +18648,15 @@
             // Gemini 原生渠道，或用户指定的"自定义"渠道都走 Gemini 协议（按用户要求）
             const useGemini = isGeminiUrl(config.url) || config.provider === 'custom';
             if (useGemini) {
+                // 自定义渠道只是借用 Gemini 的请求格式，网关不会把 inline_data/Files API 的
+                // PDF 转给后面的模型（模型会说"看不到附件"），所以这里先在本地提取文本再发。
+                // 请求地址、请求头一概不变，只换 PDF 的携带方式。
+                if (options.pdfAttachment && !isGeminiUrl(config.url)) {
+                    const extractedText = await extractPdfTextAsFallback(options.pdfAttachment);
+                    return await doGeminiRequest(config, systemPrompt,
+                        injectPdfTextIntoLastUser(messages, extractedText),
+                        { ...options, pdfAttachment: null });
+                }
                 return await doGeminiRequest(config, systemPrompt, messages, options);
             }
 
@@ -18721,7 +18730,10 @@
             }
             
             const data = await response.json();
-            return data.choices?.[0]?.message?.content || null;
+            // 只取 content：reasoning_content 是思考，不要；内联的 <think> 也清掉
+            const content = data.choices?.[0]?.message?.content;
+            if (typeof content === 'string') return stripThinkingMarkup(content) || null;
+            return content || null;
         }
 
         // 把 PDF 文本提取，作为"附件文本"拼到 messages 最后一条 user 内容前
@@ -18746,15 +18758,17 @@
         }
 
         function injectPdfTextIntoLastUser(messages, extractedText) {
+            // attached_pdf_text 带 {0} 占位符，必须把正文当参数传进去，否则提示词里会留下字面的 {0}
+            const pdfText = i18n('attached_pdf_text', extractedText);
             if (!messages || messages.length === 0) {
-                return [{ role: 'user', content: i18n('attached_pdf_text') + '\n' + extractedText }];
+                return [{ role: 'user', content: pdfText }];
             }
             const out = messages.slice();
             const lastIdx = out.length - 1;
             const last = out[lastIdx];
             out[lastIdx] = {
                 role: last.role,
-                content: i18n('attached_pdf_text') + '\n' + extractedText + '\n\n---\n\n' + String(last.content || '')
+                content: pdfText + '\n\n---\n\n' + String(last.content || '')
             };
             return out;
         }
@@ -18819,6 +18833,38 @@
             const arr = new Uint8Array(raw.length);
             for (let i = 0; i < raw.length; i++) arr[i] = raw.charCodeAt(i);
             return arr;
+        }
+
+        // 推理模型（自定义渠道常用的 maxthinking 之类别名）会把思考和正文一起返回，
+        // 网关有时还会把思考内联成 <think>…</think>。这里只保留正文，思考一律丢掉。
+        function stripThinkingMarkup(text) {
+            let out = String(text == null ? '' : text);
+            out = out.replace(/<(think|thinking|reasoning)(?:\s[^>]*)?>[\s\S]*?<\/\1\s*>/gi, '\n');
+            // 思考被截断时只会剩半边标签：结束标签之前、开始标签之后的内容都不是正文
+            const beforeClose = out.match(/^[\s\S]*<\/(?:think|thinking|reasoning)\s*>/i);
+            if (beforeClose) out = out.slice(beforeClose[0].length);
+            out = out.replace(/<(?:think|thinking|reasoning)(?:\s[^>]*)?>[\s\S]*$/i, '');
+            return out.trim();
+        }
+
+        // Gemini 响应里 thought:true 的 part 是思考摘要，不是正文。
+        // 返回 { text, thinking }：text 是正文；thinking 只用来判断“只想了没写”。
+        function extractGeminiAnswer(data) {
+            const parts = data?.candidates?.[0]?.content?.parts;
+            if (!Array.isArray(parts)) return { text: '', thinking: '' };
+            const answerChunks = [];
+            const thinkingChunks = [];
+            parts.forEach(part => {
+                const text = typeof part?.text === 'string' ? part.text : '';
+                if (!text) return;
+                // 个别网关会把布尔值发成字符串
+                if (part.thought && part.thought !== 'false') thinkingChunks.push(text);
+                else answerChunks.push(text);
+            });
+            const raw = answerChunks.join('');
+            const text = stripThinkingMarkup(raw);
+            if (!text && raw.trim()) thinkingChunks.push(raw);
+            return { text, thinking: thinkingChunks.join('\n\n').trim() };
         }
 
         // Google Gemini 原生协议调用
@@ -18905,26 +18951,43 @@
             }
 
             const url = base + '/models/' + encodeURIComponent(modelName) + ':generateContent?key=' + encodeURIComponent(config.key);
-            const response = await fetch(url, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(body)
-            });
-            if (!response.ok) {
-                const errText = await response.text().catch(() => '');
-                throw new Error(i18n('api_error', response.status, errText));
+            const sendOnce = async (maxOutputTokens) => {
+                body.generationConfig.maxOutputTokens = maxOutputTokens;
+                const response = await fetch(url, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(body)
+                });
+                if (!response.ok) {
+                    const errText = await response.text().catch(() => '');
+                    throw new Error(i18n('api_error', response.status, errText));
+                }
+                const data = await response.json();
+                return {
+                    answer: extractGeminiAnswer(data),
+                    finishReason: data.candidates?.[0]?.finishReason
+                };
+            };
+
+            const baseMaxTokens = options.maxTokens || 8192;
+            let result = await sendOnce(baseMaxTokens);
+            if (result.finishReason && result.finishReason !== 'STOP') {
+                console.warn('Gemini finishReason:', result.finishReason, '— 输出可能被截断');
             }
-            const data = await response.json();
-            const candidate = data.candidates?.[0];
-            const finishReason = candidate?.finishReason;
-            if (finishReason && finishReason !== 'STOP') {
-                console.warn('Gemini finishReason:', finishReason, '— 输出可能被截断');
+            // 思考也算在 maxOutputTokens 里。思考把预算吃光时正文一个字都不会有，
+            // 这时抬高一次上限重试；仍然没有正文就返回空，绝不把思考当结果。
+            if (!result.answer.text &&
+                (result.answer.thinking || result.finishReason === 'MAX_TOKENS')) {
+                const retryMaxTokens = Math.min(Math.max(baseMaxTokens * 4, 32768), 65536);
+                console.warn('只拿到思考没有正文，提高 maxOutputTokens 重试:',
+                    baseMaxTokens, '->', retryMaxTokens);
+                try {
+                    result = await sendOnce(retryMaxTokens);
+                } catch (e) {
+                    console.warn('提高 maxOutputTokens 重试失败:', e);
+                }
             }
-            const parts = candidate?.content?.parts;
-            if (Array.isArray(parts) && parts.length > 0) {
-                return parts.map(p => p.text || '').join('');
-            }
-            return null;
+            return result.answer.text || null;
         }
 
         // 构造 Gemini contents，带 PDF。超过 18MB 走 Files API。
@@ -19583,7 +19646,9 @@ ${i18n('prompt_lecture_gen')}`;
                     pdfAttachment
                 });
 
-                const contentText = result || i18n('toast_content_gen_failed');
+                // 空回复不能当讲义存下来：会被标记成已生成，用户只能手动重新生成
+                if (!result) throw new Error(i18n('toast_content_gen_failed'));
+                const contentText = result;
                 chapter.status = 'ready';
                 chapter.generatedAt = new Date().toISOString();
                 chapter.updatedAt = chapter.generatedAt;

--- a/docs/index.html
+++ b/docs/index.html
@@ -18648,6 +18648,15 @@
             // Gemini 原生渠道，或用户指定的"自定义"渠道都走 Gemini 协议（按用户要求）
             const useGemini = isGeminiUrl(config.url) || config.provider === 'custom';
             if (useGemini) {
+                // 自定义渠道只是借用 Gemini 的请求格式，网关不会把 inline_data/Files API 的
+                // PDF 转给后面的模型（模型会说"看不到附件"），所以这里先在本地提取文本再发。
+                // 请求地址、请求头一概不变，只换 PDF 的携带方式。
+                if (options.pdfAttachment && !isGeminiUrl(config.url)) {
+                    const extractedText = await extractPdfTextAsFallback(options.pdfAttachment);
+                    return await doGeminiRequest(config, systemPrompt,
+                        injectPdfTextIntoLastUser(messages, extractedText),
+                        { ...options, pdfAttachment: null });
+                }
                 return await doGeminiRequest(config, systemPrompt, messages, options);
             }
 
@@ -18721,7 +18730,10 @@
             }
             
             const data = await response.json();
-            return data.choices?.[0]?.message?.content || null;
+            // 只取 content：reasoning_content 是思考，不要；内联的 <think> 也清掉
+            const content = data.choices?.[0]?.message?.content;
+            if (typeof content === 'string') return stripThinkingMarkup(content) || null;
+            return content || null;
         }
 
         // 把 PDF 文本提取，作为"附件文本"拼到 messages 最后一条 user 内容前
@@ -18746,15 +18758,17 @@
         }
 
         function injectPdfTextIntoLastUser(messages, extractedText) {
+            // attached_pdf_text 带 {0} 占位符，必须把正文当参数传进去，否则提示词里会留下字面的 {0}
+            const pdfText = i18n('attached_pdf_text', extractedText);
             if (!messages || messages.length === 0) {
-                return [{ role: 'user', content: i18n('attached_pdf_text') + '\n' + extractedText }];
+                return [{ role: 'user', content: pdfText }];
             }
             const out = messages.slice();
             const lastIdx = out.length - 1;
             const last = out[lastIdx];
             out[lastIdx] = {
                 role: last.role,
-                content: i18n('attached_pdf_text') + '\n' + extractedText + '\n\n---\n\n' + String(last.content || '')
+                content: pdfText + '\n\n---\n\n' + String(last.content || '')
             };
             return out;
         }
@@ -18819,6 +18833,38 @@
             const arr = new Uint8Array(raw.length);
             for (let i = 0; i < raw.length; i++) arr[i] = raw.charCodeAt(i);
             return arr;
+        }
+
+        // 推理模型（自定义渠道常用的 maxthinking 之类别名）会把思考和正文一起返回，
+        // 网关有时还会把思考内联成 <think>…</think>。这里只保留正文，思考一律丢掉。
+        function stripThinkingMarkup(text) {
+            let out = String(text == null ? '' : text);
+            out = out.replace(/<(think|thinking|reasoning)(?:\s[^>]*)?>[\s\S]*?<\/\1\s*>/gi, '\n');
+            // 思考被截断时只会剩半边标签：结束标签之前、开始标签之后的内容都不是正文
+            const beforeClose = out.match(/^[\s\S]*<\/(?:think|thinking|reasoning)\s*>/i);
+            if (beforeClose) out = out.slice(beforeClose[0].length);
+            out = out.replace(/<(?:think|thinking|reasoning)(?:\s[^>]*)?>[\s\S]*$/i, '');
+            return out.trim();
+        }
+
+        // Gemini 响应里 thought:true 的 part 是思考摘要，不是正文。
+        // 返回 { text, thinking }：text 是正文；thinking 只用来判断“只想了没写”。
+        function extractGeminiAnswer(data) {
+            const parts = data?.candidates?.[0]?.content?.parts;
+            if (!Array.isArray(parts)) return { text: '', thinking: '' };
+            const answerChunks = [];
+            const thinkingChunks = [];
+            parts.forEach(part => {
+                const text = typeof part?.text === 'string' ? part.text : '';
+                if (!text) return;
+                // 个别网关会把布尔值发成字符串
+                if (part.thought && part.thought !== 'false') thinkingChunks.push(text);
+                else answerChunks.push(text);
+            });
+            const raw = answerChunks.join('');
+            const text = stripThinkingMarkup(raw);
+            if (!text && raw.trim()) thinkingChunks.push(raw);
+            return { text, thinking: thinkingChunks.join('\n\n').trim() };
         }
 
         // Google Gemini 原生协议调用
@@ -18905,26 +18951,43 @@
             }
 
             const url = base + '/models/' + encodeURIComponent(modelName) + ':generateContent?key=' + encodeURIComponent(config.key);
-            const response = await fetch(url, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(body)
-            });
-            if (!response.ok) {
-                const errText = await response.text().catch(() => '');
-                throw new Error(i18n('api_error', response.status, errText));
+            const sendOnce = async (maxOutputTokens) => {
+                body.generationConfig.maxOutputTokens = maxOutputTokens;
+                const response = await fetch(url, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(body)
+                });
+                if (!response.ok) {
+                    const errText = await response.text().catch(() => '');
+                    throw new Error(i18n('api_error', response.status, errText));
+                }
+                const data = await response.json();
+                return {
+                    answer: extractGeminiAnswer(data),
+                    finishReason: data.candidates?.[0]?.finishReason
+                };
+            };
+
+            const baseMaxTokens = options.maxTokens || 8192;
+            let result = await sendOnce(baseMaxTokens);
+            if (result.finishReason && result.finishReason !== 'STOP') {
+                console.warn('Gemini finishReason:', result.finishReason, '— 输出可能被截断');
             }
-            const data = await response.json();
-            const candidate = data.candidates?.[0];
-            const finishReason = candidate?.finishReason;
-            if (finishReason && finishReason !== 'STOP') {
-                console.warn('Gemini finishReason:', finishReason, '— 输出可能被截断');
+            // 思考也算在 maxOutputTokens 里。思考把预算吃光时正文一个字都不会有，
+            // 这时抬高一次上限重试；仍然没有正文就返回空，绝不把思考当结果。
+            if (!result.answer.text &&
+                (result.answer.thinking || result.finishReason === 'MAX_TOKENS')) {
+                const retryMaxTokens = Math.min(Math.max(baseMaxTokens * 4, 32768), 65536);
+                console.warn('只拿到思考没有正文，提高 maxOutputTokens 重试:',
+                    baseMaxTokens, '->', retryMaxTokens);
+                try {
+                    result = await sendOnce(retryMaxTokens);
+                } catch (e) {
+                    console.warn('提高 maxOutputTokens 重试失败:', e);
+                }
             }
-            const parts = candidate?.content?.parts;
-            if (Array.isArray(parts) && parts.length > 0) {
-                return parts.map(p => p.text || '').join('');
-            }
-            return null;
+            return result.answer.text || null;
         }
 
         // 构造 Gemini contents，带 PDF。超过 18MB 走 Files API。
@@ -19583,7 +19646,9 @@ ${i18n('prompt_lecture_gen')}`;
                     pdfAttachment
                 });
 
-                const contentText = result || i18n('toast_content_gen_failed');
+                // 空回复不能当讲义存下来：会被标记成已生成，用户只能手动重新生成
+                if (!result) throw new Error(i18n('toast_content_gen_failed'));
+                const contentText = result;
                 chapter.status = 'ready';
                 chapter.generatedAt = new Date().toISOString();
                 chapter.updatedAt = chapter.generatedAt;

--- a/tests/ai-thinking.test.js
+++ b/tests/ai-thinking.test.js
@@ -1,0 +1,180 @@
+'use strict';
+
+// index.html 是单文件应用，没法直接 require：按函数名把相关函数原样抠出来跑，
+// 保证"只取正文、不取思考"和自定义渠道的 PDF 处理不会被改回去。
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const html = fs.readFileSync(
+    path.join(__dirname, '..', 'app', 'src', 'main', 'assets', 'www', 'index.html'), 'utf8');
+
+function extractFunction(name) {
+    const match = html.match(new RegExp('^ *(?:async )?function ' + name + '\\(', 'm'));
+    assert.ok(match, 'index.html 里找不到函数 ' + name);
+    // 先跳过参数表，避免把 `options = {}` 的默认值当成函数体
+    let i = html.indexOf('(', match.index);
+    for (let parens = 0; i < html.length; i++) {
+        if (html[i] === '(') parens++;
+        else if (html[i] === ')' && --parens === 0) { i++; break; }
+    }
+    let depth = 0;
+    let quote = null;
+    for (i = html.indexOf('{', i); i < html.length; i++) {
+        const ch = html[i];
+        if (quote) {
+            if (ch === '\\') i++;
+            else if (ch === quote) quote = null;
+        } else if (ch === '"' || ch === "'" || ch === '`') quote = ch;
+        else if (ch === '{') depth++;
+        else if (ch === '}' && --depth === 0) return html.slice(match.index, i + 1);
+    }
+    throw new Error('函数括号不配对: ' + name);
+}
+
+const SOURCE = ['stripThinkingMarkup', 'extractGeminiAnswer', 'doGeminiRequest', 'doAIRequest',
+    'doClaudeRequest', 'isGeminiUrl', 'extractPdfTextAsFallback', 'injectPdfTextIntoLastUser',
+    'buildGeminiContentsWithPdf', 'embedPdfForClaude', 'uint8ToBase64', 'base64ToUint8']
+    .map(extractFunction).join('\n\n');
+
+const load = new Function('i18n', 'fetch', 'window', 'pdfjsLib', 'console', SOURCE +
+    '\nreturn { stripThinkingMarkup, extractGeminiAnswer, doGeminiRequest, doAIRequest };');
+
+// respond(url, body, callIndex) -> { json } 或 { ok:false, status, json }
+function sandbox(respond, pdfjsLib) {
+    const calls = [];
+    const fetchStub = async (url, init) => {
+        const body = init && init.body ? JSON.parse(init.body) : null;
+        calls.push({ url, body });
+        const result = respond(url, body, calls.length - 1);
+        return {
+            ok: result.ok !== false,
+            status: result.status || 200,
+            json: async () => result.json,
+            text: async () => JSON.stringify(result.json)
+        };
+    };
+    const i18n = (key, ...args) => args.reduce(
+        (text, arg, idx) => text.replace(new RegExp('\\{' + idx + '\\}', 'g'), String(arg)),
+        I18N_TEMPLATES[key] || key);
+    const api = load(i18n, fetchStub, {}, pdfjsLib || null, { warn() {}, error() {}, log() {} });
+    return { api, calls };
+}
+
+// 用 index.html 里真实的模板，才能验出 i18n 占位符没被替换的情况
+const I18N_TEMPLATES = {
+    attached_pdf_text: html.match(/attached_pdf_text:'([^']*)'/)[1]
+};
+
+const GEMINI = { url: 'https://generativelanguage.googleapis.com/v1beta', key: 'k', model: 'gemini-2.5-pro' };
+const CUSTOM = { url: 'https://gateway.example.com/v1beta', key: 'k', model: 'opus-maxthinking', provider: 'custom' };
+const ONE_PAGE_PDF = {
+    getDocument: () => ({ promise: Promise.resolve({
+        numPages: 1,
+        getPage: async () => ({ getTextContent: async () => ({ items: [{ str: 'Section 7 Fatou–Julia' }] }) })
+    }) })
+};
+const PDF_ATTACHMENT = { bytes: new Uint8Array([1, 2, 3]), base64: 'AQID', name: 'ch1.pdf' };
+
+function geminiReply(parts, finishReason) {
+    return { json: { candidates: [{ finishReason: finishReason || 'STOP', content: { parts } }] } };
+}
+
+test('只保留正文，丢掉 thought 分段', () => {
+    const { api } = sandbox(() => ({ json: {} }));
+    const answer = api.extractGeminiAnswer({ candidates: [{ content: { parts: [
+        { text: "I'm trying to recall the specific arXiv paper 1506.07113", thought: true },
+        { text: '## 一、预习\n\n设 $f_c(z)=z^2+c$。' }
+    ] } }] });
+    assert.equal(answer.text, '## 一、预习\n\n设 $f_c(z)=z^2+c$。');
+    assert.equal(answer.thinking, "I'm trying to recall the specific arXiv paper 1506.07113");
+});
+
+test('只有思考时正文为空，思考不会被当成正文', () => {
+    const { api } = sandbox(() => ({ json: {} }));
+    // 网关有时把布尔发成字符串
+    const answer = api.extractGeminiAnswer({ candidates: [{ finishReason: 'MAX_TOKENS', content: { parts: [
+        { text: 'Let me reconsider with a cleaner argument.', thought: 'true' }
+    ] } }] });
+    assert.equal(answer.text, '');
+    assert.equal(answer.thinking, 'Let me reconsider with a cleaner argument.');
+    // thought:false 的分段是正文
+    assert.equal(api.extractGeminiAnswer({ candidates: [{ content: { parts: [
+        { text: '正文', thought: false }] } }] }).text, '正文');
+    // 畸形响应不炸
+    for (const payload of [null, {}, { candidates: [] }, { candidates: [{}] }]) {
+        assert.deepEqual(api.extractGeminiAnswer(payload), { text: '', thinking: '' });
+    }
+});
+
+test('内联的 <think> 标签会被清掉，正常正文不受影响', () => {
+    const { api } = sandbox(() => ({ json: {} }));
+    assert.equal(api.stripThinkingMarkup('<think>weighing options</think>\n\n# 讲义'), '# 讲义');
+    // 思考先输出、只剩一个结束标签
+    assert.equal(api.stripThinkingMarkup('recalling the lemma</thinking>\n# 讲义'), '# 讲义');
+    // 思考没写完就被截断
+    assert.equal(api.stripThinkingMarkup('# 讲义\n<reasoning>still unsure'), '# 讲义');
+    const lecture = '## 一、预习\n\n若 $|\\lambda| < 1$，则 $c = \\lambda/2 - \\lambda^2/4$。';
+    assert.equal(api.stripThinkingMarkup(lecture), lecture);
+});
+
+test('思考吃光预算时提高上限重试一次', async () => {
+    const { api, calls } = sandbox((url, body, index) => index === 0
+        ? geminiReply([{ text: 'thinking…', thought: true }], 'MAX_TOKENS')
+        : geminiReply([{ text: '## 一、预习' }]));
+    assert.equal(await api.doGeminiRequest(GEMINI, 'sys', [{ role: 'user', content: 'go' }], { maxTokens: 8192 }),
+        '## 一、预习');
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].body.generationConfig.maxOutputTokens, 8192);
+    assert.equal(calls[1].body.generationConfig.maxOutputTokens, 32768);
+});
+
+test('重试后仍然只有思考就返回空，不返回独白', async () => {
+    const { api, calls } = sandbox(() => geminiReply(
+        [{ text: "I'm working through the immediate basin argument", thought: true }], 'MAX_TOKENS'));
+    assert.equal(await api.doGeminiRequest(GEMINI, 'sys', [{ role: 'user', content: 'go' }], { maxTokens: 8192 }),
+        null);
+    assert.equal(calls.length, 2);
+});
+
+test('正常回复只请求一次', async () => {
+    const { api, calls } = sandbox(() => geminiReply([{ text: '## 一、预习' }]));
+    assert.equal(await api.doGeminiRequest(GEMINI, 'sys', [{ role: 'user', content: 'go' }], { maxTokens: 8192 }),
+        '## 一、预习');
+    assert.equal(calls.length, 1);
+});
+
+test('自定义渠道的地址和请求格式不变，PDF 换成本地提取的文本', async () => {
+    const { api, calls } = sandbox(() => geminiReply([{ text: '# 讲义' }]), ONE_PAGE_PDF);
+    const result = await api.doAIRequest(CUSTOM, 'sys', [{ role: 'user', content: '生成讲义' }],
+        { maxTokens: 8192, pdfAttachment: PDF_ATTACHMENT });
+    assert.equal(result, '# 讲义');
+    assert.equal(calls.length, 1);
+    // 仍然是 Gemini 协议的地址和请求体
+    assert.equal(calls[0].url,
+        'https://gateway.example.com/v1beta/models/opus-maxthinking:generateContent?key=k');
+    assert.ok(calls[0].body.contents, '请求体仍然是 Gemini 的 contents');
+    const parts = calls[0].body.contents[calls[0].body.contents.length - 1].parts;
+    assert.ok(!parts.some(p => p.inline_data || p.file_data), 'PDF 不再作为 Gemini 附件发送');
+    assert.match(parts[0].text, /Section 7 Fatou–Julia/);
+    assert.doesNotMatch(parts[0].text, /\{0\}/);
+});
+
+test('真正的 Gemini 端点仍然直接上传 PDF', async () => {
+    const { api, calls } = sandbox(() => geminiReply([{ text: '# 讲义' }]), ONE_PAGE_PDF);
+    await api.doAIRequest(GEMINI, 'sys', [{ role: 'user', content: '生成讲义' }],
+        { maxTokens: 8192, pdfAttachment: PDF_ATTACHMENT });
+    const parts = calls[0].body.contents[calls[0].body.contents.length - 1].parts;
+    assert.equal(parts[0].inline_data.mime_type, 'application/pdf');
+});
+
+test('OpenAI 兼容渠道只取 content，清掉内联思考', async () => {
+    const { api } = sandbox(() => ({ json: { choices: [{
+        message: { content: '<think>hmm</think>\n\n# 讲义', reasoning_content: 'hmm' }
+    }] } }));
+    assert.equal(await api.doAIRequest(
+        { url: 'https://api.deepseek.com/v1/chat/completions', key: 'k', model: 'deepseek-chat' },
+        'sys', [{ role: 'user', content: 'go' }], {}), '# 讲义');
+});


### PR DESCRIPTION
## 上一版为什么会 failed to fetch

#44 把自定义渠道从 Gemini 协议改成了 OpenAI 协议。自定义渠道填的是 Gemini 形状的地址（`.../v1beta`），改完之后 OpenAI 格式的 POST 打到这个地址上，返回的是没有 CORS 头的 404，浏览器就报 `Failed to fetch`。

**这一版不动请求地址、请求头和协议选择**（`useGemini = isGeminiUrl(url) || provider === 'custom'` 原样保留），只改真正出问题的地方。

## 改了什么

**1. 只取正文，不取思考**

`doGeminiRequest` 原来把 `candidates[0].content.parts` 全部拼起来返回，而 `thought: true` 的 part 是思考摘要不是正文，所以整篇思考被当讲义存了下来。现在只保留正文 part，并清掉网关内联的 `<think>` / `<thinking>` / `<reasoning>`（包括思考被截断、只剩半边标签的情况）。OpenAI 兼容分支同样只取 `content`，不碰 `reasoning_content`。

**2. 思考吃光输出预算时重试一次**

思考也计入 `maxOutputTokens`。maxthinking 这类模型会把讲义的 8192 预算全花在思考上（`finishReason: MAX_TOKENS`），正文一个字都不剩——这正是那份「讲义」只有思考、还在句子中间断掉的原因。现在检测到「只有思考没有正文」时自动提高一次上限重试（4 倍，32K 起、64K 封顶）；重试失败或仍然只有思考就返回空，绝不把思考当结果返回。正常回复仍然只请求一次。

**3. 自定义渠道带 PDF 改发提取出来的文本**

网关不会把 Gemini 的 `inline_data` / Files API 附件转给后面的模型——模型在思考里自己说了「I don't have direct access to the attachment content」，然后开始凭空编。所以自定义渠道带 PDF 时先在本地用 pdf.js 提取文本再随提示词发送，走的是 OpenAI/DeepSeek 渠道早就在用的同一条路。**请求地址、请求头、请求体格式都不变**，仍然是 Gemini 的 `contents`，只是把 PDF 分段换成文本。真正的 Google 端点不受影响，仍然直接上传 PDF。

**4. 顺带两处**

- `injectPdfTextIntoLastUser`：`attached_pdf_text` 是带 `{0}` 占位符的模板，之前没传参，提示词里会留下字面的 `{0}`。
- 讲义拿到空回复时不再写成「内容生成失败」并标记为已生成（那样只能手动重新生成），改为报错走失败分支，章节状态是 `error`。

## 测试

`node --test tests/*.test.js`，11 个用例全过（CI 的 build-apk 会跑）。

新增的 `tests/ai-thinking.test.js` 按函数名从 `index.html` 里抠出 `doGeminiRequest` / `doAIRequest` 等函数，配假 `fetch` 跑真实逻辑：

- thought 分段被丢掉、正文保留；只有思考时正文为空；`thought:'true'` / `thought:false` / 畸形响应都覆盖到
- 内联 `<think>` 被清掉，正常的 LaTeX 讲义正文不受影响
- 思考吃光预算时会带 32768 重试；仍然只有思考则返回 null；正常回复只请求一次
- 自定义渠道的请求地址仍是 `https://gateway/v1beta/models/<model>:generateContent?key=`、请求体仍是 Gemini 的 `contents`，PDF 换成了提取的文本，且提示词里没有残留的 `{0}`
- 真正的 Google 端点仍然以 `inline_data` 直接上传 PDF

## 没有动的地方

请求地址、请求头、协议选择、Files API、i18n 词典、Claude 分支、录音链路、摘要链路。

---
_Generated by [Claude Code](https://claude.ai/code/session_017sPHLsuqXz519de97LXKhM)_