### PR TITLE
Sync every notebook page before classroom payloads

### DIFF
--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -14016,6 +14016,9 @@
                     throw e;
                 }
 
+                // 笔记页面必须先同步；课堂残留素材失败不能阻断整本笔记上传。
+                await r2SyncAllNotebookPages();
+
                 // 所有课堂正文先于 metadata 提交，避免其它设备看见悬空索引。
                 let classroomPayloadSyncFailed = false;
                 for (const matId of (newMatIds || [])) {
@@ -14058,7 +14061,6 @@
                 if (classroomPayloadSyncFailed) return;
 
                 await r2SyncChangedLectureContents();
-                await r2SyncAllNotebookPages();
 
                 // 再把合并后的结果推回云端
                 const metadataPublishResult = await r2SyncMetadataOnly();
@@ -15950,6 +15952,9 @@
                     }
                     allowEmptyMetadataOverwrite = true;
                 }
+                // 笔记页面必须先同步；课堂残留素材失败不能阻断整本笔记上传。
+                await r2SyncAllNotebookPages();
+
                 // 课堂正文（录音、照片/文件、AI 讲义）必须全部先于 metadata 提交。
                 let uploadedMaterials = 0;
                 let uploadedClassroomNotes = 0;
@@ -15976,7 +15981,6 @@
                 }
                 // 手动"同步到云端"是全量推送，同时充当云端正文丢失后的修复入口。
                 const uploadedLectures = await r2SyncChangedLectureContents({ force: true });
-                await r2SyncAllNotebookPages();
                 metadata.lectures = stripLectureContent(appData.lectures);
                 metadata.notebooks = appData.notebooks || { items: [], reviews: [] };
                 metadata.classroom = stripClassroomData(appData.classroom, true);

--- a/docs/index.html
+++ b/docs/index.html
@@ -14016,6 +14016,9 @@
                     throw e;
                 }
 
+                // 笔记页面必须先同步；课堂残留素材失败不能阻断整本笔记上传。
+                await r2SyncAllNotebookPages();
+
                 // 所有课堂正文先于 metadata 提交，避免其它设备看见悬空索引。
                 let classroomPayloadSyncFailed = false;
                 for (const matId of (newMatIds || [])) {
@@ -14058,7 +14061,6 @@
                 if (classroomPayloadSyncFailed) return;
 
                 await r2SyncChangedLectureContents();
-                await r2SyncAllNotebookPages();
 
                 // 再把合并后的结果推回云端
                 const metadataPublishResult = await r2SyncMetadataOnly();
@@ -15950,6 +15952,9 @@
                     }
                     allowEmptyMetadataOverwrite = true;
                 }
+                // 笔记页面必须先同步；课堂残留素材失败不能阻断整本笔记上传。
+                await r2SyncAllNotebookPages();
+
                 // 课堂正文（录音、照片/文件、AI 讲义）必须全部先于 metadata 提交。
                 let uploadedMaterials = 0;
                 let uploadedClassroomNotes = 0;
@@ -15976,7 +15981,6 @@
                 }
                 // 手动"同步到云端"是全量推送，同时充当云端正文丢失后的修复入口。
                 const uploadedLectures = await r2SyncChangedLectureContents({ force: true });
-                await r2SyncAllNotebookPages();
                 metadata.lectures = stripLectureContent(appData.lectures);
                 metadata.notebooks = appData.notebooks || { items: [], reviews: [] };
                 metadata.classroom = stripClassroomData(appData.classroom, true);


### PR DESCRIPTION
## Fix\n- upload every notebook page before processing classroom payloads in manual full sync\n- do the same in scheduled full sync\n- prevent a missing classroom asset from stopping notebook page uploads\n\nThis keeps per-page change sync separate from full sync and fixes only one page per notebook reaching cloud.