### PR TITLE
Keep full sync running past missing classroom data

### DIFF
--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -14028,7 +14028,9 @@
                             classroomRecordingState?.id === found.material.id) continue;
                         try {
                             if (found.material.recordingCloudCommitted !== true &&
-                                !await r2SyncRecording(found.material)) classroomPayloadSyncFailed = true;
+                                !await r2SyncRecording(found.material)) {
+                                console.warn('跳过本地不完整的录音，继续定时全量同步:', matId);
+                            }
                         } catch (e) {
                             classroomPayloadSyncFailed = true;
                             console.warn('上传新录音失败:', matId, e);
@@ -14058,6 +14060,10 @@
                         }
                     }
                     catch (e) {
+                        if (e?.code === 'LOCAL_CLASSROOM_NOTE_MISSING') {
+                            console.warn('跳过本地缺失的课堂讲义，继续定时全量同步:', noteId);
+                            continue;
+                        }
                         classroomPayloadSyncFailed = true;
                         console.warn('上传新课堂讲义失败:', noteId, e);
                     }
@@ -14716,7 +14722,18 @@
         async function r2SyncClassroomNote(note) {
             if (!note?.id) return false;
             const content = await ensureClassroomNoteContent(note);
-            if (!String(content || '').trim()) throw new Error(i18n('class_note_content_missing', note.id));
+            if (!String(content || '').trim() && note.contentCloudCommitted === true) return true;
+            if (!String(content || '').trim()) {
+                const current = _findClassroomNote(note.id);
+                if (current) {
+                    current.note.contentCloudCommitted = false;
+                    current.note.contentMetadataCloudCommitted = false;
+                    saveData();
+                }
+                const error = new Error(i18n('class_note_content_missing', note.id));
+                error.code = 'LOCAL_CLASSROOM_NOTE_MISSING';
+                throw error;
+            }
             await r2PutObject('classroom/notes/' + note.id + '.md', content,
                 'text/markdown; charset=utf-8');
             const current = _findClassroomNote(note.id);
@@ -15977,13 +15994,15 @@
                 let uploadedMaterials = 0;
                 let uploadedClassroomNotes = 0;
                 const skippedMissingClassroomMaterials = [];
+                const skippedMissingClassroomNotes = [];
                 for (const listKey of ['courses', 'seminars']) {
                     for (const folder of (appData.classroom?.[listKey] || [])) {
                         for (const session of (folder.sessions || [])) {
                             for (const mat of (session.sourceFolder || [])) {
                                 if (mat.type === 'recording') {
                                     if (!await r2SyncRecording(mat)) {
-                                        throw new Error(i18n('recording_not_fully_saved', mat.id));
+                                        skippedMissingClassroomMaterials.push(mat.id);
+                                        console.warn('跳过本地不完整的录音，继续手动全量同步:', mat.id);
                                     }
                                 } else {
                                     try {
@@ -15997,8 +16016,13 @@
                             }
                             for (const note of (session.notes || [])) {
                                 if (!note.contentKey) continue;
-                                await r2SyncClassroomNote(note);
-                                uploadedClassroomNotes++;
+                                try {
+                                    if (await r2SyncClassroomNote(note)) uploadedClassroomNotes++;
+                                } catch (e) {
+                                    if (e?.code !== 'LOCAL_CLASSROOM_NOTE_MISSING') throw e;
+                                    skippedMissingClassroomNotes.push(note.id);
+                                    console.warn('跳过本地缺失的课堂讲义，继续手动全量同步:', note.id);
+                                }
                             }
                         }
                     }
@@ -16019,6 +16043,9 @@
                 }
                 if (skippedMissingClassroomMaterials.length) {
                     console.warn('本轮全量同步跳过的本地缺失课堂素材:', skippedMissingClassroomMaterials);
+                }
+                if (skippedMissingClassroomNotes.length) {
+                    console.warn('本轮全量同步跳过的本地缺失课堂讲义:', skippedMissingClassroomNotes);
                 }
 
                 // 2. 上传PDF文件 (从IndexedDB获取)

--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -14040,6 +14040,10 @@
                             }
                         }
                         catch (e) {
+                            if (e?.code === 'LOCAL_CLASSROOM_ASSET_MISSING') {
+                                console.warn('跳过本地缺失的课堂素材，继续定时全量同步:', matId);
+                                continue;
+                            }
                             classroomPayloadSyncFailed = true;
                             console.warn('上传新课堂素材失败:', matId, e);
                         }
@@ -14678,7 +14682,21 @@
             if (!material?.id || material.type === 'recording') return false;
             let data = material.data;
             if (!data) data = await getFileData(classroomAssetDataKey(material.id)).catch(() => null);
-            if (!data) throw new Error(i18n('local_class_material_missing', material.id));
+            // 已确认提交过云端的素材不要求本机仍保留一份副本；手动全量同步不能
+            // 因为这种本地缓存缺失而中断。未提交过且本地也缺失的条目保持 pending，
+            // 由 metadata 过滤，但其它类别继续同步。
+            if (!data && material.assetCloudCommitted === true) return true;
+            if (!data) {
+                const current = _findRecordingMaterial(material.id);
+                if (current) {
+                    current.material.assetCloudCommitted = false;
+                    current.material.assetMetadataCloudCommitted = false;
+                    saveData();
+                }
+                const error = new Error(i18n('local_class_material_missing', material.id));
+                error.code = 'LOCAL_CLASSROOM_ASSET_MISSING';
+                throw error;
+            }
             await r2PutObject('classroom/' + material.id, data,
                 material.mimeType || 'application/octet-stream');
             const current = _findRecordingMaterial(material.id);
@@ -15958,6 +15976,7 @@
                 // 课堂正文（录音、照片/文件、AI 讲义）必须全部先于 metadata 提交。
                 let uploadedMaterials = 0;
                 let uploadedClassroomNotes = 0;
+                const skippedMissingClassroomMaterials = [];
                 for (const listKey of ['courses', 'seminars']) {
                     for (const folder of (appData.classroom?.[listKey] || [])) {
                         for (const session of (folder.sessions || [])) {
@@ -15967,8 +15986,13 @@
                                         throw new Error(i18n('recording_not_fully_saved', mat.id));
                                     }
                                 } else {
-                                    await r2SyncClassroomAsset(mat);
-                                    uploadedMaterials++;
+                                    try {
+                                        if (await r2SyncClassroomAsset(mat)) uploadedMaterials++;
+                                    } catch (e) {
+                                        if (e?.code !== 'LOCAL_CLASSROOM_ASSET_MISSING') throw e;
+                                        skippedMissingClassroomMaterials.push(mat.id);
+                                        console.warn('跳过本地缺失的课堂素材，继续手动全量同步:', mat.id);
+                                    }
                                 }
                             }
                             for (const note of (session.notes || [])) {
@@ -15992,6 +16016,9 @@
                     });
                 if (metadataPublishResult.casCommitted) {
                     await flushClassroomDeletionOutboxAfterMetadata();
+                }
+                if (skippedMissingClassroomMaterials.length) {
+                    console.warn('本轮全量同步跳过的本地缺失课堂素材:', skippedMissingClassroomMaterials);
                 }
 
                 // 2. 上传PDF文件 (从IndexedDB获取)

