### PR TITLE
Apply Apple Pencil mode to notebook writing

### DIFF
--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -28488,6 +28488,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             nbState.redoStack = [];
             nbState.selection = null;
             nbState.bgImageCache = {};
+            nbState.drawing = null;
             nbResetNotebookTouchGesture();
             document.body.classList.add('nb-editor-active');
             document.getElementById('nbEditor').classList.add('show');
@@ -28504,12 +28505,13 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             ++_nbOpenRequestToken;
             ++_nbPageLoadToken;
             const closingPageId = nbCurrentPage() && nbCurrentPage().id;
+            nbFinishActiveNotebookGesture();
+            nbResetNotebookTouchGesture();
             nbFlushPositionSync();
             await nbSavePageNow();
             nbHidePanel();
             nbHideOutline();
             nbClearSelection();
-            nbResetNotebookTouchGesture();
             nbForceClearNotebookNativeSelection();
             document.getElementById('nbEditor').classList.remove('show');
             document.body.classList.remove('nb-editor-active', 'nb-text-mode');
@@ -28565,6 +28567,8 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         async function nbLoadPage(index, syncPosition = true) {
             const loadToken = ++_nbPageLoadToken;
             const notebookId = nbState.notebookId;
+            nbFinishActiveNotebookGesture();
+            nbResetNotebookTouchGesture();
             await nbSavePageNow();
             if (loadToken !== _nbPageLoadToken || nbState.notebookId !== notebookId) return false;
             const nb = nbGetNotebook(notebookId);
@@ -29154,6 +29158,10 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
         function nbNotebookTouchStart(e) {
             if (!applePencilMode || !nbNotebookSelectionGuardActive()) return;
+            if (nbFocusedNativeSelectionControlAt(e.target)) {
+                nbResetNotebookTouchGesture();
+                return;
+            }
             if (nbState.drawing) {
                 nbResetNotebookTouchGesture();
                 return;
@@ -29178,6 +29186,10 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
         function nbNotebookTouchMove(e) {
             if (!applePencilMode || !nbNotebookSelectionGuardActive()) {
+                nbResetNotebookTouchGesture();
+                return;
+            }
+            if (nbFocusedNativeSelectionControlAt(e.target)) {
                 nbResetNotebookTouchGesture();
                 return;
             }
@@ -29241,7 +29253,8 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 wrap.scrollTop = (oldScrollTop + viewportY) * ratio - viewportY;
             }
 
-            if (commitZoom && applePencilMode && e?.touches?.length === 1 &&
+            if (commitZoom && applePencilMode && !nbFocusedNativeSelectionControlAt(e?.target) &&
+                e?.touches?.length === 1 &&
                 nbDirectFingerTouch(e.touches[0])) {
                 _nbTouchGesture = {
                     mode: 'pan',
@@ -29253,6 +29266,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
         function nbInitCanvasEvents() {
             const c = document.getElementById('nbCanvas');
+            const touchSurface = document.getElementById('nbPageBox');
             if (c._nbBound) return;
             c._nbBound = true;
             c.addEventListener('pointerdown', nbPointerDown);
@@ -29260,10 +29274,10 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             c.addEventListener('pointerup', nbPointerUp);
             c.addEventListener('pointercancel', nbPointerUp);
             c.addEventListener('contextmenu', e => e.preventDefault());
-            c.addEventListener('touchstart', nbNotebookTouchStart, { passive: false });
-            c.addEventListener('touchmove', nbNotebookTouchMove, { passive: false });
-            c.addEventListener('touchend', e => nbFinishNotebookTouchGesture(e, true), { passive: true });
-            c.addEventListener('touchcancel', e => nbFinishNotebookTouchGesture(e, false), { passive: true });
+            touchSurface.addEventListener('touchstart', nbNotebookTouchStart, { passive: false });
+            touchSurface.addEventListener('touchmove', nbNotebookTouchMove, { passive: false });
+            touchSurface.addEventListener('touchend', e => nbFinishNotebookTouchGesture(e, true), { passive: true });
+            touchSurface.addEventListener('touchcancel', e => nbFinishNotebookTouchGesture(e, false), { passive: true });
             ['selectstart', 'dragstart', 'contextmenu'].forEach(type => {
                 document.addEventListener(type, nbBlockNotebookNativeSelection, true);
             });
@@ -29273,12 +29287,18 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             document.addEventListener('touchcancel', nbScheduleNotebookNativeSelectionClear, true);
             document.addEventListener('pointerup', nbScheduleNotebookNativeSelectionClear, true);
             document.addEventListener('pointercancel', nbScheduleNotebookNativeSelectionClear, true);
+            document.addEventListener('pointerup', nbPointerUp, true);
+            document.addEventListener('pointercancel', nbPointerUp, true);
             document.addEventListener('pointerdown', nbBlurNotebookControlOnOutsidePointer, true);
         }
 
         function nbPointerDown(e) {
-            if (e.button === 2 || nbState.drawing) return;
+            if (e.button === 2) return;
             if (applePencilMode && !booxReaderIsPen(e)) return;
+            if (nbState.drawing) {
+                if (!applePencilMode || nbState.drawing.pointerId === e.pointerId) return;
+                nbFinishActiveNotebookGesture();
+            }
             nbBlurNotebookTextEditing();
             nbHidePanel();
             nbHideOutline();
@@ -29385,10 +29405,11 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             if (d.mode === 'lasso' || d.mode === 'shape') nbDrawOverlay();
         }
 
-        function nbPointerUp(e) {
+        function nbFinishActiveNotebookGesture() {
             const d = nbState.drawing;
-            if (!d || d.pointerId !== e.pointerId) return;
+            if (!d) return;
             nbState.drawing = null;
+            if (!nbState.content) return;
             if (d.mode === 'stroke') {
                 const pts = d.stroke.paths[0];
                 if (pts.length >= 1) {
@@ -29429,6 +29450,12 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 }
                 nbDrawOverlay();
             }
+        }
+
+        function nbPointerUp(e) {
+            const d = nbState.drawing;
+            if (!d || d.pointerId !== e.pointerId) return;
+            nbFinishActiveNotebookGesture();
         }
 
         // ---------- 笔画橡皮擦：整笔擦除 ----------
@@ -29802,13 +29829,21 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 if (e.target.classList.contains('nb-tb-corner') || e.target.classList.contains('nb-media-del')) return;
                 const editing = document.activeElement === inner;
                 if (editing && e.target === inner) return;   // 编辑中不拦截光标操作
+                if (applePencilMode && !booxReaderIsPen(e)) {
+                    // 未进入编辑的文本框仍属于手指滚动区域；阻止 pointerdown
+                    // 默认聚焦，否则随后的 touchstart 会被误判成原生文本编辑。
+                    e.preventDefault();
+                    return;
+                }
                 e.preventDefault();
                 e.stopPropagation();
                 nbSelectTextBox(box.id);
                 const s = nbDisplayScale();
+                const pointerId = e.pointerId;
                 const sx = e.clientX, sy = e.clientY, ox = box.x, oy = box.y;
                 let moved = false;
                 const mv = (ev) => {
+                    if (ev.pointerId !== pointerId) return;
                     const dx = (ev.clientX - sx) / s, dy = (ev.clientY - sy) / s;
                     if (Math.abs(dx) > 2 || Math.abs(dy) > 2) moved = true;
                     box.x = Math.round(ox + dx);
@@ -29817,12 +29852,14 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     el.style.top = box.y + 'px';
                     nbPositionTextToolbar(box.id);
                 };
-                const up = () => {
+                const up = (ev) => {
+                    if (ev.pointerId !== pointerId) return;
                     document.removeEventListener('pointermove', mv);
                     document.removeEventListener('pointerup', up);
+                    document.removeEventListener('pointercancel', up);
                     if (moved) {
                         nbScheduleSave();
-                    } else {
+                    } else if (ev.type !== 'pointercancel') {
                         // 原地点按 → 进入编辑并把光标放到末尾
                         inner.focus();
                         try {
@@ -29837,6 +29874,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 };
                 document.addEventListener('pointermove', mv);
                 document.addEventListener('pointerup', up);
+                document.addEventListener('pointercancel', up);
             });
 
             // 四角缩放：等比调整字号与宽度，对角固定
@@ -29845,9 +29883,11 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 h.className = 'nb-tb-corner';
                 h.dataset.c = c;
                 h.addEventListener('pointerdown', (e) => {
+                    if (applePencilMode && !booxReaderIsPen(e)) return;
                     e.preventDefault();
                     e.stopPropagation();
                     const s = nbDisplayScale();
+                    const pointerId = e.pointerId;
                     const w0 = el.offsetWidth, h0 = el.offsetHeight, f0 = box.fontSize || 18;
                     const x0 = box.x, y0 = box.y;
                     // 对角锚点（逻辑坐标）
@@ -29858,6 +29898,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     const d0 = Math.max(10, Math.hypot(cx0 - ax, cy0 - ay));
                     const sx = e.clientX, sy = e.clientY;
                     const mv = (ev) => {
+                        if (ev.pointerId !== pointerId) return;
                         const px = (ev.clientX - sx) / s + (c.includes('l') ? x0 : x0 + w0);
                         const py = (ev.clientY - sy) / s + (c.includes('t') ? y0 : y0 + h0);
                         const k = Math.max(0.2, Math.min(6, Math.hypot(px - ax, py - ay) / d0));
@@ -29871,14 +29912,17 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                         inner.style.fontSize = box.fontSize + 'px';
                         nbPositionTextToolbar(box.id);
                     };
-                    const up = () => {
+                    const up = (ev) => {
+                        if (ev.pointerId !== pointerId) return;
                         document.removeEventListener('pointermove', mv);
                         document.removeEventListener('pointerup', up);
+                        document.removeEventListener('pointercancel', up);
                         nbScheduleSave();
                         nbShowTextToolbar(box.id);   // 刷新工具条上的字号状态
                     };
                     document.addEventListener('pointermove', mv);
                     document.addEventListener('pointerup', up);
+                    document.addEventListener('pointercancel', up);
                 });
                 el.appendChild(h);
             });
@@ -30001,14 +30045,17 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             el.appendChild(del);
             el.addEventListener('pointerdown', (e) => {
                 if (e.target.tagName === 'BUTTON') return;
+                if (applePencilMode && !booxReaderIsPen(e)) return;
                 e.preventDefault();
                 e.stopPropagation();
                 document.querySelectorAll('.nb-media-img.selected,.nb-media-audio.selected,.nb-textbox.selected').forEach(x => x.classList.remove('selected'));
                 el.classList.add('selected');
                 const s = nbDisplayScale();
+                const pointerId = e.pointerId;
                 const sx = e.clientX, sy = e.clientY, ox = m.x, oy = m.y;
                 let moved = false;
                 const mv = (ev) => {
+                    if (ev.pointerId !== pointerId) return;
                     const dx = (ev.clientX - sx) / s, dy = (ev.clientY - sy) / s;
                     if (Math.abs(dx) > 2 || Math.abs(dy) > 2) moved = true;
                     m.x = Math.round(ox + dx);
@@ -30016,13 +30063,16 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     el.style.left = m.x + 'px';
                     el.style.top = m.y + 'px';
                 };
-                const up = () => {
+                const up = (ev) => {
+                    if (ev.pointerId !== pointerId) return;
                     document.removeEventListener('pointermove', mv);
                     document.removeEventListener('pointerup', up);
+                    document.removeEventListener('pointercancel', up);
                     if (moved) nbScheduleSave();
                 };
                 document.addEventListener('pointermove', mv);
                 document.addEventListener('pointerup', up);
+                document.addEventListener('pointercancel', up);
             });
             return el;
         }

--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -28488,6 +28488,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             nbState.redoStack = [];
             nbState.selection = null;
             nbState.bgImageCache = {};
+            nbResetNotebookTouchGesture();
             document.body.classList.add('nb-editor-active');
             document.getElementById('nbEditor').classList.add('show');
             nbForceClearNotebookNativeSelection();
@@ -28508,6 +28509,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             nbHidePanel();
             nbHideOutline();
             nbClearSelection();
+            nbResetNotebookTouchGesture();
             nbForceClearNotebookNativeSelection();
             document.getElementById('nbEditor').classList.remove('show');
             document.body.classList.remove('nb-editor-active', 'nb-text-mode');
@@ -29093,6 +29095,162 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             nbForceClearNotebookNativeSelection();
         }
 
+        // Apple Pencil 模式与阅读界面保持一致：Pencil 负责当前画布工具，
+        // 手指在画布上只负责单指滚动和双指缩放。
+        let _nbTouchGesture = null;
+
+        function nbDirectFingerTouch(touch) {
+            return !!touch && touch.touchType !== 'stylus';
+        }
+
+        function nbTwoDirectFingerTouches(touches) {
+            return !!touches && touches.length === 2 &&
+                nbDirectFingerTouch(touches[0]) && nbDirectFingerTouch(touches[1]);
+        }
+
+        function nbTouchDistance(t1, t2) {
+            return Math.hypot(t2.clientX - t1.clientX, t2.clientY - t1.clientY);
+        }
+
+        function nbTouchCenter(t1, t2) {
+            return {
+                x: (t1.clientX + t2.clientX) / 2,
+                y: (t1.clientY + t2.clientY) / 2
+            };
+        }
+
+        function nbClearTouchZoomPreview() {
+            const box = document.getElementById('nbPageBox');
+            if (!box) return;
+            box.style.transform = '';
+            box.style.transformOrigin = '';
+        }
+
+        function nbResetNotebookTouchGesture() {
+            nbClearTouchZoomPreview();
+            _nbTouchGesture = null;
+        }
+
+        function nbStartNotebookPinch(touches) {
+            const box = document.getElementById('nbPageBox');
+            if (!box || !nbTwoDirectFingerTouches(touches)) return false;
+            const distance = nbTouchDistance(touches[0], touches[1]);
+            if (distance <= 0) return false;
+            const center = nbTouchCenter(touches[0], touches[1]);
+            const rect = box.getBoundingClientRect();
+            _nbTouchGesture = {
+                mode: 'pinch',
+                startDistance: distance,
+                baseZoom: nbState.zoom,
+                liveZoom: nbState.zoom,
+                lastCenterX: center.x,
+                lastCenterY: center.y,
+                originX: center.x - rect.left,
+                originY: center.y - rect.top
+            };
+            box.style.transformOrigin = _nbTouchGesture.originX + 'px ' + _nbTouchGesture.originY + 'px';
+            return true;
+        }
+
+        function nbNotebookTouchStart(e) {
+            if (!applePencilMode || !nbNotebookSelectionGuardActive()) return;
+            if (nbState.drawing) {
+                nbResetNotebookTouchGesture();
+                return;
+            }
+            if (nbTwoDirectFingerTouches(e.touches)) {
+                nbClearTouchZoomPreview();
+                if (nbStartNotebookPinch(e.touches)) e.preventDefault();
+                return;
+            }
+            if (e.touches.length === 1 && nbDirectFingerTouch(e.touches[0])) {
+                nbClearTouchZoomPreview();
+                _nbTouchGesture = {
+                    mode: 'pan',
+                    lastX: e.touches[0].clientX,
+                    lastY: e.touches[0].clientY
+                };
+                return;
+            }
+            // Pencil + finger must not be promoted to a notebook pinch gesture.
+            nbResetNotebookTouchGesture();
+        }
+
+        function nbNotebookTouchMove(e) {
+            if (!applePencilMode || !nbNotebookSelectionGuardActive()) {
+                nbResetNotebookTouchGesture();
+                return;
+            }
+            if (nbState.drawing) {
+                nbResetNotebookTouchGesture();
+                return;
+            }
+            const wrap = document.getElementById('nbCanvasWrap');
+            if (!wrap) return;
+
+            if (nbTwoDirectFingerTouches(e.touches)) {
+                if (!_nbTouchGesture || _nbTouchGesture.mode !== 'pinch') {
+                    nbClearTouchZoomPreview();
+                    if (!nbStartNotebookPinch(e.touches)) return;
+                }
+                const g = _nbTouchGesture;
+                const center = nbTouchCenter(e.touches[0], e.touches[1]);
+                wrap.scrollLeft -= center.x - g.lastCenterX;
+                wrap.scrollTop -= center.y - g.lastCenterY;
+                g.lastCenterX = center.x;
+                g.lastCenterY = center.y;
+                const scale = nbTouchDistance(e.touches[0], e.touches[1]) / g.startDistance;
+                g.liveZoom = Math.max(0.5, Math.min(2, g.baseZoom * scale));
+                const previewScale = g.liveZoom / g.baseZoom;
+                const box = document.getElementById('nbPageBox');
+                if (box) box.style.transform = 'scale(' + previewScale + ')';
+                e.preventDefault();
+                return;
+            }
+
+            if (_nbTouchGesture?.mode === 'pan' && e.touches.length === 1 &&
+                nbDirectFingerTouch(e.touches[0])) {
+                const touch = e.touches[0];
+                wrap.scrollLeft -= touch.clientX - _nbTouchGesture.lastX;
+                wrap.scrollTop -= touch.clientY - _nbTouchGesture.lastY;
+                _nbTouchGesture.lastX = touch.clientX;
+                _nbTouchGesture.lastY = touch.clientY;
+                e.preventDefault();
+                return;
+            }
+
+            nbResetNotebookTouchGesture();
+        }
+
+        function nbFinishNotebookTouchGesture(e, commitZoom) {
+            const g = _nbTouchGesture;
+            const wrap = document.getElementById('nbCanvasWrap');
+            nbClearTouchZoomPreview();
+            _nbTouchGesture = null;
+
+            if (commitZoom && g?.mode === 'pinch' && wrap &&
+                Math.abs(g.liveZoom - g.baseZoom) >= 0.01) {
+                const rect = wrap.getBoundingClientRect();
+                const viewportX = Math.max(0, Math.min(rect.width, g.lastCenterX - rect.left));
+                const viewportY = Math.max(0, Math.min(rect.height, g.lastCenterY - rect.top));
+                const oldScrollLeft = wrap.scrollLeft;
+                const oldScrollTop = wrap.scrollTop;
+                const ratio = g.liveZoom / g.baseZoom;
+                nbZoomSet(g.liveZoom * 100);
+                wrap.scrollLeft = (oldScrollLeft + viewportX) * ratio - viewportX;
+                wrap.scrollTop = (oldScrollTop + viewportY) * ratio - viewportY;
+            }
+
+            if (commitZoom && applePencilMode && e?.touches?.length === 1 &&
+                nbDirectFingerTouch(e.touches[0])) {
+                _nbTouchGesture = {
+                    mode: 'pan',
+                    lastX: e.touches[0].clientX,
+                    lastY: e.touches[0].clientY
+                };
+            }
+        }
+
         function nbInitCanvasEvents() {
             const c = document.getElementById('nbCanvas');
             if (c._nbBound) return;
@@ -29102,6 +29260,10 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             c.addEventListener('pointerup', nbPointerUp);
             c.addEventListener('pointercancel', nbPointerUp);
             c.addEventListener('contextmenu', e => e.preventDefault());
+            c.addEventListener('touchstart', nbNotebookTouchStart, { passive: false });
+            c.addEventListener('touchmove', nbNotebookTouchMove, { passive: false });
+            c.addEventListener('touchend', e => nbFinishNotebookTouchGesture(e, true), { passive: true });
+            c.addEventListener('touchcancel', e => nbFinishNotebookTouchGesture(e, false), { passive: true });
             ['selectstart', 'dragstart', 'contextmenu'].forEach(type => {
                 document.addEventListener(type, nbBlockNotebookNativeSelection, true);
             });
@@ -29115,7 +29277,8 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         }
 
         function nbPointerDown(e) {
-            if (e.button === 2) return;
+            if (e.button === 2 || nbState.drawing) return;
+            if (applePencilMode && !booxReaderIsPen(e)) return;
             nbBlurNotebookTextEditing();
             nbHidePanel();
             nbHideOutline();
@@ -29136,29 +29299,30 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                         document.querySelectorAll('.nb-media-img.selected,.nb-media-audio.selected').forEach(x => x.classList.remove('selected'));
                         document.querySelector(`#nbTextLayer [data-id="${hit.obj.id}"]`)?.classList.add('selected');
                     }
-                    nbState.drawing = { mode: 'boxdrag', kind: hit.kind, obj: hit.obj, last: p, moved: false };
+                    nbState.drawing = { mode: 'boxdrag', pointerId: e.pointerId, kind: hit.kind, obj: hit.obj, last: p, moved: false };
                     nbNativeRefresh();   // 清掉原生层点按留下的墨点
                     return;
                 }
                 const brush = nbState.brushes[nbState.brushIndex];
                 nbState.drawing = {
                     mode: 'stroke',
+                    pointerId: e.pointerId,
                     stroke: { id: nbUid('s'), tool: brush.type, color: brush.color, w: Math.round(brush.mm * NB_MM * 100) / 100, paths: [[p]] },
                     last: p
                 };
             } else if (tool === 'eraser') {
-                nbState.drawing = { mode: 'erase', last: p, removed: [] };
+                nbState.drawing = { mode: 'erase', pointerId: e.pointerId, last: p, removed: [] };
                 nbEraseAt(p, p);
             } else if (tool === 'lasso') {
                 const sel = nbState.selection;
                 if (sel && p[0] >= sel.bbox.x0 - 10 && p[0] <= sel.bbox.x1 + 10 && p[1] >= sel.bbox.y0 - 10 && p[1] <= sel.bbox.y1 + 10) {
-                    nbState.drawing = { mode: 'move', last: p, start: p, before: nbCopySelStrokes(), moved: false };
+                    nbState.drawing = { mode: 'move', pointerId: e.pointerId, last: p, start: p, before: nbCopySelStrokes(), moved: false };
                 } else {
                     nbClearSelection();
-                    nbState.drawing = { mode: 'lasso', pts: [p] };
+                    nbState.drawing = { mode: 'lasso', pointerId: e.pointerId, pts: [p] };
                 }
             } else if (tool === 'shape') {
-                nbState.drawing = { mode: 'shape', start: p, cur: p, freehand: [p], preview: null };
+                nbState.drawing = { mode: 'shape', pointerId: e.pointerId, start: p, cur: p, freehand: [p], preview: null };
             } else if (tool === 'text') {
                 nbAddTextBox(p[0], p[1]);
                 nbState.drawing = null;
@@ -29167,7 +29331,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
         function nbPointerMove(e) {
             const d = nbState.drawing;
-            if (!d) return;
+            if (!d || d.pointerId !== e.pointerId) return;
             e.preventDefault();
             const events = (typeof e.getCoalescedEvents === 'function' && e.getCoalescedEvents().length) ? e.getCoalescedEvents() : [e];
             for (const ev of events) {
@@ -29223,7 +29387,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
         function nbPointerUp(e) {
             const d = nbState.drawing;
-            if (!d) return;
+            if (!d || d.pointerId !== e.pointerId) return;
             nbState.drawing = null;
             if (d.mode === 'stroke') {
                 const pts = d.stroke.paths[0];

--- a/docs/index.html
+++ b/docs/index.html
@@ -28488,6 +28488,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             nbState.redoStack = [];
             nbState.selection = null;
             nbState.bgImageCache = {};
+            nbState.drawing = null;
             nbResetNotebookTouchGesture();
             document.body.classList.add('nb-editor-active');
             document.getElementById('nbEditor').classList.add('show');
@@ -28504,12 +28505,13 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             ++_nbOpenRequestToken;
             ++_nbPageLoadToken;
             const closingPageId = nbCurrentPage() && nbCurrentPage().id;
+            nbFinishActiveNotebookGesture();
+            nbResetNotebookTouchGesture();
             nbFlushPositionSync();
             await nbSavePageNow();
             nbHidePanel();
             nbHideOutline();
             nbClearSelection();
-            nbResetNotebookTouchGesture();
             nbForceClearNotebookNativeSelection();
             document.getElementById('nbEditor').classList.remove('show');
             document.body.classList.remove('nb-editor-active', 'nb-text-mode');
@@ -28565,6 +28567,8 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         async function nbLoadPage(index, syncPosition = true) {
             const loadToken = ++_nbPageLoadToken;
             const notebookId = nbState.notebookId;
+            nbFinishActiveNotebookGesture();
+            nbResetNotebookTouchGesture();
             await nbSavePageNow();
             if (loadToken !== _nbPageLoadToken || nbState.notebookId !== notebookId) return false;
             const nb = nbGetNotebook(notebookId);
@@ -29154,6 +29158,10 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
         function nbNotebookTouchStart(e) {
             if (!applePencilMode || !nbNotebookSelectionGuardActive()) return;
+            if (nbFocusedNativeSelectionControlAt(e.target)) {
+                nbResetNotebookTouchGesture();
+                return;
+            }
             if (nbState.drawing) {
                 nbResetNotebookTouchGesture();
                 return;
@@ -29178,6 +29186,10 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
         function nbNotebookTouchMove(e) {
             if (!applePencilMode || !nbNotebookSelectionGuardActive()) {
+                nbResetNotebookTouchGesture();
+                return;
+            }
+            if (nbFocusedNativeSelectionControlAt(e.target)) {
                 nbResetNotebookTouchGesture();
                 return;
             }
@@ -29241,7 +29253,8 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 wrap.scrollTop = (oldScrollTop + viewportY) * ratio - viewportY;
             }
 
-            if (commitZoom && applePencilMode && e?.touches?.length === 1 &&
+            if (commitZoom && applePencilMode && !nbFocusedNativeSelectionControlAt(e?.target) &&
+                e?.touches?.length === 1 &&
                 nbDirectFingerTouch(e.touches[0])) {
                 _nbTouchGesture = {
                     mode: 'pan',
@@ -29253,6 +29266,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
         function nbInitCanvasEvents() {
             const c = document.getElementById('nbCanvas');
+            const touchSurface = document.getElementById('nbPageBox');
             if (c._nbBound) return;
             c._nbBound = true;
             c.addEventListener('pointerdown', nbPointerDown);
@@ -29260,10 +29274,10 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             c.addEventListener('pointerup', nbPointerUp);
             c.addEventListener('pointercancel', nbPointerUp);
             c.addEventListener('contextmenu', e => e.preventDefault());
-            c.addEventListener('touchstart', nbNotebookTouchStart, { passive: false });
-            c.addEventListener('touchmove', nbNotebookTouchMove, { passive: false });
-            c.addEventListener('touchend', e => nbFinishNotebookTouchGesture(e, true), { passive: true });
-            c.addEventListener('touchcancel', e => nbFinishNotebookTouchGesture(e, false), { passive: true });
+            touchSurface.addEventListener('touchstart', nbNotebookTouchStart, { passive: false });
+            touchSurface.addEventListener('touchmove', nbNotebookTouchMove, { passive: false });
+            touchSurface.addEventListener('touchend', e => nbFinishNotebookTouchGesture(e, true), { passive: true });
+            touchSurface.addEventListener('touchcancel', e => nbFinishNotebookTouchGesture(e, false), { passive: true });
             ['selectstart', 'dragstart', 'contextmenu'].forEach(type => {
                 document.addEventListener(type, nbBlockNotebookNativeSelection, true);
             });
@@ -29273,12 +29287,18 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             document.addEventListener('touchcancel', nbScheduleNotebookNativeSelectionClear, true);
             document.addEventListener('pointerup', nbScheduleNotebookNativeSelectionClear, true);
             document.addEventListener('pointercancel', nbScheduleNotebookNativeSelectionClear, true);
+            document.addEventListener('pointerup', nbPointerUp, true);
+            document.addEventListener('pointercancel', nbPointerUp, true);
             document.addEventListener('pointerdown', nbBlurNotebookControlOnOutsidePointer, true);
         }
 
         function nbPointerDown(e) {
-            if (e.button === 2 || nbState.drawing) return;
+            if (e.button === 2) return;
             if (applePencilMode && !booxReaderIsPen(e)) return;
+            if (nbState.drawing) {
+                if (!applePencilMode || nbState.drawing.pointerId === e.pointerId) return;
+                nbFinishActiveNotebookGesture();
+            }
             nbBlurNotebookTextEditing();
             nbHidePanel();
             nbHideOutline();
@@ -29385,10 +29405,11 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             if (d.mode === 'lasso' || d.mode === 'shape') nbDrawOverlay();
         }
 
-        function nbPointerUp(e) {
+        function nbFinishActiveNotebookGesture() {
             const d = nbState.drawing;
-            if (!d || d.pointerId !== e.pointerId) return;
+            if (!d) return;
             nbState.drawing = null;
+            if (!nbState.content) return;
             if (d.mode === 'stroke') {
                 const pts = d.stroke.paths[0];
                 if (pts.length >= 1) {
@@ -29429,6 +29450,12 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 }
                 nbDrawOverlay();
             }
+        }
+
+        function nbPointerUp(e) {
+            const d = nbState.drawing;
+            if (!d || d.pointerId !== e.pointerId) return;
+            nbFinishActiveNotebookGesture();
         }
 
         // ---------- 笔画橡皮擦：整笔擦除 ----------
@@ -29802,13 +29829,21 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 if (e.target.classList.contains('nb-tb-corner') || e.target.classList.contains('nb-media-del')) return;
                 const editing = document.activeElement === inner;
                 if (editing && e.target === inner) return;   // 编辑中不拦截光标操作
+                if (applePencilMode && !booxReaderIsPen(e)) {
+                    // 未进入编辑的文本框仍属于手指滚动区域；阻止 pointerdown
+                    // 默认聚焦，否则随后的 touchstart 会被误判成原生文本编辑。
+                    e.preventDefault();
+                    return;
+                }
                 e.preventDefault();
                 e.stopPropagation();
                 nbSelectTextBox(box.id);
                 const s = nbDisplayScale();
+                const pointerId = e.pointerId;
                 const sx = e.clientX, sy = e.clientY, ox = box.x, oy = box.y;
                 let moved = false;
                 const mv = (ev) => {
+                    if (ev.pointerId !== pointerId) return;
                     const dx = (ev.clientX - sx) / s, dy = (ev.clientY - sy) / s;
                     if (Math.abs(dx) > 2 || Math.abs(dy) > 2) moved = true;
                     box.x = Math.round(ox + dx);
@@ -29817,12 +29852,14 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     el.style.top = box.y + 'px';
                     nbPositionTextToolbar(box.id);
                 };
-                const up = () => {
+                const up = (ev) => {
+                    if (ev.pointerId !== pointerId) return;
                     document.removeEventListener('pointermove', mv);
                     document.removeEventListener('pointerup', up);
+                    document.removeEventListener('pointercancel', up);
                     if (moved) {
                         nbScheduleSave();
-                    } else {
+                    } else if (ev.type !== 'pointercancel') {
                         // 原地点按 → 进入编辑并把光标放到末尾
                         inner.focus();
                         try {
@@ -29837,6 +29874,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 };
                 document.addEventListener('pointermove', mv);
                 document.addEventListener('pointerup', up);
+                document.addEventListener('pointercancel', up);
             });
 
             // 四角缩放：等比调整字号与宽度，对角固定
@@ -29845,9 +29883,11 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 h.className = 'nb-tb-corner';
                 h.dataset.c = c;
                 h.addEventListener('pointerdown', (e) => {
+                    if (applePencilMode && !booxReaderIsPen(e)) return;
                     e.preventDefault();
                     e.stopPropagation();
                     const s = nbDisplayScale();
+                    const pointerId = e.pointerId;
                     const w0 = el.offsetWidth, h0 = el.offsetHeight, f0 = box.fontSize || 18;
                     const x0 = box.x, y0 = box.y;
                     // 对角锚点（逻辑坐标）
@@ -29858,6 +29898,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     const d0 = Math.max(10, Math.hypot(cx0 - ax, cy0 - ay));
                     const sx = e.clientX, sy = e.clientY;
                     const mv = (ev) => {
+                        if (ev.pointerId !== pointerId) return;
                         const px = (ev.clientX - sx) / s + (c.includes('l') ? x0 : x0 + w0);
                         const py = (ev.clientY - sy) / s + (c.includes('t') ? y0 : y0 + h0);
                         const k = Math.max(0.2, Math.min(6, Math.hypot(px - ax, py - ay) / d0));
@@ -29871,14 +29912,17 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                         inner.style.fontSize = box.fontSize + 'px';
                         nbPositionTextToolbar(box.id);
                     };
-                    const up = () => {
+                    const up = (ev) => {
+                        if (ev.pointerId !== pointerId) return;
                         document.removeEventListener('pointermove', mv);
                         document.removeEventListener('pointerup', up);
+                        document.removeEventListener('pointercancel', up);
                         nbScheduleSave();
                         nbShowTextToolbar(box.id);   // 刷新工具条上的字号状态
                     };
                     document.addEventListener('pointermove', mv);
                     document.addEventListener('pointerup', up);
+                    document.addEventListener('pointercancel', up);
                 });
                 el.appendChild(h);
             });
@@ -30001,14 +30045,17 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             el.appendChild(del);
             el.addEventListener('pointerdown', (e) => {
                 if (e.target.tagName === 'BUTTON') return;
+                if (applePencilMode && !booxReaderIsPen(e)) return;
                 e.preventDefault();
                 e.stopPropagation();
                 document.querySelectorAll('.nb-media-img.selected,.nb-media-audio.selected,.nb-textbox.selected').forEach(x => x.classList.remove('selected'));
                 el.classList.add('selected');
                 const s = nbDisplayScale();
+                const pointerId = e.pointerId;
                 const sx = e.clientX, sy = e.clientY, ox = m.x, oy = m.y;
                 let moved = false;
                 const mv = (ev) => {
+                    if (ev.pointerId !== pointerId) return;
                     const dx = (ev.clientX - sx) / s, dy = (ev.clientY - sy) / s;
                     if (Math.abs(dx) > 2 || Math.abs(dy) > 2) moved = true;
                     m.x = Math.round(ox + dx);
@@ -30016,13 +30063,16 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     el.style.left = m.x + 'px';
                     el.style.top = m.y + 'px';
                 };
-                const up = () => {
+                const up = (ev) => {
+                    if (ev.pointerId !== pointerId) return;
                     document.removeEventListener('pointermove', mv);
                     document.removeEventListener('pointerup', up);
+                    document.removeEventListener('pointercancel', up);
                     if (moved) nbScheduleSave();
                 };
                 document.addEventListener('pointermove', mv);
                 document.addEventListener('pointerup', up);
+                document.addEventListener('pointercancel', up);
             });
             return el;
         }

--- a/docs/index.html
+++ b/docs/index.html
@@ -28488,6 +28488,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             nbState.redoStack = [];
             nbState.selection = null;
             nbState.bgImageCache = {};
+            nbResetNotebookTouchGesture();
             document.body.classList.add('nb-editor-active');
             document.getElementById('nbEditor').classList.add('show');
             nbForceClearNotebookNativeSelection();
@@ -28508,6 +28509,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             nbHidePanel();
             nbHideOutline();
             nbClearSelection();
+            nbResetNotebookTouchGesture();
             nbForceClearNotebookNativeSelection();
             document.getElementById('nbEditor').classList.remove('show');
             document.body.classList.remove('nb-editor-active', 'nb-text-mode');
@@ -29093,6 +29095,162 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             nbForceClearNotebookNativeSelection();
         }
 
+        // Apple Pencil 模式与阅读界面保持一致：Pencil 负责当前画布工具，
+        // 手指在画布上只负责单指滚动和双指缩放。
+        let _nbTouchGesture = null;
+
+        function nbDirectFingerTouch(touch) {
+            return !!touch && touch.touchType !== 'stylus';
+        }
+
+        function nbTwoDirectFingerTouches(touches) {
+            return !!touches && touches.length === 2 &&
+                nbDirectFingerTouch(touches[0]) && nbDirectFingerTouch(touches[1]);
+        }
+
+        function nbTouchDistance(t1, t2) {
+            return Math.hypot(t2.clientX - t1.clientX, t2.clientY - t1.clientY);
+        }
+
+        function nbTouchCenter(t1, t2) {
+            return {
+                x: (t1.clientX + t2.clientX) / 2,
+                y: (t1.clientY + t2.clientY) / 2
+            };
+        }
+
+        function nbClearTouchZoomPreview() {
+            const box = document.getElementById('nbPageBox');
+            if (!box) return;
+            box.style.transform = '';
+            box.style.transformOrigin = '';
+        }
+
+        function nbResetNotebookTouchGesture() {
+            nbClearTouchZoomPreview();
+            _nbTouchGesture = null;
+        }
+
+        function nbStartNotebookPinch(touches) {
+            const box = document.getElementById('nbPageBox');
+            if (!box || !nbTwoDirectFingerTouches(touches)) return false;
+            const distance = nbTouchDistance(touches[0], touches[1]);
+            if (distance <= 0) return false;
+            const center = nbTouchCenter(touches[0], touches[1]);
+            const rect = box.getBoundingClientRect();
+            _nbTouchGesture = {
+                mode: 'pinch',
+                startDistance: distance,
+                baseZoom: nbState.zoom,
+                liveZoom: nbState.zoom,
+                lastCenterX: center.x,
+                lastCenterY: center.y,
+                originX: center.x - rect.left,
+                originY: center.y - rect.top
+            };
+            box.style.transformOrigin = _nbTouchGesture.originX + 'px ' + _nbTouchGesture.originY + 'px';
+            return true;
+        }
+
+        function nbNotebookTouchStart(e) {
+            if (!applePencilMode || !nbNotebookSelectionGuardActive()) return;
+            if (nbState.drawing) {
+                nbResetNotebookTouchGesture();
+                return;
+            }
+            if (nbTwoDirectFingerTouches(e.touches)) {
+                nbClearTouchZoomPreview();
+                if (nbStartNotebookPinch(e.touches)) e.preventDefault();
+                return;
+            }
+            if (e.touches.length === 1 && nbDirectFingerTouch(e.touches[0])) {
+                nbClearTouchZoomPreview();
+                _nbTouchGesture = {
+                    mode: 'pan',
+                    lastX: e.touches[0].clientX,
+                    lastY: e.touches[0].clientY
+                };
+                return;
+            }
+            // Pencil + finger must not be promoted to a notebook pinch gesture.
+            nbResetNotebookTouchGesture();
+        }
+
+        function nbNotebookTouchMove(e) {
+            if (!applePencilMode || !nbNotebookSelectionGuardActive()) {
+                nbResetNotebookTouchGesture();
+                return;
+            }
+            if (nbState.drawing) {
+                nbResetNotebookTouchGesture();
+                return;
+            }
+            const wrap = document.getElementById('nbCanvasWrap');
+            if (!wrap) return;
+
+            if (nbTwoDirectFingerTouches(e.touches)) {
+                if (!_nbTouchGesture || _nbTouchGesture.mode !== 'pinch') {
+                    nbClearTouchZoomPreview();
+                    if (!nbStartNotebookPinch(e.touches)) return;
+                }
+                const g = _nbTouchGesture;
+                const center = nbTouchCenter(e.touches[0], e.touches[1]);
+                wrap.scrollLeft -= center.x - g.lastCenterX;
+                wrap.scrollTop -= center.y - g.lastCenterY;
+                g.lastCenterX = center.x;
+                g.lastCenterY = center.y;
+                const scale = nbTouchDistance(e.touches[0], e.touches[1]) / g.startDistance;
+                g.liveZoom = Math.max(0.5, Math.min(2, g.baseZoom * scale));
+                const previewScale = g.liveZoom / g.baseZoom;
+                const box = document.getElementById('nbPageBox');
+                if (box) box.style.transform = 'scale(' + previewScale + ')';
+                e.preventDefault();
+                return;
+            }
+
+            if (_nbTouchGesture?.mode === 'pan' && e.touches.length === 1 &&
+                nbDirectFingerTouch(e.touches[0])) {
+                const touch = e.touches[0];
+                wrap.scrollLeft -= touch.clientX - _nbTouchGesture.lastX;
+                wrap.scrollTop -= touch.clientY - _nbTouchGesture.lastY;
+                _nbTouchGesture.lastX = touch.clientX;
+                _nbTouchGesture.lastY = touch.clientY;
+                e.preventDefault();
+                return;
+            }
+
+            nbResetNotebookTouchGesture();
+        }
+
+        function nbFinishNotebookTouchGesture(e, commitZoom) {
+            const g = _nbTouchGesture;
+            const wrap = document.getElementById('nbCanvasWrap');
+            nbClearTouchZoomPreview();
+            _nbTouchGesture = null;
+
+            if (commitZoom && g?.mode === 'pinch' && wrap &&
+                Math.abs(g.liveZoom - g.baseZoom) >= 0.01) {
+                const rect = wrap.getBoundingClientRect();
+                const viewportX = Math.max(0, Math.min(rect.width, g.lastCenterX - rect.left));
+                const viewportY = Math.max(0, Math.min(rect.height, g.lastCenterY - rect.top));
+                const oldScrollLeft = wrap.scrollLeft;
+                const oldScrollTop = wrap.scrollTop;
+                const ratio = g.liveZoom / g.baseZoom;
+                nbZoomSet(g.liveZoom * 100);
+                wrap.scrollLeft = (oldScrollLeft + viewportX) * ratio - viewportX;
+                wrap.scrollTop = (oldScrollTop + viewportY) * ratio - viewportY;
+            }
+
+            if (commitZoom && applePencilMode && e?.touches?.length === 1 &&
+                nbDirectFingerTouch(e.touches[0])) {
+                _nbTouchGesture = {
+                    mode: 'pan',
+                    lastX: e.touches[0].clientX,
+                    lastY: e.touches[0].clientY
+                };
+            }
+        }
+
         function nbInitCanvasEvents() {
             const c = document.getElementById('nbCanvas');
             if (c._nbBound) return;
@@ -29102,6 +29260,10 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             c.addEventListener('pointerup', nbPointerUp);
             c.addEventListener('pointercancel', nbPointerUp);
             c.addEventListener('contextmenu', e => e.preventDefault());
+            c.addEventListener('touchstart', nbNotebookTouchStart, { passive: false });
+            c.addEventListener('touchmove', nbNotebookTouchMove, { passive: false });
+            c.addEventListener('touchend', e => nbFinishNotebookTouchGesture(e, true), { passive: true });
+            c.addEventListener('touchcancel', e => nbFinishNotebookTouchGesture(e, false), { passive: true });
             ['selectstart', 'dragstart', 'contextmenu'].forEach(type => {
                 document.addEventListener(type, nbBlockNotebookNativeSelection, true);
             });
@@ -29115,7 +29277,8 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         }
 
         function nbPointerDown(e) {
-            if (e.button === 2) return;
+            if (e.button === 2 || nbState.drawing) return;
+            if (applePencilMode && !booxReaderIsPen(e)) return;
             nbBlurNotebookTextEditing();
             nbHidePanel();
             nbHideOutline();
@@ -29136,29 +29299,30 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                         document.querySelectorAll('.nb-media-img.selected,.nb-media-audio.selected').forEach(x => x.classList.remove('selected'));
                         document.querySelector(`#nbTextLayer [data-id="${hit.obj.id}"]`)?.classList.add('selected');
                     }
-                    nbState.drawing = { mode: 'boxdrag', kind: hit.kind, obj: hit.obj, last: p, moved: false };
+                    nbState.drawing = { mode: 'boxdrag', pointerId: e.pointerId, kind: hit.kind, obj: hit.obj, last: p, moved: false };
                     nbNativeRefresh();   // 清掉原生层点按留下的墨点
                     return;
                 }
                 const brush = nbState.brushes[nbState.brushIndex];
                 nbState.drawing = {
                     mode: 'stroke',
+                    pointerId: e.pointerId,
                     stroke: { id: nbUid('s'), tool: brush.type, color: brush.color, w: Math.round(brush.mm * NB_MM * 100) / 100, paths: [[p]] },
                     last: p
                 };
             } else if (tool === 'eraser') {
-                nbState.drawing = { mode: 'erase', last: p, removed: [] };
+                nbState.drawing = { mode: 'erase', pointerId: e.pointerId, last: p, removed: [] };
                 nbEraseAt(p, p);
             } else if (tool === 'lasso') {
                 const sel = nbState.selection;
                 if (sel && p[0] >= sel.bbox.x0 - 10 && p[0] <= sel.bbox.x1 + 10 && p[1] >= sel.bbox.y0 - 10 && p[1] <= sel.bbox.y1 + 10) {
-                    nbState.drawing = { mode: 'move', last: p, start: p, before: nbCopySelStrokes(), moved: false };
+                    nbState.drawing = { mode: 'move', pointerId: e.pointerId, last: p, start: p, before: nbCopySelStrokes(), moved: false };
                 } else {
                     nbClearSelection();
-                    nbState.drawing = { mode: 'lasso', pts: [p] };
+                    nbState.drawing = { mode: 'lasso', pointerId: e.pointerId, pts: [p] };
                 }
             } else if (tool === 'shape') {
-                nbState.drawing = { mode: 'shape', start: p, cur: p, freehand: [p], preview: null };
+                nbState.drawing = { mode: 'shape', pointerId: e.pointerId, start: p, cur: p, freehand: [p], preview: null };
             } else if (tool === 'text') {
                 nbAddTextBox(p[0], p[1]);
                 nbState.drawing = null;
@@ -29167,7 +29331,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
         function nbPointerMove(e) {
             const d = nbState.drawing;
-            if (!d) return;
+            if (!d || d.pointerId !== e.pointerId) return;
             e.preventDefault();
             const events = (typeof e.getCoalescedEvents === 'function' && e.getCoalescedEvents().length) ? e.getCoalescedEvents() : [e];
             for (const ev of events) {
@@ -29223,7 +29387,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
         function nbPointerUp(e) {
             const d = nbState.drawing;
-            if (!d) return;
+            if (!d || d.pointerId !== e.pointerId) return;
             nbState.drawing = null;
             if (d.mode === 'stroke') {
                 const pts = d.stroke.paths[0];


### PR DESCRIPTION
## Summary
- accept only pen pointers for notebook canvas tools while Apple Pencil mode is enabled
- route one-finger touches to notebook scrolling and two-finger touches to focused zoom
- keep Pencil-plus-finger input out of pinch handling and lock strokes to their initiating pointer
- keep the app and docs HTML mirrors identical

## Verification
- parsed the inline script with the bundled Node.js runtime
- ran targeted mocked cases for finger pan, finger pinch, stylus isolation, and mixed Pencil/finger input
- ran git diff --check
- verified the mirrored HTML files are byte-identical