### PR TITLE
Fix cloud sync interrupting reader AI chat

### DIFF
--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -13570,6 +13570,7 @@
         let r2SyncInProgress = false;
         let r2PendingSyncQueue = []; // 排队等待的文件变更同步任务队列
         let activeLectureGenerationCount = 0;
+        let activeReaderChatGenerationCount = 0;
         const r2ClassroomRetryTimers = new Map();
         let r2StartupMetadataReady = Promise.resolve();
         let _resolveR2StartupMetadataReady = null;
@@ -13602,6 +13603,22 @@
             return !CLASSROOM_ONLY_METADATA_ACTIONS.includes(action);
         }
         let r2DeferredMetadataPublish = false;
+
+        function isR2SyncDeferredByGeneration() {
+            return activeLectureGenerationCount > 0 || activeReaderChatGenerationCount > 0;
+        }
+
+        function flushR2PendingSyncAfterGeneration() {
+            if (isR2SyncDeferredByGeneration() || r2SyncInProgress || r2PendingSyncQueue.length === 0) {
+                return;
+            }
+            const lectureUploadIndex = r2PendingSyncQueue.findIndex(item =>
+                item.action === 'lecture_upload');
+            const pending = lectureUploadIndex >= 0
+                ? r2PendingSyncQueue.splice(lectureUploadIndex, 1)[0]
+                : r2PendingSyncQueue.shift();
+            triggerSyncOnFileChange(pending.fileId, pending.action, pending.attempt || 0);
+        }
 
         function mergeClassroomTombstones(...sources) {
             const merged = new Map();
@@ -13834,8 +13851,8 @@
                 console.warn('[sync] 数据未加载完成，跳过定时同步');
                 return;
             }
-            if (activeLectureGenerationCount > 0) {
-                console.log('[sync] 讲义仍在生成，延后定时同步');
+            if (isR2SyncDeferredByGeneration()) {
+                console.log('[sync] AI 内容仍在生成，延后定时同步');
                 return;
             }
             const config = appData.settings.r2Config;
@@ -15038,7 +15055,7 @@
                 return;
             }
 
-            if (activeLectureGenerationCount > 0) {
+            if (isR2SyncDeferredByGeneration()) {
                 if (!r2PendingSyncQueue.some(t => t.fileId === fileId && t.action === action)) {
                     r2PendingSyncQueue.push({ fileId, action, attempt });
                 }
@@ -18084,7 +18101,7 @@
             return [];
         }
 
-        function saveReaderChatHistory(docId, history) {
+        function saveReaderChatHistory(docId, history, syncToCloud = true) {
             // Keep max 30 messages
             if (history.length > 30) {
                 history = history.slice(-30);
@@ -18101,8 +18118,17 @@
                 });
                 try { saveData(); } catch (e) { console.error('saveData failed:', e); }
                 doc.chatHistory = orig;
-                // 立即同步到云端防止数据丢失
-                debouncedChatSync();
+                if (syncToCloud) debouncedChatSync();
+            }
+        }
+
+        async function finishReaderChatGeneration() {
+            try {
+                // 计数仍大于 0，此调用只会把最终完整聊天记录放入同步队列。
+                await triggerSyncOnFileChange(null, 'metadata_update');
+            } finally {
+                activeReaderChatGenerationCount = Math.max(0, activeReaderChatGenerationCount - 1);
+                flushR2PendingSyncAfterGeneration();
             }
         }
 
@@ -18479,7 +18505,7 @@
             // Update this message and remove all messages after it
             history[index].content = newText.trim();
             history = history.slice(0, index + 1);
-            saveReaderChatHistory(currentDoc.id, history);
+            saveReaderChatHistory(currentDoc.id, history, false);
             renderReaderChatHistory();
 
             // Re-send to get new AI response
