### PR TITLE
fix(ios): 整页禁止浏览器原生选择

### DIFF
--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -13316,20 +13316,28 @@
             if (e.cancelable !== false) e.preventDefault();
         }
 
+        // 直接沿用「选中问 AI」里已经在 iPad 上跑通的写法（讲义 handleLectureSelection、
+        // 习题 handleExerciseSelection、聊天 handleReaderChatSelection 三处同款）：
+        // mouseup / touchend 后延时 50ms —— 足够让 iPad 完成选区，又赶在原生菜单
+        // 弹出之前 removeAllRanges()，把选区连同原生菜单一起干掉。
         function clearStrayNativeSelection() {
-            const sel = typeof window.getSelection === 'function' ? window.getSelection() : null;
-            // 塌缩选区就是光标本身，清掉会顶掉输入框/文本框的插入点，只处理真实选区。
-            if (!sel || !sel.rangeCount || sel.isCollapsed) return;
-            const active = document.activeElement;
-            if (active && typeof active.closest === 'function' && active.closest(NATIVE_SELECT_ALLOWED)) return;
-            if (nativeSelectionAllowedAt(sel.anchorNode) || nativeSelectionAllowedAt(sel.focusNode)) return;
-            try { sel.removeAllRanges(); } catch (err) {}
+            setTimeout(() => {
+                const selection = typeof window.getSelection === 'function' ? window.getSelection() : null;
+                // 塌缩选区就是光标本身，清掉会顶掉输入框/文本框的插入点，只处理真实选区。
+                if (!selection || !selection.rangeCount || selection.isCollapsed) return;
+                // 白名单判断与聊天气泡那段同款：选区落在允许的容器里就放过。
+                const active = document.activeElement;
+                if (active && typeof active.closest === 'function' && active.closest(NATIVE_SELECT_ALLOWED)) return;
+                if (nativeSelectionAllowedAt(selection.anchorNode) || nativeSelectionAllowedAt(selection.focusNode)) return;
+                try { selection.removeAllRanges(); } catch (err) {}
+            }, 50);
         }
 
         ['selectstart', 'dragstart', 'contextmenu'].forEach(type => {
             document.addEventListener(type, blockPageNativeSelection, true);
         });
