### PR TITLE
修复 ready 无正文的死界面：自动重新生成，并显示真实报错

### DIFF
--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -13491,6 +13491,9 @@
         let activeLectureGenerationCount = 0;
         // 本次会话真正在途的章节生成（bookId/chapterId）。只存内存，不落盘
         const _lectureInflight = new Set();
+        // 本次会话已经自动补生成过的章节：每章只自动补一次，失败后改走手动按钮，
+        // 防止存储坏掉的设备反复自动重生成、白烧 API 额度
+        const _lectureAutoRegen = new Set();
         const r2ClassroomRetryTimers = new Map();
         let r2StartupMetadataReady = Promise.resolve();
         let _resolveR2StartupMetadataReady = null;
@@ -19647,6 +19650,7 @@ ${i18n('prompt_lecture_gen')}`;
                 if (!result) throw new Error(i18n('toast_content_gen_failed'));
                 const contentText = result;
                 chapter.status = 'ready';
+                delete chapter.lastError;
                 chapter.generatedAt = new Date().toISOString();
                 chapter.updatedAt = chapter.generatedAt;
                 chapter.contentUpdatedAt = chapter.generatedAt;
@@ -19672,6 +19676,8 @@ ${i18n('prompt_lecture_gen')}`;
             } catch (err) {
                 console.error('生成章节内容失败:', err);
                 chapter.status = 'error';
+                // 把真实报错留在章节上，错误界面直接显示，省得只在 toast 里一闪而过
+                chapter.lastError = String(err && err.message || err).slice(0, 300);
                 chapter.updatedAt = new Date().toISOString();
                 lectureData.updatedAt = chapter.updatedAt;
                 saveData();
@@ -19774,10 +19780,12 @@ ${i18n('prompt_lecture_gen')}`;
             }
 
             if (chapter.status === 'error') {
+                const lastError = chapter.lastError ? escapeHtml(chapter.lastError) : '';
                 container.innerHTML = `
                     <div style="text-align:center;padding:60px 20px;color:var(--text-muted);">
                         <p style="font-size:16px;margin-bottom:12px;">${i18n('generation_failed')}</p>
                         <p style="font-size:13px;margin-bottom:20px;">${i18n('network_api_retry')}</p>
+                        ${lastError ? `<p style="font-size:12px;margin-bottom:20px;word-break:break-all;">${lastError}</p>` : ''}
                         <button onclick="retryGenerateChapter()" style="padding:10px 24px;border-radius:10px;background:var(--accent);color:white;border:none;font-size:14px;font-weight:600;cursor:pointer;">${i18n('regenerate')}</button>
                     </div>`;
                 return;
@@ -19820,6 +19828,16 @@ ${i18n('prompt_lecture_gen')}`;
             }
             
             if (!contentText) {
+                // 状态是 ready 但正文在本地和云端都找不到（历史坏数据或存储被清），
+                // 这不是等用户点按钮的场景：直接按重新生成处理，别停在死界面
+                const bookExists = appData.books.some(b => b.id === currentLecture.bookId);
+                if (chapter.status === 'ready' && chapter.id && bookExists &&
+                    !_lectureAutoRegen.has(chapter.id)) {
+                    _lectureAutoRegen.add(chapter.id);
+                    console.warn('[lecture] 状态 ready 但无正文，自动重新生成:', chapter.id);
+                    retryGenerateChapter();
+                    return;
+                }
                 container.innerHTML = `
                     <div style="text-align:center;padding:60px 20px;color:var(--text-muted);">
                         <p style="font-size:16px;margin-bottom:12px;">${i18n('content_load_failed')}</p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -13491,6 +13491,9 @@
         let activeLectureGenerationCount = 0;
         // 本次会话真正在途的章节生成（bookId/chapterId）。只存内存，不落盘
         const _lectureInflight = new Set();
+        // 本次会话已经自动补生成过的章节：每章只自动补一次，失败后改走手动按钮，
+        // 防止存储坏掉的设备反复自动重生成、白烧 API 额度
+        const _lectureAutoRegen = new Set();
         const r2ClassroomRetryTimers = new Map();
         let r2StartupMetadataReady = Promise.resolve();
         let _resolveR2StartupMetadataReady = null;
@@ -19647,6 +19650,7 @@ ${i18n('prompt_lecture_gen')}`;
                 if (!result) throw new Error(i18n('toast_content_gen_failed'));
                 const contentText = result;
                 chapter.status = 'ready';
+                delete chapter.lastError;
                 chapter.generatedAt = new Date().toISOString();
                 chapter.updatedAt = chapter.generatedAt;
                 chapter.contentUpdatedAt = chapter.generatedAt;
@@ -19672,6 +19676,8 @@ ${i18n('prompt_lecture_gen')}`;
             } catch (err) {
                 console.error('生成章节内容失败:', err);
                 chapter.status = 'error';
+                // 把真实报错留在章节上，错误界面直接显示，省得只在 toast 里一闪而过
+                chapter.lastError = String(err && err.message || err).slice(0, 300);
                 chapter.updatedAt = new Date().toISOString();
                 lectureData.updatedAt = chapter.updatedAt;
                 saveData();
@@ -19774,10 +19780,12 @@ ${i18n('prompt_lecture_gen')}`;
             }
 
             if (chapter.status === 'error') {
+                const lastError = chapter.lastError ? escapeHtml(chapter.lastError) : '';
                 container.innerHTML = `
                     <div style="text-align:center;padding:60px 20px;color:var(--text-muted);">
                         <p style="font-size:16px;margin-bottom:12px;">${i18n('generation_failed')}</p>
                         <p style="font-size:13px;margin-bottom:20px;">${i18n('network_api_retry')}</p>
+                        ${lastError ? `<p style="font-size:12px;margin-bottom:20px;word-break:break-all;">${lastError}</p>` : ''}
                         <button onclick="retryGenerateChapter()" style="padding:10px 24px;border-radius:10px;background:var(--accent);color:white;border:none;font-size:14px;font-weight:600;cursor:pointer;">${i18n('regenerate')}</button>
                     </div>`;
                 return;
@@ -19820,6 +19828,16 @@ ${i18n('prompt_lecture_gen')}`;
             }
             
             if (!contentText) {
+                // 状态是 ready 但正文在本地和云端都找不到（历史坏数据或存储被清），
+                // 这不是等用户点按钮的场景：直接按重新生成处理，别停在死界面
+                const bookExists = appData.books.some(b => b.id === currentLecture.bookId);
+                if (chapter.status === 'ready' && chapter.id && bookExists &&
+                    !_lectureAutoRegen.has(chapter.id)) {
+                    _lectureAutoRegen.add(chapter.id);
+                    console.warn('[lecture] 状态 ready 但无正文，自动重新生成:', chapter.id);
+                    retryGenerateChapter();
+                    return;
+                }
                 container.innerHTML = `
                     <div style="text-align:center;padding:60px 20px;color:var(--text-muted);">
                         <p style="font-size:16px;margin-bottom:12px;">${i18n('content_load_failed')}</p>


### PR DESCRIPTION
截图里的「内容加载失败 / 未找到讲义内容」是第三条死路，和前两轮修的不是同一个问题：

章节状态被持久化成了 `ready`，但正文在内存缓存、IndexedDB、云端都不存在（此前多轮坏版本留下的脏数据，或设备存储被清）。而 `openLecture` 只对非 `ready` 状态触发生成，所以这种章节每次打开都停在这个死界面——第 7 节现在就是这个状态，代码怎么修都显示不出内容，因为它压根不会去生成。

## 改动（18 行，全部新增，不改任何现有路径）

**1. `ready` 但找不到正文 → 自动重新生成。**
`displayLectureContent` 走到「未找到讲义内容」分支且状态为 `ready` 时，直接复用 `retryGenerateChapter()`（置 pending → 生成 → 界面立即切到“生成中”），不再停在死界面等人点按钮。每章每次会话只自动补一次，若生成又失败就落到错误界面走手动按钮，防止存储坏掉的设备反复自动重生成、白烧 API 额度。书籍已被删除等取不到素材的情况维持原界面。

**2. 错误界面显示真实报错。**
生成失败时把 `err.message` 存到 `chapter.lastError`（截断 300 字符），错误界面里直接显示（经 `escapeHtml`），不再只有一闪而过的 toast 和笼统的「请检查网络或 API 设置」。下次再失败，界面上就能直接看到网关返回的具体错误（HTTP 状态码和响应内容），不用再盲猜。生成成功时清除。

## 合并后你那边的表现

更新后重新打开第 7 节：它会自动开始重新生成（走 #48 的管线：只取正文、thinking 模型给足 32768 预算、10 分钟超时）。成功就直接显示讲义；如果你的网关这次仍然出问题，界面会停在错误页并**把具体报错显示出来**——那条信息发我，我就能对着网关的真实行为修，不用再猜。

验证：整页 JS 语法检查通过；此前 7 组函数级场景重跑通过；仓库测试通过。无测试文件。

---
_Generated by [Claude Code](https://claude.ai/code/session_017sPHLsuqXz519de97LXKhM)_