@@ -18488,6 +18514,7 @@
 
         async function resendReaderChatFromIndex(userMsgIndex) {
             if (!currentDoc) return;
+            activeReaderChatGenerationCount++;
             let history = loadReaderChatHistory(currentDoc.id);
 
             // Build system prompt
@@ -18524,12 +18551,14 @@
                 document.getElementById('readerChatLoading')?.remove();
                 if (result) {
                     history.push({ role: 'assistant', content: result });
-                    saveReaderChatHistory(currentDoc.id, history);
+                    saveReaderChatHistory(currentDoc.id, history, false);
                     renderReaderChatHistory();
                 }
             } catch (err) {
                 document.getElementById('readerChatLoading')?.remove();
                 showToast(i18n('toast_regen_failed') + err.message);
+            } finally {
+                await finishReaderChatGeneration();
             }
         }
 
@@ -18543,7 +18572,7 @@
 
             // Remove this AI message and all subsequent messages
             history = history.slice(0, index);
-            saveReaderChatHistory(currentDoc.id, history);
+            saveReaderChatHistory(currentDoc.id, history, false);
             renderReaderChatHistory();
 
             // Find last user message to re-send
@@ -18591,7 +18620,7 @@
             const input = document.getElementById('readerChatInput');
             const message = input.value.trim();
             if (!message || !currentDoc) return;
-
+            activeReaderChatGenerationCount++;
             input.value = '';
 
             // 附带引用内容（若有），随后清除引用预览
@@ -18603,7 +18632,7 @@
             const userMsg = { role: 'user', content: message };
             if (quote) userMsg.quote = quote;
             history.push(userMsg);
-            saveReaderChatHistory(currentDoc.id, history);
+            saveReaderChatHistory(currentDoc.id, history, false);
             renderReaderChatHistory();
 
             // 切出当前页PDF作为附件发给AI
@@ -18650,7 +18679,7 @@
 
                 if (result) {
                     history.push({ role: 'assistant', content: result });
-                    saveReaderChatHistory(currentDoc.id, history);
+                    saveReaderChatHistory(currentDoc.id, history, false);
                     renderReaderChatHistory();
                 } else {
                     document.getElementById('readerChatLoading')?.remove();
@@ -18663,15 +18692,17 @@
                     ];
                     const fallback = replies[Math.floor(Math.random() * replies.length)];
                     history.push({ role: 'assistant', content: fallback });
-                    saveReaderChatHistory(currentDoc.id, history);
+                    saveReaderChatHistory(currentDoc.id, history, false);
                     renderReaderChatHistory();
                 }
             } catch (e) {
                 console.error('Reader chat error:', e);
                 document.getElementById('readerChatLoading')?.remove();
                 history.push({ role: 'assistant', content: i18n('request_failed') + (e.message || i18n('unknown_error')) });
-                saveReaderChatHistory(currentDoc.id, history);
+                saveReaderChatHistory(currentDoc.id, history, false);
                 renderReaderChatHistory();
+            } finally {
+                await finishReaderChatGeneration();
             }
         }
 