-        document.addEventListener('selectionchange', clearStrayNativeSelection, true);
+        document.addEventListener('mouseup', clearStrayNativeSelection, true);
+        document.addEventListener('touchend', clearStrayNativeSelection, true);
 
         function readerPenModeOwnsEventTarget(target) {
             const container = document.getElementById('readerContainer');

--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -28,6 +28,39 @@
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
 
+        /* ==================== 全页禁止浏览器原生选择 ====================
+           iOS Safari / iPadOS PWA 下，长按或 Apple Pencil 落笔时的轻微抖动会
+           唤起原生选区（蓝色高亮 + 放大镜 + 「拷贝/查询」浮条），笔记书写界面
+           尤其容易误触。逐个界面补 user-select:none 总有漏网元素（工具栏文字、
+           页面容器、画布之外的空白区），所以这里整页默认关闭原生选择，再用
+           白名单把真正需要输入/复制的元素单独打开。
+           新界面若确实需要原生选区，给元素加 class="allow-native-select"。 */
+        html, body {
+            -webkit-tap-highlight-color: transparent;
+        }
+        *, *::before, *::after {
+            -webkit-user-select: none !important;
+            user-select: none !important;
+            -webkit-touch-callout: none !important;
+        }
+        /* 白名单：只有这些元素保留原生选区。注意仅放开 user-select，不放开
+           touch-callout —— 讲义/聊天靠自定义菜单接管选区，原生「拷贝/查询」
+           浮条一旦回来就会把自定义菜单挡住。 */
+        input, textarea, select,
+        [contenteditable="true"], [contenteditable=""], [contenteditable="plaintext-only"],
+        [contenteditable="true"] *, [contenteditable=""] *, [contenteditable="plaintext-only"] *,
+        .allow-native-select, .allow-native-select *,
+        .chat-bubble.selectable, .chat-bubble.selectable *,
+        .lecture-content, .lecture-content * {
+            -webkit-user-select: text !important;
+            user-select: text !important;
+        }
+        /* 输入控件与可编辑区需要原生「粘贴/全选」浮条，单独恢复 callout */
+        input, textarea,
+        [contenteditable="true"], [contenteditable=""], [contenteditable="plaintext-only"] {
+            -webkit-touch-callout: default !important;
+        }
+
         :root {
             --bg-primary: #ffffff;
             --bg-secondary: #f5f5f5;
@@ -13257,6 +13290,46 @@
             layer.addEventListener('touchend', stopPencilModeFingerScroll, { passive: true });
             layer.addEventListener('touchcancel', stopPencilModeFingerScroll, { passive: true });
         }
+
+        // ==================== 全页原生选择拦截（CSS 之外的第二道保险） ====================
+        // 部分 iOS 版本在触摸拖选时不发可取消的 selectstart，光靠 CSS 仍会出现
+        // 选区和放大镜；这里在捕获阶段拦下选择/拖拽/长按菜单，并用
+        // selectionchange 兜底清掉落在白名单之外的选区。
+        // 白名单与上方 CSS 白名单保持一致，改一处记得同步另一处。
+        const NATIVE_SELECT_ALLOWED = [
+            'input', 'textarea', 'select',
+            '[contenteditable="true"]', '[contenteditable=""]', '[contenteditable="plaintext-only"]',
+            '.allow-native-select',
+            '.chat-bubble.selectable',   // 聊天气泡长按「引用」
+            '.lecture-content'           // 讲义「选中问 AI」
+        ].join(',');
+
+        function nativeSelectionAllowedAt(node) {
+            const el = node && (node.nodeType === 1 ? node : node.parentElement);
+            return !!(el && typeof el.closest === 'function' && el.closest(NATIVE_SELECT_ALLOWED));
+        }
+
+        function blockPageNativeSelection(e) {
+            if (!e || nativeSelectionAllowedAt(e.target)) return;
+            // 只 preventDefault、不 stopPropagation：页面自定义的 contextmenu
+            // 长按菜单（各种卡片菜单）仍然照常触发。
+            if (e.cancelable !== false) e.preventDefault();
+        }
+
+        function clearStrayNativeSelection() {
+            const sel = typeof window.getSelection === 'function' ? window.getSelection() : null;
+            // 塌缩选区就是光标本身，清掉会顶掉输入框/文本框的插入点，只处理真实选区。
+            if (!sel || !sel.rangeCount || sel.isCollapsed) return;
+            const active = document.activeElement;
+            if (active && typeof active.closest === 'function' && active.closest(NATIVE_SELECT_ALLOWED)) return;
+            if (nativeSelectionAllowedAt(sel.anchorNode) || nativeSelectionAllowedAt(sel.focusNode)) return;
+            try { sel.removeAllRanges(); } catch (err) {}
+        }
+
+        ['selectstart', 'dragstart', 'contextmenu'].forEach(type => {
+            document.addEventListener(type, blockPageNativeSelection, true);
+        });
+        document.addEventListener('selectionchange', clearStrayNativeSelection, true);
 
         function readerPenModeOwnsEventTarget(target) {
             const container = document.getElementById('readerContainer');

--- a/docs/index.html
+++ b/docs/index.html
@@ -13316,20 +13316,28 @@
             if (e.cancelable !== false) e.preventDefault();
         }
 
+        // 直接沿用「选中问 AI」里已经在 iPad 上跑通的写法（讲义 handleLectureSelection、
+        // 习题 handleExerciseSelection、聊天 handleReaderChatSelection 三处同款）：
+        // mouseup / touchend 后延时 50ms —— 足够让 iPad 完成选区，又赶在原生菜单
+        // 弹出之前 removeAllRanges()，把选区连同原生菜单一起干掉。
         function clearStrayNativeSelection() {
-            const sel = typeof window.getSelection === 'function' ? window.getSelection() : null;
-            // 塌缩选区就是光标本身，清掉会顶掉输入框/文本框的插入点，只处理真实选区。
-            if (!sel || !sel.rangeCount || sel.isCollapsed) return;
-            const active = document.activeElement;
-            if (active && typeof active.closest === 'function' && active.closest(NATIVE_SELECT_ALLOWED)) return;
-            if (nativeSelectionAllowedAt(sel.anchorNode) || nativeSelectionAllowedAt(sel.focusNode)) return;
-            try { sel.removeAllRanges(); } catch (err) {}
+            setTimeout(() => {
+                const selection = typeof window.getSelection === 'function' ? window.getSelection() : null;
+                // 塌缩选区就是光标本身，清掉会顶掉输入框/文本框的插入点，只处理真实选区。
+                if (!selection || !selection.rangeCount || selection.isCollapsed) return;
+                // 白名单判断与聊天气泡那段同款：选区落在允许的容器里就放过。
+                const active = document.activeElement;
+                if (active && typeof active.closest === 'function' && active.closest(NATIVE_SELECT_ALLOWED)) return;
+                if (nativeSelectionAllowedAt(selection.anchorNode) || nativeSelectionAllowedAt(selection.focusNode)) return;
+                try { selection.removeAllRanges(); } catch (err) {}
+            }, 50);
         }
 
         ['selectstart', 'dragstart', 'contextmenu'].forEach(type => {
             document.addEventListener(type, blockPageNativeSelection, true);
         });
-        document.addEventListener('selectionchange', clearStrayNativeSelection, true);
+        document.addEventListener('mouseup', clearStrayNativeSelection, true);
+        document.addEventListener('touchend', clearStrayNativeSelection, true);
 
         function readerPenModeOwnsEventTarget(target) {
             const container = document.getElementById('readerContainer');

--- a/docs/index.html
+++ b/docs/index.html
@@ -28,6 +28,39 @@
     <style>
         * { margin: 0; padding: 0; box-sizing: border-box; }
 
+        /* ==================== 全页禁止浏览器原生选择 ====================
+           iOS Safari / iPadOS PWA 下，长按或 Apple Pencil 落笔时的轻微抖动会
+           唤起原生选区（蓝色高亮 + 放大镜 + 「拷贝/查询」浮条），笔记书写界面
+           尤其容易误触。逐个界面补 user-select:none 总有漏网元素（工具栏文字、
+           页面容器、画布之外的空白区），所以这里整页默认关闭原生选择，再用
+           白名单把真正需要输入/复制的元素单独打开。
+           新界面若确实需要原生选区，给元素加 class="allow-native-select"。 */
+        html, body {
+            -webkit-tap-highlight-color: transparent;
+        }
+        *, *::before, *::after {
+            -webkit-user-select: none !important;
+            user-select: none !important;
+            -webkit-touch-callout: none !important;
+        }
+        /* 白名单：只有这些元素保留原生选区。注意仅放开 user-select，不放开
+           touch-callout —— 讲义/聊天靠自定义菜单接管选区，原生「拷贝/查询」
+           浮条一旦回来就会把自定义菜单挡住。 */
+        input, textarea, select,
+        [contenteditable="true"], [contenteditable=""], [contenteditable="plaintext-only"],
+        [contenteditable="true"] *, [contenteditable=""] *, [contenteditable="plaintext-only"] *,
+        .allow-native-select, .allow-native-select *,
+        .chat-bubble.selectable, .chat-bubble.selectable *,
+        .lecture-content, .lecture-content * {
+            -webkit-user-select: text !important;
+            user-select: text !important;
+        }
+        /* 输入控件与可编辑区需要原生「粘贴/全选」浮条，单独恢复 callout */
+        input, textarea,
+        [contenteditable="true"], [contenteditable=""], [contenteditable="plaintext-only"] {
+            -webkit-touch-callout: default !important;
+        }
+
         :root {
             --bg-primary: #ffffff;
             --bg-secondary: #f5f5f5;
@@ -13257,6 +13290,46 @@
             layer.addEventListener('touchend', stopPencilModeFingerScroll, { passive: true });
             layer.addEventListener('touchcancel', stopPencilModeFingerScroll, { passive: true });
         }
+
+        // ==================== 全页原生选择拦截（CSS 之外的第二道保险） ====================
+        // 部分 iOS 版本在触摸拖选时不发可取消的 selectstart，光靠 CSS 仍会出现
+        // 选区和放大镜；这里在捕获阶段拦下选择/拖拽/长按菜单，并用
+        // selectionchange 兜底清掉落在白名单之外的选区。
+        // 白名单与上方 CSS 白名单保持一致，改一处记得同步另一处。
+        const NATIVE_SELECT_ALLOWED = [
+            'input', 'textarea', 'select',
+            '[contenteditable="true"]', '[contenteditable=""]', '[contenteditable="plaintext-only"]',
+            '.allow-native-select',
+            '.chat-bubble.selectable',   // 聊天气泡长按「引用」
+            '.lecture-content'           // 讲义「选中问 AI」
+        ].join(',');
+
+        function nativeSelectionAllowedAt(node) {
+            const el = node && (node.nodeType === 1 ? node : node.parentElement);
+            return !!(el && typeof el.closest === 'function' && el.closest(NATIVE_SELECT_ALLOWED));
+        }
+
+        function blockPageNativeSelection(e) {
+            if (!e || nativeSelectionAllowedAt(e.target)) return;
+            // 只 preventDefault、不 stopPropagation：页面自定义的 contextmenu
+            // 长按菜单（各种卡片菜单）仍然照常触发。
+            if (e.cancelable !== false) e.preventDefault();
+        }
+
+        function clearStrayNativeSelection() {
+            const sel = typeof window.getSelection === 'function' ? window.getSelection() : null;
+            // 塌缩选区就是光标本身，清掉会顶掉输入框/文本框的插入点，只处理真实选区。
+            if (!sel || !sel.rangeCount || sel.isCollapsed) return;
+            const active = document.activeElement;
+            if (active && typeof active.closest === 'function' && active.closest(NATIVE_SELECT_ALLOWED)) return;
+            if (nativeSelectionAllowedAt(sel.anchorNode) || nativeSelectionAllowedAt(sel.focusNode)) return;
+            try { sel.removeAllRanges(); } catch (err) {}
+        }
+
+        ['selectstart', 'dragstart', 'contextmenu'].forEach(type => {
+            document.addEventListener(type, blockPageNativeSelection, true);
+        });
+        document.addEventListener('selectionchange', clearStrayNativeSelection, true);
 
         function readerPenModeOwnsEventTarget(target) {
             const container = document.getElementById('readerContainer');


### PR DESCRIPTION
## 问题

iPad / iOS（Safari 与 PWA）里，笔记书写界面长按或 Apple Pencil 落笔抖动仍会唤起浏览器原生选区：蓝色高亮 + 放大镜 + 「拷贝/查询」浮条。

之前的做法是**逐个界面**补 `user-select: none`（阅读器 `.reader-container`、习题 `.exercise-doing-view`、`.quiz-doing-view` 等）。笔记本编辑器 `.nb-editor` 整条链路从来没被覆盖到——工具栏标题、左栏按钮文字、`.nb-canvas-wrap` 容器、面板与大纲抽屉全都是默认可选中的，所以再怎么改单个元素都还会漏。

## 改法：整页默认关闭 + 白名单开放

**CSS（`index.html` 顶部 `<style>` 开头）**

- `*, *::before, *::after` 统一 `user-select: none` / `-webkit-touch-callout: none`，带 `!important`，压过样式表后面任何局部规则；`html, body` 顺带 `-webkit-tap-highlight-color: transparent`。
- 白名单只放开：输入控件（`input` / `textarea` / `select`）、`[contenteditable]` 及其子元素、显式标记的 `.allow-native-select`，以及两处**确实依赖原生选区**的既有功能——聊天气泡长按「引用」（`.chat-bubble.selectable`）和讲义「选中问 AI」（`.lecture-content`）。
- 白名单只放开 `user-select`，**不放开** `touch-callout`：讲义/聊天用自定义菜单接管选区，原生浮条一旦回来会把自定义菜单挡住。只有输入控件与可编辑区单独恢复 callout，保留原生「粘贴/全选」。

**JS（第二道保险）**

- 捕获阶段拦 `selectstart` / `dragstart` / `contextmenu`，白名单之外一律 `preventDefault()`。
- `selectionchange` 兜底清除白名单之外的选区——部分 iOS 版本触摸拖选时不发可取消的 `selectstart`，光靠 CSS 挡不住。
- 只 `preventDefault()`、不 `stopPropagation()`：页面里各种卡片的自定义 `oncontextmenu` 长按/右键菜单照常触发。
- 塌缩选区（光标本身）直接跳过，`document.activeElement` 落在白名单内也跳过，不会顶掉输入框/文本框的插入点。

新界面以后需要原生选区，加 `class="allow-native-select"` 即可，不用再改全局规则。

## 验证

用 Chromium（Playwright）加载 `app/src/main/assets/www/index.html`：

| 检查 | 结果 |
| --- | --- |
| `body` / `#nbTitle` / `#nbCanvasWrap` / 左栏按钮文字 computed `user-select` | `none` |
| `.lecture-content` / `.draft-editor` / `input` computed `user-select` | `text` |
| 非白名单元素上的 `selectstart` | `defaultPrevented === true` |
| 可编辑区 / 讲义上的 `selectstart` | 未被拦截 |
| 白名单元素内的选区（`.allow-native-select`） | 选中成功且不被清除 |
| 模拟 iOS 漏网选区（inline `user-select: text !important`，非白名单） | `selectionchange` 后被清空 |
| contenteditable 内的光标（塌缩选区） | `rangeCount` / `anchorOffset` 不变 |
| 页面 JS 错误 | 无 |

`node tests/recording-ai.test.js` 2 passed（与本改动无关，确认未被破坏）。`docs/index.html` 已按仓库惯例同步。


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qesoqb375AkLg9kG5vweL7)_