--- a/docs/index.html
+++ b/docs/index.html
@@ -14028,7 +14028,9 @@
                             classroomRecordingState?.id === found.material.id) continue;
                         try {
                             if (found.material.recordingCloudCommitted !== true &&
-                                !await r2SyncRecording(found.material)) classroomPayloadSyncFailed = true;
+                                !await r2SyncRecording(found.material)) {
+                                console.warn('跳过本地不完整的录音，继续定时全量同步:', matId);
+                            }
                         } catch (e) {
                             classroomPayloadSyncFailed = true;
                             console.warn('上传新录音失败:', matId, e);
@@ -14058,6 +14060,10 @@
                         }
                     }
                     catch (e) {
+                        if (e?.code === 'LOCAL_CLASSROOM_NOTE_MISSING') {
+                            console.warn('跳过本地缺失的课堂讲义，继续定时全量同步:', noteId);
+                            continue;
+                        }
                         classroomPayloadSyncFailed = true;
                         console.warn('上传新课堂讲义失败:', noteId, e);
                     }
@@ -14716,7 +14722,18 @@
         async function r2SyncClassroomNote(note) {
             if (!note?.id) return false;
             const content = await ensureClassroomNoteContent(note);
-            if (!String(content || '').trim()) throw new Error(i18n('class_note_content_missing', note.id));
+            if (!String(content || '').trim() && note.contentCloudCommitted === true) return true;
+            if (!String(content || '').trim()) {
+                const current = _findClassroomNote(note.id);
+                if (current) {
+                    current.note.contentCloudCommitted = false;
+                    current.note.contentMetadataCloudCommitted = false;
+                    saveData();
+                }
+                const error = new Error(i18n('class_note_content_missing', note.id));
+                error.code = 'LOCAL_CLASSROOM_NOTE_MISSING';
+                throw error;
+            }
             await r2PutObject('classroom/notes/' + note.id + '.md', content,
                 'text/markdown; charset=utf-8');
             const current = _findClassroomNote(note.id);
@@ -15977,13 +15994,15 @@
                 let uploadedMaterials = 0;
                 let uploadedClassroomNotes = 0;
                 const skippedMissingClassroomMaterials = [];
+                const skippedMissingClassroomNotes = [];
                 for (const listKey of ['courses', 'seminars']) {
                     for (const folder of (appData.classroom?.[listKey] || [])) {
                         for (const session of (folder.sessions || [])) {
                             for (const mat of (session.sourceFolder || [])) {
                                 if (mat.type === 'recording') {
                                     if (!await r2SyncRecording(mat)) {
-                                        throw new Error(i18n('recording_not_fully_saved', mat.id));
+                                        skippedMissingClassroomMaterials.push(mat.id);
+                                        console.warn('跳过本地不完整的录音，继续手动全量同步:', mat.id);
                                     }
                                 } else {
                                     try {
@@ -15997,8 +16016,13 @@
                             }
                             for (const note of (session.notes || [])) {
                                 if (!note.contentKey) continue;
-                                await r2SyncClassroomNote(note);
-                                uploadedClassroomNotes++;
+                                try {
+                                    if (await r2SyncClassroomNote(note)) uploadedClassroomNotes++;
+                                } catch (e) {
+                                    if (e?.code !== 'LOCAL_CLASSROOM_NOTE_MISSING') throw e;
+                                    skippedMissingClassroomNotes.push(note.id);
+                                    console.warn('跳过本地缺失的课堂讲义，继续手动全量同步:', note.id);
+                                }
                             }
                         }
                     }
@@ -16019,6 +16043,9 @@
                 }
                 if (skippedMissingClassroomMaterials.length) {
                     console.warn('本轮全量同步跳过的本地缺失课堂素材:', skippedMissingClassroomMaterials);
+                }
+                if (skippedMissingClassroomNotes.length) {
+                    console.warn('本轮全量同步跳过的本地缺失课堂讲义:', skippedMissingClassroomNotes);
                 }
 
                 // 2. 上传PDF文件 (从IndexedDB获取)

--- a/docs/index.html
+++ b/docs/index.html
@@ -14040,6 +14040,10 @@
                             }
                         }
                         catch (e) {
+                            if (e?.code === 'LOCAL_CLASSROOM_ASSET_MISSING') {
+                                console.warn('跳过本地缺失的课堂素材，继续定时全量同步:', matId);
+                                continue;
+                            }
                             classroomPayloadSyncFailed = true;
                             console.warn('上传新课堂素材失败:', matId, e);
                         }
@@ -14678,7 +14682,21 @@
             if (!material?.id || material.type === 'recording') return false;
             let data = material.data;
             if (!data) data = await getFileData(classroomAssetDataKey(material.id)).catch(() => null);
-            if (!data) throw new Error(i18n('local_class_material_missing', material.id));
+            // 已确认提交过云端的素材不要求本机仍保留一份副本；手动全量同步不能
+            // 因为这种本地缓存缺失而中断。未提交过且本地也缺失的条目保持 pending，
+            // 由 metadata 过滤，但其它类别继续同步。
+            if (!data && material.assetCloudCommitted === true) return true;
+            if (!data) {
+                const current = _findRecordingMaterial(material.id);
+                if (current) {
+                    current.material.assetCloudCommitted = false;
+                    current.material.assetMetadataCloudCommitted = false;
+                    saveData();
+                }
+                const error = new Error(i18n('local_class_material_missing', material.id));
+                error.code = 'LOCAL_CLASSROOM_ASSET_MISSING';
+                throw error;
+            }
             await r2PutObject('classroom/' + material.id, data,
                 material.mimeType || 'application/octet-stream');
             const current = _findRecordingMaterial(material.id);
@@ -15958,6 +15976,7 @@
                 // 课堂正文（录音、照片/文件、AI 讲义）必须全部先于 metadata 提交。
                 let uploadedMaterials = 0;
                 let uploadedClassroomNotes = 0;
+                const skippedMissingClassroomMaterials = [];
                 for (const listKey of ['courses', 'seminars']) {
                     for (const folder of (appData.classroom?.[listKey] || [])) {
                         for (const session of (folder.sessions || [])) {
@@ -15967,8 +15986,13 @@
                                         throw new Error(i18n('recording_not_fully_saved', mat.id));
                                     }
                                 } else {
-                                    await r2SyncClassroomAsset(mat);
-                                    uploadedMaterials++;
+                                    try {
+                                        if (await r2SyncClassroomAsset(mat)) uploadedMaterials++;
+                                    } catch (e) {
+                                        if (e?.code !== 'LOCAL_CLASSROOM_ASSET_MISSING') throw e;
+                                        skippedMissingClassroomMaterials.push(mat.id);
+                                        console.warn('跳过本地缺失的课堂素材，继续手动全量同步:', mat.id);
+                                    }
                                 }
                             }
                             for (const note of (session.notes || [])) {
@@ -15992,6 +16016,9 @@
                     });
                 if (metadataPublishResult.casCommitted) {
                     await flushClassroomDeletionOutboxAfterMetadata();
+                }
+                if (skippedMissingClassroomMaterials.length) {
+                    console.warn('本轮全量同步跳过的本地缺失课堂素材:', skippedMissingClassroomMaterials);
                 }
 
                 // 2. 上传PDF文件 (从IndexedDB获取)


### PR DESCRIPTION
修复手动和定时全量同步被本地课堂数据缺失中断的问题。

- 普通课堂素材缺失时只跳过该条
- 本地录音不完整时只跳过该条
- 课堂讲义正文缺失时只跳过该条
- 笔记本所有页面仍先于课堂数据同步
- Android 与 docs 同步实现保持一致

PR #66 保持原提交不变；本 PR 为独立修改。