@@ -19702,14 +19733,7 @@ ${i18n('prompt_lecture_gen')}`;
                 renderNotesPage();
             } finally {
                 activeLectureGenerationCount = Math.max(0, activeLectureGenerationCount - 1);
-                if (activeLectureGenerationCount === 0 && !r2SyncInProgress && r2PendingSyncQueue.length > 0) {
-                    const lectureUploadIndex = r2PendingSyncQueue.findIndex(item =>
-                        item.action === 'lecture_upload');
-                    const pending = lectureUploadIndex >= 0
-                        ? r2PendingSyncQueue.splice(lectureUploadIndex, 1)[0]
-                        : r2PendingSyncQueue.shift();
-                    triggerSyncOnFileChange(pending.fileId, pending.action, pending.attempt || 0);
-                }
+                flushR2PendingSyncAfterGeneration();
             }
         }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -13570,6 +13570,7 @@
         let r2SyncInProgress = false;
         let r2PendingSyncQueue = []; // 排队等待的文件变更同步任务队列
         let activeLectureGenerationCount = 0;
+        let activeReaderChatGenerationCount = 0;
         const r2ClassroomRetryTimers = new Map();
         let r2StartupMetadataReady = Promise.resolve();
         let _resolveR2StartupMetadataReady = null;
@@ -13602,6 +13603,22 @@
             return !CLASSROOM_ONLY_METADATA_ACTIONS.includes(action);
         }
         let r2DeferredMetadataPublish = false;
+
+        function isR2SyncDeferredByGeneration() {
+            return activeLectureGenerationCount > 0 || activeReaderChatGenerationCount > 0;
+        }
+
+        function flushR2PendingSyncAfterGeneration() {
+            if (isR2SyncDeferredByGeneration() || r2SyncInProgress || r2PendingSyncQueue.length === 0) {
+                return;
+            }
+            const lectureUploadIndex = r2PendingSyncQueue.findIndex(item =>
+                item.action === 'lecture_upload');
+            const pending = lectureUploadIndex >= 0
+                ? r2PendingSyncQueue.splice(lectureUploadIndex, 1)[0]
+                : r2PendingSyncQueue.shift();
+            triggerSyncOnFileChange(pending.fileId, pending.action, pending.attempt || 0);
+        }
 
         function mergeClassroomTombstones(...sources) {
             const merged = new Map();
@@ -13834,8 +13851,8 @@
                 console.warn('[sync] 数据未加载完成，跳过定时同步');
                 return;
             }
-            if (activeLectureGenerationCount > 0) {
-                console.log('[sync] 讲义仍在生成，延后定时同步');
+            if (isR2SyncDeferredByGeneration()) {
+                console.log('[sync] AI 内容仍在生成，延后定时同步');
                 return;
             }
             const config = appData.settings.r2Config;
@@ -15038,7 +15055,7 @@
                 return;
             }
 
-            if (activeLectureGenerationCount > 0) {
+            if (isR2SyncDeferredByGeneration()) {
                 if (!r2PendingSyncQueue.some(t => t.fileId === fileId && t.action === action)) {
                     r2PendingSyncQueue.push({ fileId, action, attempt });
                 }
@@ -18084,7 +18101,7 @@
             return [];
         }
 
-        function saveReaderChatHistory(docId, history) {
+        function saveReaderChatHistory(docId, history, syncToCloud = true) {
             // Keep max 30 messages
             if (history.length > 30) {
                 history = history.slice(-30);
@@ -18101,8 +18118,17 @@
                 });
                 try { saveData(); } catch (e) { console.error('saveData failed:', e); }
                 doc.chatHistory = orig;
-                // 立即同步到云端防止数据丢失
-                debouncedChatSync();
+                if (syncToCloud) debouncedChatSync();
+            }
+        }
+
+        async function finishReaderChatGeneration() {
+            try {
+                // 计数仍大于 0，此调用只会把最终完整聊天记录放入同步队列。
+                await triggerSyncOnFileChange(null, 'metadata_update');
+            } finally {
+                activeReaderChatGenerationCount = Math.max(0, activeReaderChatGenerationCount - 1);
+                flushR2PendingSyncAfterGeneration();
             }
         }
 
@@ -18479,7 +18505,7 @@
             // Update this message and remove all messages after it
             history[index].content = newText.trim();
             history = history.slice(0, index + 1);
-            saveReaderChatHistory(currentDoc.id, history);
+            saveReaderChatHistory(currentDoc.id, history, false);
             renderReaderChatHistory();
 
             // Re-send to get new AI response
@@ -18488,6 +18514,7 @@
 
         async function resendReaderChatFromIndex(userMsgIndex) {
             if (!currentDoc) return;
+            activeReaderChatGenerationCount++;
             let history = loadReaderChatHistory(currentDoc.id);
 
             // Build system prompt
@@ -18524,12 +18551,14 @@
                 document.getElementById('readerChatLoading')?.remove();
                 if (result) {
                     history.push({ role: 'assistant', content: result });
-                    saveReaderChatHistory(currentDoc.id, history);
+                    saveReaderChatHistory(currentDoc.id, history, false);
                     renderReaderChatHistory();
                 }
             } catch (err) {
                 document.getElementById('readerChatLoading')?.remove();
                 showToast(i18n('toast_regen_failed') + err.message);
+            } finally {
+                await finishReaderChatGeneration();
             }
         }
 
@@ -18543,7 +18572,7 @@
 
             // Remove this AI message and all subsequent messages
             history = history.slice(0, index);
-            saveReaderChatHistory(currentDoc.id, history);
+            saveReaderChatHistory(currentDoc.id, history, false);
             renderReaderChatHistory();
 
             // Find last user message to re-send
@@ -18591,7 +18620,7 @@
             const input = document.getElementById('readerChatInput');
             const message = input.value.trim();
             if (!message || !currentDoc) return;
-
+            activeReaderChatGenerationCount++;
             input.value = '';
 
             // 附带引用内容（若有），随后清除引用预览
@@ -18603,7 +18632,7 @@
             const userMsg = { role: 'user', content: message };
             if (quote) userMsg.quote = quote;
             history.push(userMsg);
-            saveReaderChatHistory(currentDoc.id, history);
+            saveReaderChatHistory(currentDoc.id, history, false);
             renderReaderChatHistory();
 
             // 切出当前页PDF作为附件发给AI
@@ -18650,7 +18679,7 @@
 
                 if (result) {
                     history.push({ role: 'assistant', content: result });
-                    saveReaderChatHistory(currentDoc.id, history);
+                    saveReaderChatHistory(currentDoc.id, history, false);
                     renderReaderChatHistory();
                 } else {
                     document.getElementById('readerChatLoading')?.remove();
@@ -18663,15 +18692,17 @@
                     ];
                     const fallback = replies[Math.floor(Math.random() * replies.length)];
                     history.push({ role: 'assistant', content: fallback });
-                    saveReaderChatHistory(currentDoc.id, history);
+                    saveReaderChatHistory(currentDoc.id, history, false);
                     renderReaderChatHistory();
                 }
             } catch (e) {
                 console.error('Reader chat error:', e);
                 document.getElementById('readerChatLoading')?.remove();
                 history.push({ role: 'assistant', content: i18n('request_failed') + (e.message || i18n('unknown_error')) });
-                saveReaderChatHistory(currentDoc.id, history);
+                saveReaderChatHistory(currentDoc.id, history, false);
                 renderReaderChatHistory();
+            } finally {
+                await finishReaderChatGeneration();
             }
         }
 
@@ -19702,14 +19733,7 @@ ${i18n('prompt_lecture_gen')}`;
                 renderNotesPage();
             } finally {
                 activeLectureGenerationCount = Math.max(0, activeLectureGenerationCount - 1);
-                if (activeLectureGenerationCount === 0 && !r2SyncInProgress && r2PendingSyncQueue.length > 0) {
-                    const lectureUploadIndex = r2PendingSyncQueue.findIndex(item =>
-                        item.action === 'lecture_upload');
-                    const pending = lectureUploadIndex >= 0
-                        ? r2PendingSyncQueue.splice(lectureUploadIndex, 1)[0]
-                        : r2PendingSyncQueue.shift();
-                    triggerSyncOnFileChange(pending.fileId, pending.action, pending.attempt || 0);
-                }
+                flushR2PendingSyncAfterGeneration();
             }
         }
 


### PR DESCRIPTION
## 问题
阅读界面左上角 AI 聊天在回复生成期间会触发 metadata 云同步。同步与 AI 请求并行时，当前聊天状态可能被合并流程打断，表现为回复截断。

## 修复
- 为阅读器 AI 聊天增加生成计数，和讲义生成共用云同步延后判断
- 发送、编辑重问、重新生成期间只保存本地聊天状态
- 完整回复或错误结果落盘后，再排队并放行一次 metadata 同步
- 定时同步和文件变更同步在生成期间统一延后
- 同步更新 Android assets 与 GitHub Pages 副本

## 验证
- 两份 index.html 完全一致
- 两份内联 JavaScript 均通过语法解析
- git diff --check 通过

未运行无关的全量 Android 构建。