### PR TITLE
Fix notebook UI/sync issues, iOS selection guard, Pencil mode, BOOX ZIP export, camera permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ API Key 保存在本机设置中，不会随 R2 元数据同步到云端；完�
 3. 进入具体场次后，使用右下角按钮：
    - **麦克风**：开始/停止课堂录音；首次使用需要授予麦克风权限。
    - **上传**：可选择图片、音频、PDF、Word、纯文本、Markdown、TeX/LaTeX 等资料。
-   - **相机**：拍摄板书、讲义或现场资料。
+   - **相机**：拍摄板书、讲义或现场资料；安卓 APK 首次使用需要授予相机权限。
 4. 上传完成后，资料保存在“源素材”，应用会基于素材生成 AI 笔记；停止录音后会保存录音并生成转写纪要。
 5. 打开 AI 笔记可阅读 LaTeX 内容、查看进度，并通过来源引用跳回对应素材。
 6. 长按源素材可重新生成笔记或删除；长按 AI 笔记可下载 Markdown 或删除。课程/讲座文件夹支持重命名和删除，场次支持重命名。
@@ -268,7 +268,7 @@ Normal text search on a text PDF does not need AI. OCR, lasso questions, and scr
 
 1. Tap an empty area under Course or Seminar to create a top-level folder.
 2. Open it and create a session. A date-based title is suggested and can be edited.
-3. In the session, use the lower-right actions to record audio, upload files, or take a photo. Uploads accept images, audio, PDF, Word, plain text, Markdown, and TeX/LaTeX files.
+3. In the session, use the lower-right actions to record audio, upload files, or take a photo. The Android APK asks for camera permission the first time you take a photo. Uploads accept images, audio, PDF, Word, plain text, Markdown, and TeX/LaTeX files.
 4. Uploaded material appears under Source Material and is converted into an AI note. Stopping a recording saves it and starts transcript/minutes generation.
 5. Open an AI note to read formatted math and follow source references back to the original material.
 6. Long-press source material to regenerate its note or delete it. Long-press an AI note to download Markdown or delete it. Folders and sessions can be renamed.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,17 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
+    <!-- 课堂「拍照」按钮：<input capture> 经 WebView 文件选择器启动系统相机 -->
+    <uses-permission android:name="android.permission.CAMERA" />
+
+    <uses-feature android:name="android.hardware.camera.any" android:required="false" />
+
+    <!-- Android 11+ 包可见性：允许解析系统相机的拍照 Intent -->
+    <queries>
+        <intent>
+            <action android:name="android.media.action.IMAGE_CAPTURE" />
+        </intent>
+    </queries>
 
     <application
         android:name=".MainApp"
@@ -28,6 +39,17 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <!-- 相机拍照的输出文件（应用缓存目录）经 FileProvider 授权给系统相机写入 -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
 
     </application>
 

--- a/app/src/main/assets/boox-pen.js
+++ b/app/src/main/assets/boox-pen.js
@@ -7,7 +7,7 @@
  *    探测完全基于 PWA 已有的通用信号（可见性 + pointer-events），不依赖其内部状态。
  * 2. 抬笔后原生回传整笔触点，本脚本以合成 PointerEvent 回放给画布元素，
  *    PWA 自己的绘制/撤销/保存逻辑零修改全部复用。
- * 3. 拦截 blob: 下载（PWA 导出 PDF/JSON），转交原生保存到下载目录。
+ * 3. 拦截 blob: 下载（PWA 导出 PDF / 数据备份 ZIP / JSON），分片转交原生保存到下载目录。
  *
  * index.html 含阅读器套索模式的 Boox 集成补丁，升级上游时需保留对应接口。
  */
@@ -58,22 +58,62 @@
     /* ---------------- blob 下载桥接（与手写 SDK 无关，始终启用） ---------------- */
     var dl = window.BooxDownloadNative;
     if (dl) {
+        /* 分片大小（原始字节）。数据备份 ZIP 可达几十到几百 MB，整体 readAsDataURL 会撞上
+         * JS 字符串长度上限，整段传给 JS 桥也会超出单次消息上限而静默失败——PDF 小所以能
+         * 成功，ZIP 却拿不到文件。改为逐片 base64 → DownloadBridge.appendBase64，Java 侧逐片
+         * 解码追加，最终与 PDF 走同一 open()，落在同一下载目录。 */
+        var SAVE_CHUNK_BYTES = 2 * 1024 * 1024;
+        var base64Of = function (blob) {
+            return new Promise(function (resolve, reject) {
+                var fr = new FileReader();
+                fr.onload = function () {
+                    var s = String(fr.result || '');
+                    var i = s.indexOf(',');
+                    resolve(i >= 0 ? s.slice(i + 1) : '');
+                };
+                fr.onerror = function () { reject(fr.error || new Error('read failed')); };
+                fr.readAsDataURL(blob);
+            });
+        };
+        var saveBlobChunked = function (name, blob) {
+            var mime = blob.type || 'application/octet-stream';
+            if (typeof dl.beginSave !== 'function') {
+                // 旧版原生桥：整体一次写入
+                return base64Of(blob).then(function (b64) { dl.saveBase64(name, mime, b64); });
+            }
+            var token = dl.beginSave(name, mime);
+            if (!token) { throw new Error('beginSave failed'); }
+            var offset = 0;
+            var step = function () {
+                if (offset >= blob.size) {
+                    if (!dl.finishSave(token)) { throw new Error('finishSave failed'); }
+                    return;
+                }
+                var slice = blob.slice(offset, Math.min(blob.size, offset + SAVE_CHUNK_BYTES), mime);
+                return base64Of(slice).then(function (b64) {
+                    if (!dl.appendBase64(token, b64)) { throw new Error('appendBase64 failed'); }
+                    offset += slice.size;
+                    return step();
+                }, function (err) {
+                    try { dl.abortSave(token, String(err && err.message || err)); } catch (e) { /* 忽略 */ }
+                    throw err;
+                });
+            };
+            return Promise.resolve().then(step);
+        };
         var handleBlobAnchor = function (a) {
             var name = a.getAttribute('download') || 'download.bin';
             fetch(a.href)
                 .then(function (r) { return r.blob(); })
-                .then(function (blob) {
-                    var fr = new FileReader();
-                    fr.onload = function () {
-                        var s = String(fr.result || '');
-                        var i = s.indexOf(',');
-                        if (i >= 0) {
-                            dl.saveBase64(name, blob.type || 'application/octet-stream', s.slice(i + 1));
+                .then(function (blob) { return saveBlobChunked(name, blob); })
+                .catch(function (e) {
+                    console.warn('boox-pen: blob download failed', e);
+                    try {
+                        if (typeof window.showToast === 'function') {
+                            window.showToast((typeof window.i18n === 'function' ? window.i18n('export_failed') : '导出失败：') + name);
                         }
-                    };
-                    fr.readAsDataURL(blob);
-                })
-                .catch(function (e) { console.warn('boox-pen: blob download failed', e); });
+                    } catch (e2) { /* 忽略 */ }
+                });
         };
         // PWA 多处用 a.click() 触发下载，且 anchor 可能未挂到 DOM，必须打补丁
         var origClick = HTMLAnchorElement.prototype.click;

--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -4532,18 +4532,32 @@
             background: var(--bg-secondary);
             display: none;
             flex-direction: column;
+            /* 顶栏实际高度由 nbLayout() 量测后写入，窄屏换行为两行时左栏/画布区随之下移 */
+            --nb-topbar-h: 52px;
         }
         .nb-editor.show { display: flex; }
         .nb-topbar {
-            height: 52px; flex-shrink: 0;
+            min-height: 52px; flex-shrink: 0;
             background: var(--bg-primary);
             border-bottom: 1px solid var(--border-color, rgba(0,0,0,0.08));
             display: flex; align-items: center; justify-content: space-between;
             padding: 0 10px; gap: 8px; z-index: 3010;
         }
         .nb-topbar-left { display: flex; align-items: center; gap: 8px; min-width: 0; flex: 1; }
-        .nb-topbar-right { display: flex; align-items: center; gap: 4px; flex-shrink: 0; }
+        .nb-topbar-right, .nb-topbar-nav { display: flex; align-items: center; gap: 4px; flex-shrink: 0; }
         .nb-title { font-size: 15px; font-weight: 700; color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 30vw; }
+        /* 手机等窄屏：笔刷/橡皮/撤销重做换行到第二行；退出、标题与翻页留在首行，
+           顶栏不再横向溢出屏幕，退出与下一页按钮始终可点 */
+        @media (max-width: 640px) {
+            .nb-topbar { flex-wrap: wrap; padding: 4px 8px; row-gap: 2px; column-gap: 6px; }
+            .nb-topbar-left { order: 0; min-height: 40px; }
+            .nb-topbar-nav { order: 1; min-height: 40px; }
+            .nb-topbar-nav .nb-tb-sep { display: none; }
+            .nb-topbar-right { order: 2; flex: 1 1 100%; justify-content: center; gap: 6px; min-height: 40px; }
+            .nb-title { max-width: none; }
+            .nb-topbar .nb-tb-btn, .nb-topbar .nb-brush-btn { width: 36px; height: 36px; }
+            .nb-pageno { padding: 6px 8px; }
+        }
         .nb-tb-btn {
             width: 38px; height: 38px; border: none; background: none; border-radius: 10px;
             display: flex; align-items: center; justify-content: center; cursor: pointer;
@@ -4569,7 +4583,7 @@
 
         /* ---------- 左栏 ---------- */
         .nb-leftbar {
-            position: absolute; left: 0; top: 52px; bottom: 0; width: 56px;
+            position: absolute; left: 0; top: var(--nb-topbar-h, 52px); bottom: 0; width: 56px;
             background: var(--bg-primary);
             border-right: 1px solid var(--border-color, rgba(0,0,0,0.08));
             display: flex; flex-direction: column; align-items: center;
@@ -4589,7 +4603,7 @@
 
         /* ---------- 画布区 ---------- */
         .nb-canvas-wrap {
-            position: absolute; left: 56px; right: 0; top: 52px; bottom: 0;
+            position: absolute; left: 56px; right: 0; top: var(--nb-topbar-h, 52px); bottom: 0;
             overflow: auto;
             display: block;
             background: var(--bg-secondary);
@@ -4608,6 +4622,13 @@
         #nbTextLayer { position: absolute; left: 0; top: 0; z-index: 4; pointer-events: none; transform-origin: 0 0; }
         #nbTextLayer > * { pointer-events: auto; }
         body.nb-text-mode #nbTextLayer { cursor: text; }
+        /* iOS/iPadOS：书写区与工具栏禁止原生文本选择和长按呼出菜单，避免长按或 Pencil 抖动
+           唤起浏览器选区/放大镜（同阅读页画笔模式的处理）；正在编辑的文本框保留原生光标与选区 */
+        .nb-editor .nb-topbar, .nb-editor .nb-leftbar, .nb-editor .nb-canvas-wrap,
+        .nb-editor .nb-canvas-wrap *:not([contenteditable="true"]) {
+            -webkit-user-select: none; user-select: none; -webkit-touch-callout: none;
+        }
+        .nb-editor .nb-textbox-inner[contenteditable="true"] { -webkit-user-select: text; user-select: text; }
 
         .nb-textbox {
             position: absolute;
@@ -4681,7 +4702,7 @@
 
         /* ---------- 页面大纲抽屉 ---------- */
         .nb-outline {
-            position: absolute; right: 0; top: 52px; bottom: 0; width: 330px; max-width: 85vw;
+            position: absolute; right: 0; top: var(--nb-topbar-h, 52px); bottom: 0; width: 330px; max-width: 85vw;
             background: var(--bg-primary);
             box-shadow: -4px 0 16px rgba(0,0,0,0.12);
             z-index: 3040; display: none; flex-direction: column; padding: 12px;
@@ -6134,6 +6155,8 @@
                 <button class="nb-tb-btn" id="nbRedoBtn" onclick="nbRedo()" title="重做" data-i18n="redo" data-i18n-attr="title">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 14 20 9 15 4"/><path d="M4 20v-7a4 4 0 014-4h12"/></svg>
                 </button>
+            </div>
+            <div class="nb-topbar-nav">
                 <div class="nb-tb-sep"></div>
                 <button class="nb-tb-btn" onclick="nbPrevPage()" title="上一页" data-i18n="prev_page" data-i18n-attr="title">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg>
@@ -6961,7 +6984,7 @@
             local_class_material_missing:'本地课堂素材缺失：{0}', class_material_index_changed:'课堂素材索引已变化：{0}', class_note_content_missing:'课堂讲义内容缺失：{0}', class_note_index_changed:'课堂讲义索引已变化：{0}', delete_cloud_class_material_failed:'删除云端课堂素材失败：{0}', delete_cloud_class_note_failed:'删除云端课堂讲义失败：{0}',
             notification_lecture_sync_title:'讲义同步完成', notification_lecture_sync_body:'讲义已同步到云端', notification_abstract_sync_title:'摘要同步完成', notification_abstract_sync_body:'摘要已同步到云端', network_endpoint_cors_error:'网络、Endpoint 或 CORS 配置错误', permission_key_error:'权限或密钥错误', bucket_not_found:'未找到存储桶',
             local_recording_chunk_corrupt:'本地录音分块 {0} 损坏', recording_source_size_failed:'无法确认录音源文件大小', cloud_recording_manifest_invalid:'云端录音清单无效', cloud_recording_chunk_invalid:'云端录音分块 {0} 无效', cloud_recording_chunk_hash_failed:'云端录音分块 {0} 校验失败', delete_cloud_recording_manifest_failed:'删除云端录音清单失败：{0}', delete_cloud_recording_chunk_failed:'删除云端录音分块失败：{0}', delete_legacy_cloud_recording_failed:'删除旧版云端录音失败：{0}',
-            confirm_empty_local_overwrite_cloud:'本地数据为空。确定要覆盖非空的云端数据吗？', upload_cancelled:'上传已取消', recording_not_fully_saved:'录音尚未完整保存：{0}', cloud_index_repaired:'云端索引已修复', count_lectures:'{0} 篇讲义', count_abstracts:'{0} 篇摘要', count_class_materials:'{0} 个课堂素材', count_exercise_files:'{0} 个习题文件', count_note_pages:'{0} 页笔记', count_note_media:'{0} 个笔记媒体', confirm_empty_cloud_overwrite_local:'云端数据为空。确定要覆盖本地数据吗？', restore_cancelled:'恢复已取消', restore_notebook_detail:'，另恢复 {0} 页笔记和 {1} 个媒体文件',
+            confirm_empty_local_overwrite_cloud:'本地数据为空。确定要覆盖非空的云端数据吗？', upload_cancelled:'上传已取消', recording_not_fully_saved:'录音尚未完整保存：{0}', sync_skipped_class_items:'；{0} 个课堂素材在本机缺失已跳过，云端已有内容保持不变', cloud_index_repaired:'云端索引已修复', count_lectures:'{0} 篇讲义', count_abstracts:'{0} 篇摘要', count_class_materials:'{0} 个课堂素材', count_exercise_files:'{0} 个习题文件', count_note_pages:'{0} 页笔记', count_note_media:'{0} 个笔记媒体', confirm_empty_cloud_overwrite_local:'云端数据为空。确定要覆盖本地数据吗？', restore_cancelled:'恢复已取消', restore_notebook_detail:'，另恢复 {0} 页笔记和 {1} 个媒体文件',
             backup_file_too_large:'备份文件过大', compressed_zip_unsupported:'不支持压缩格式的 ZIP 条目', zip_descriptor_unsupported:'不支持带数据描述符的 ZIP 条目', recording_backup_source_size_invalid:'录音备份源大小无效：{0}', recording_backup_manifest_invalid:'录音备份清单无效：{0}', recording_backup_chunk_missing:'录音 {0} 的第 {1} 个备份分块缺失', recording_backup_length_failed:'录音备份长度校验失败：{0}', unknown_recording_backup_source:'未知的录音备份源：{0}', legacy_recording_missing:'旧版录音缺失：{0}', recording_backup_chunk_length_failed:'录音备份分块长度校验失败：{0}', recording_backup_chunk_missing_simple:'录音备份分块缺失：{0}', recording_has_no_backup_data:'录音没有可备份的数据：{0}', stop_recording_before_backup:'请先停止录音再备份', packing_zip_backup:'正在打包 ZIP 备份…', recording_added_during_export:'导出期间新增的录音',
             export_local_files_detail:'（含 {0} 个本地文件）', export_missing_recordings_detail:'（另含 {0} 个补充录音）', export_failed:'导出失败：', confirm_import_zip_overwrite:'导入 ZIP 备份将覆盖当前数据，是否继续？', parsing_zip_backup:'正在解析 ZIP 备份…', backup_missing_metadata:'备份中缺少 metadata.json', missing_recordings_manifest_invalid:'补充录音清单无效', missing_recordings_manifest_invalid_id:'补充录音清单包含无效 ID', recording_backup_index_invalid:'录音备份索引无效', recording_backup_chunk_invalid:'录音 {0} 的第 {1} 个备份分块无效', import_complete_files:'导入完成，共恢复 {0} 个文件', import_failed:'导入失败：',
             indexeddb_unavailable:'IndexedDB 不可用', transaction_aborted:'事务被中止：{0}', unknown_reason:'未知原因', recording_transaction_failed:'录音事务失败', recording_transaction_aborted:'录音事务被中止', class_file_transaction_failed:'课堂文件事务失败', class_file_transaction_aborted:'课堂文件事务被中止', recording_storage_module_not_loaded:'录音存储模块未加载', class_lecture_content_empty:'课堂讲义内容为空', data_structure_corrupt:'数据结构损坏：books/papers 不是数组'
@@ -6980,7 +7003,7 @@
             local_class_material_missing:'Local class material is missing: {0}', class_material_index_changed:'The class material index changed: {0}', class_note_content_missing:'Class lecture content is missing: {0}', class_note_index_changed:'The class lecture index changed: {0}', delete_cloud_class_material_failed:'Failed to delete cloud class material: {0}', delete_cloud_class_note_failed:'Failed to delete cloud class lecture: {0}',
             notification_lecture_sync_title:'Lecture sync complete', notification_lecture_sync_body:'The lecture was synced to the cloud', notification_abstract_sync_title:'Abstract sync complete', notification_abstract_sync_body:'The abstract was synced to the cloud', network_endpoint_cors_error:'Network, endpoint, or CORS configuration error', permission_key_error:'Permission or credential error', bucket_not_found:'Bucket not found',
             local_recording_chunk_corrupt:'Local recording chunk {0} is corrupted', recording_source_size_failed:'Could not verify the recording source size', cloud_recording_manifest_invalid:'The cloud recording manifest is invalid', cloud_recording_chunk_invalid:'Cloud recording chunk {0} is invalid', cloud_recording_chunk_hash_failed:'Cloud recording chunk {0} failed verification', delete_cloud_recording_manifest_failed:'Failed to delete cloud recording manifest: {0}', delete_cloud_recording_chunk_failed:'Failed to delete cloud recording chunk: {0}', delete_legacy_cloud_recording_failed:'Failed to delete legacy cloud recording: {0}',
-            confirm_empty_local_overwrite_cloud:'Local data is empty. Overwrite non-empty cloud data?', upload_cancelled:'Upload cancelled', recording_not_fully_saved:'Recording is not fully saved: {0}', cloud_index_repaired:'Cloud index repaired', count_lectures:'{0} lectures', count_abstracts:'{0} abstracts', count_class_materials:'{0} class materials', count_exercise_files:'{0} exercise files', count_note_pages:'{0} note pages', count_note_media:'{0} note media files', confirm_empty_cloud_overwrite_local:'Cloud data is empty. Overwrite local data?', restore_cancelled:'Restore cancelled', restore_notebook_detail:', plus {0} note pages and {1} media files',
+            confirm_empty_local_overwrite_cloud:'Local data is empty. Overwrite non-empty cloud data?', upload_cancelled:'Upload cancelled', recording_not_fully_saved:'Recording is not fully saved: {0}', sync_skipped_class_items:'; {0} class materials missing locally were skipped; existing cloud copies were kept', cloud_index_repaired:'Cloud index repaired', count_lectures:'{0} lectures', count_abstracts:'{0} abstracts', count_class_materials:'{0} class materials', count_exercise_files:'{0} exercise files', count_note_pages:'{0} note pages', count_note_media:'{0} note media files', confirm_empty_cloud_overwrite_local:'Cloud data is empty. Overwrite local data?', restore_cancelled:'Restore cancelled', restore_notebook_detail:', plus {0} note pages and {1} media files',
             backup_file_too_large:'Backup file is too large', compressed_zip_unsupported:'Compressed ZIP entries are not supported', zip_descriptor_unsupported:'ZIP data descriptors are not supported', recording_backup_source_size_invalid:'Invalid recording backup source size: {0}', recording_backup_manifest_invalid:'Invalid recording backup manifest: {0}', recording_backup_chunk_missing:'Backup chunk {1} is missing for recording {0}', recording_backup_length_failed:'Recording backup length verification failed: {0}', unknown_recording_backup_source:'Unknown recording backup source: {0}', legacy_recording_missing:'Legacy recording is missing: {0}', recording_backup_chunk_length_failed:'Recording backup chunk length verification failed: {0}', recording_backup_chunk_missing_simple:'Recording backup chunk is missing: {0}', recording_has_no_backup_data:'Recording has no data to back up: {0}', stop_recording_before_backup:'Stop recording before creating a backup', packing_zip_backup:'Packing ZIP backup…', recording_added_during_export:'Recording added during export',
             export_local_files_detail:' ({0} local files included)', export_missing_recordings_detail:' ({0} supplemental recordings included)', export_failed:'Export failed: ', confirm_import_zip_overwrite:'Importing this ZIP backup will overwrite current data. Continue?', parsing_zip_backup:'Parsing ZIP backup…', backup_missing_metadata:'metadata.json is missing from the backup', missing_recordings_manifest_invalid:'Supplemental recording manifest is invalid', missing_recordings_manifest_invalid_id:'Supplemental recording manifest contains an invalid ID', recording_backup_index_invalid:'Recording backup index is invalid', recording_backup_chunk_invalid:'Backup chunk {1} is invalid for recording {0}', import_complete_files:'Import complete: {0} files restored', import_failed:'Import failed: ',
             indexeddb_unavailable:'IndexedDB is unavailable', transaction_aborted:'Transaction aborted: {0}', unknown_reason:'Unknown reason', recording_transaction_failed:'Recording transaction failed', recording_transaction_aborted:'Recording transaction was aborted', class_file_transaction_failed:'Class file transaction failed', class_file_transaction_aborted:'Class file transaction was aborted', recording_storage_module_not_loaded:'Recording storage module is not loaded', class_lecture_content_empty:'Class lecture content is empty', data_structure_corrupt:'Corrupted data structure: books/papers must be arrays'
@@ -6999,7 +7022,7 @@
             local_class_material_missing:'Support de cours local manquant : {0}', class_material_index_changed:"L’index des supports de cours a changé : {0}", class_note_content_missing:'Contenu du cours manquant : {0}', class_note_index_changed:"L’index des cours a changé : {0}", delete_cloud_class_material_failed:'Échec de suppression du support cloud : {0}', delete_cloud_class_note_failed:'Échec de suppression du cours cloud : {0}',
             notification_lecture_sync_title:'Synchronisation du cours terminée', notification_lecture_sync_body:'Le cours a été synchronisé dans le cloud', notification_abstract_sync_title:'Synchronisation du résumé terminée', notification_abstract_sync_body:'Le résumé a été synchronisé dans le cloud', network_endpoint_cors_error:'Erreur de réseau, d’endpoint ou de configuration CORS', permission_key_error:'Erreur d’autorisation ou d’identifiants', bucket_not_found:'Bucket introuvable',
             local_recording_chunk_corrupt:"Le segment local d’enregistrement {0} est corrompu", recording_source_size_failed:"Impossible de vérifier la taille de l’enregistrement source", cloud_recording_manifest_invalid:"Le manifeste cloud de l’enregistrement est invalide", cloud_recording_chunk_invalid:'Le segment cloud {0} est invalide', cloud_recording_chunk_hash_failed:'Échec de vérification du segment cloud {0}', delete_cloud_recording_manifest_failed:'Échec de suppression du manifeste cloud : {0}', delete_cloud_recording_chunk_failed:'Échec de suppression du segment cloud : {0}', delete_legacy_cloud_recording_failed:"Échec de suppression de l’ancien enregistrement cloud : {0}",
-            confirm_empty_local_overwrite_cloud:'Les données locales sont vides. Remplacer les données cloud non vides ?', upload_cancelled:'Envoi annulé', recording_not_fully_saved:"L’enregistrement n’est pas entièrement sauvegardé : {0}", cloud_index_repaired:'Index cloud réparé', count_lectures:'{0} cours', count_abstracts:'{0} résumés', count_class_materials:'{0} supports de cours', count_exercise_files:'{0} fichiers d’exercices', count_note_pages:'{0} pages de notes', count_note_media:'{0} médias de notes', confirm_empty_cloud_overwrite_local:'Les données cloud sont vides. Remplacer les données locales ?', restore_cancelled:'Restauration annulée', restore_notebook_detail:', plus {0} pages de notes et {1} médias',
+            confirm_empty_local_overwrite_cloud:'Les données locales sont vides. Remplacer les données cloud non vides ?', upload_cancelled:'Envoi annulé', recording_not_fully_saved:"L’enregistrement n’est pas entièrement sauvegardé : {0}", sync_skipped_class_items:' ; {0} supports de cours absents localement ont été ignorés ; les copies cloud existantes ont été conservées', cloud_index_repaired:'Index cloud réparé', count_lectures:'{0} cours', count_abstracts:'{0} résumés', count_class_materials:'{0} supports de cours', count_exercise_files:'{0} fichiers d’exercices', count_note_pages:'{0} pages de notes', count_note_media:'{0} médias de notes', confirm_empty_cloud_overwrite_local:'Les données cloud sont vides. Remplacer les données locales ?', restore_cancelled:'Restauration annulée', restore_notebook_detail:', plus {0} pages de notes et {1} médias',
             backup_file_too_large:'Le fichier de sauvegarde est trop volumineux', compressed_zip_unsupported:'Les entrées ZIP compressées ne sont pas prises en charge', zip_descriptor_unsupported:'Les descripteurs de données ZIP ne sont pas pris en charge', recording_backup_source_size_invalid:'Taille de source de sauvegarde invalide : {0}', recording_backup_manifest_invalid:'Manifeste de sauvegarde invalide : {0}', recording_backup_chunk_missing:"Le segment {1} de l’enregistrement {0} manque dans la sauvegarde", recording_backup_length_failed:'Échec de vérification de la longueur de la sauvegarde : {0}', unknown_recording_backup_source:'Source de sauvegarde inconnue : {0}', legacy_recording_missing:'Ancien enregistrement manquant : {0}', recording_backup_chunk_length_failed:'Échec de vérification de la longueur du segment : {0}', recording_backup_chunk_missing_simple:'Segment de sauvegarde manquant : {0}', recording_has_no_backup_data:"L’enregistrement ne contient aucune donnée à sauvegarder : {0}", stop_recording_before_backup:"Arrêtez l’enregistrement avant de créer une sauvegarde", packing_zip_backup:'Création de la sauvegarde ZIP…', recording_added_during_export:'Enregistrement ajouté pendant l’exportation',
             export_local_files_detail:' ({0} fichiers locaux inclus)', export_missing_recordings_detail:' ({0} enregistrements supplémentaires inclus)', export_failed:"Échec de l’exportation : ", confirm_import_zip_overwrite:'Importer cette sauvegarde ZIP remplacera les données actuelles. Continuer ?', parsing_zip_backup:'Analyse de la sauvegarde ZIP…', backup_missing_metadata:'metadata.json manque dans la sauvegarde', missing_recordings_manifest_invalid:'Le manifeste des enregistrements supplémentaires est invalide', missing_recordings_manifest_invalid_id:'Le manifeste contient un identifiant invalide', recording_backup_index_invalid:"L’index de sauvegarde des enregistrements est invalide", recording_backup_chunk_invalid:'Le segment {1} de l’enregistrement {0} est invalide', import_complete_files:'Importation terminée : {0} fichiers restaurés', import_failed:"Échec de l’importation : ",
             indexeddb_unavailable:'IndexedDB est indisponible', transaction_aborted:'Transaction interrompue : {0}', unknown_reason:'Raison inconnue', recording_transaction_failed:"Échec de la transaction d’enregistrement", recording_transaction_aborted:"La transaction d’enregistrement a été interrompue", class_file_transaction_failed:'Échec de la transaction du fichier de cours', class_file_transaction_aborted:'La transaction du fichier de cours a été interrompue', recording_storage_module_not_loaded:"Le module de stockage des enregistrements n’est pas chargé", class_lecture_content_empty:'Le contenu du cours est vide', data_structure_corrupt:'Structure de données corrompue : books/papers doivent être des tableaux'
@@ -15918,26 +15941,43 @@
                     }
                     allowEmptyMetadataOverwrite = true;
                 }
-                // 课堂正文（录音、照片/文件、AI 讲义）必须全部先于 metadata 提交。
+                // 课堂正文（录音、照片/文件、AI 讲义）先于 metadata 提交。单个素材在本机缺失
+                // （仅存在于云端尚未下载、录音尚未完整保存等）或上传失败时只跳过该素材，不中止
+                // 整次手动同步：跳过项不会上传任何空正文；其云端已有的正文对象原样保留，云端索引
+                // 中的对应条目也由随后的 CAS 合并按云端副本保留（同 id 以云端为准，本机 pending
+                // 条目不会进入出站索引），因此不会被本机的空数据覆盖。
                 let uploadedMaterials = 0;
                 let uploadedClassroomNotes = 0;
+                const skippedClassroomItems = [];
+                const skipClassroomItem = (item, reason) => {
+                    skippedClassroomItems.push({ id: item?.id, name: item?.name || item?.title || '', reason });
+                    console.warn('[sync] 课堂素材已跳过，云端已有内容保持不变:', item?.id, reason);
+                };
                 for (const listKey of ['courses', 'seminars']) {
                     for (const folder of (appData.classroom?.[listKey] || [])) {
                         for (const session of (folder.sessions || [])) {
                             for (const mat of (session.sourceFolder || [])) {
-                                if (mat.type === 'recording') {
-                                    if (!await r2SyncRecording(mat)) {
-                                        throw new Error(i18n('recording_not_fully_saved', mat.id));
+                                try {
+                                    if (mat.type === 'recording') {
+                                        if (!await r2SyncRecording(mat)) {
+                                            skipClassroomItem(mat, i18n('recording_not_fully_saved', mat.id));
+                                        }
+                                    } else {
+                                        await r2SyncClassroomAsset(mat);
+                                        uploadedMaterials++;
                                     }
-                                } else {
-                                    await r2SyncClassroomAsset(mat);
-                                    uploadedMaterials++;
+                                } catch (err) {
+                                    skipClassroomItem(mat, (err && err.message) || String(err));
                                 }
                             }
                             for (const note of (session.notes || [])) {
                                 if (!note.contentKey) continue;
-                                await r2SyncClassroomNote(note);
-                                uploadedClassroomNotes++;
+                                try {
+                                    await r2SyncClassroomNote(note);
+                                    uploadedClassroomNotes++;
+                                } catch (err) {
+                                    skipClassroomItem(note, (err && err.message) || String(err));
+                                }
                             }
                         }
                     }
@@ -16050,7 +16090,10 @@
                     }
                 }
 
-                showToast(i18n('sync_done_detail', uploadedFiles, uploadedLectures, uploadedAbstracts));
+                showToast(i18n('sync_done_detail', uploadedFiles, uploadedLectures, uploadedAbstracts) +
+                    (skippedClassroomItems.length
+                        ? i18n('sync_skipped_class_items', skippedClassroomItems.length)
+                        : ''));
             } catch (err) {
                 console.error('Sync to R2 failed:', err);
                 showToast(i18n('toast_sync_failed') + err.message);
@@ -28496,8 +28539,12 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
         // ==================== 布局与渲染 ====================
         function nbLayout() {
+            const editor = document.getElementById('nbEditor');
             const wrap = document.getElementById('nbCanvasWrap');
-            if (!wrap || !document.getElementById('nbEditor').classList.contains('show')) return;
+            if (!wrap || !editor || !editor.classList.contains('show')) return;
+            // 顶栏在窄屏会换行为两行：左栏与画布区的顶部偏移跟随顶栏实际高度
+            const topbar = editor.querySelector('.nb-topbar');
+            if (topbar) editor.style.setProperty('--nb-topbar-h', topbar.offsetHeight + 'px');
             const availW = wrap.clientWidth, availH = wrap.clientHeight;
             if (availW <= 0 || availH <= 0) return;
             nbState.fitScale = Math.min(availW / NB_PAGE_W, availH / NB_PAGE_H);
@@ -28893,10 +28940,131 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             c.addEventListener('pointerup', nbPointerUp);
             c.addEventListener('pointercancel', nbPointerUp);
             c.addEventListener('contextmenu', e => e.preventDefault());
+            nbInitPencilModeTouch(c);
+        }
+
+        // ---------- iOS/iPadOS 原生选区拦截（同阅读页画笔模式） ----------
+        // Safari 在长按、Pencil 抖动或跨元素拖动时会尝试建立原生文本选区并弹出放大镜/菜单，
+        // 打断书写。编辑器显示期间，在捕获阶段拦截书写区与工具栏上的 selectstart / dragstart /
+        // contextmenu，并清掉已经形成的选区；正在编辑的文本框与输入控件不受影响。
+        function nbNativeSelectionGuardOwns(target) {
+            const editor = document.getElementById('nbEditor');
+            if (!editor || !editor.classList.contains('show') || !target) return false;
+            const el = target.nodeType === Node.TEXT_NODE ? target.parentElement : target;
+            if (!el || typeof el.closest !== 'function') return false;
+            if (el.closest('[contenteditable="true"], input, textarea, select')) return false;
+            return !!el.closest('#nbEditor .nb-topbar, #nbEditor .nb-leftbar, #nbCanvasWrap');
+        }
+        function nbBlockNativeSelection(e) {
+            if (!e || !nbNativeSelectionGuardOwns(e.target)) return;
+            e.preventDefault();
+            if (typeof e.stopPropagation === 'function') e.stopPropagation();
+        }
+        function nbClearNativeSelection() {
+            const editor = document.getElementById('nbEditor');
+            if (!editor || !editor.classList.contains('show')) return;
+            const selection = typeof window.getSelection === 'function' ? window.getSelection() : null;
+            if (!selection || !selection.rangeCount) return;
+            if (nbNativeSelectionGuardOwns(selection.anchorNode) || nbNativeSelectionGuardOwns(selection.focusNode)) {
+                selection.removeAllRanges();
+            }
+        }
+        ['selectstart', 'dragstart', 'contextmenu'].forEach(type => {
+            document.addEventListener(type, nbBlockNativeSelection, true);
+        });
+        document.addEventListener('selectionchange', nbClearNativeSelection, true);
+
+        // ---------- Apple Pencil 模式：手指单指滚动画布、双指缩放（同阅读页） ----------
+        // 画布 touch-action:none 以防 Safari 把 Pencil 竖向笔迹当成滚动并发 pointercancel，
+        // 因此 Pencil 模式下手指的滚动与缩放需手动实现。touchType==='stylus' 的触点是 Pencil，
+        // 交给 pointer 事件正常落笔；只有全部触点都是手指时才进入滚动/缩放。
+        const nbPencilTouch = { panActive: false, lastX: 0, lastY: 0, pinch: null };
+        function nbInitPencilModeTouch(c) {
+            const isStylus = t => !!t && t.touchType === 'stylus';
+            const fingersOf = e => Array.from(e.touches).filter(t => !isStylus(t));
+            const pinchGeom = fingers => ({
+                dist: Math.hypot(fingers[1].clientX - fingers[0].clientX, fingers[1].clientY - fingers[0].clientY),
+                cx: (fingers[0].clientX + fingers[1].clientX) / 2,
+                cy: (fingers[0].clientY + fingers[1].clientY) / 2
+            });
+            const resetPinchPreview = () => {
+                const box = document.getElementById('nbPageBox');
+                if (box) { box.style.transform = ''; box.style.transformOrigin = ''; }
+            };
+            c.addEventListener('touchstart', (e) => {
+                nbPencilTouch.panActive = false;
+                if (!applePencilMode) return;
+                const fingers = fingersOf(e);
+                if (fingers.length !== e.touches.length) return;   // 有 Pencil 参与 → 交给 pointer 事件
+                if (fingers.length === 1 && !nbPencilTouch.pinch) {
+                    nbPencilTouch.panActive = true;
+                    nbPencilTouch.lastX = fingers[0].clientX;
+                    nbPencilTouch.lastY = fingers[0].clientY;
+                } else if (fingers.length === 2) {
+                    const g = pinchGeom(fingers);
+                    const box = document.getElementById('nbPageBox');
+                    const br = box ? box.getBoundingClientRect() : { left: 0, top: 0 };
+                    nbPencilTouch.pinch = {
+                        startDist: Math.max(1, g.dist), startZoom: nbState.zoom, scale: 1,
+                        cx: g.cx, cy: g.cy, ox: g.cx - br.left, oy: g.cy - br.top
+                    };
+                    if (box) box.style.transformOrigin = nbPencilTouch.pinch.ox + 'px ' + nbPencilTouch.pinch.oy + 'px';
+                }
+            }, { passive: true });
+            c.addEventListener('touchmove', (e) => {
+                if (!applePencilMode) { nbPencilTouch.panActive = false; return; }
+                const fingers = fingersOf(e);
+                if (fingers.length !== e.touches.length) { nbPencilTouch.panActive = false; return; }
+                const p = nbPencilTouch.pinch;
+                if (p && fingers.length === 2) {
+                    const g = pinchGeom(fingers);
+                    const target = Math.max(0.5, Math.min(2, p.startZoom * (g.dist / p.startDist)));
+                    p.scale = target / p.startZoom;
+                    const box = document.getElementById('nbPageBox');
+                    if (box) box.style.transform = 'scale(' + p.scale + ')';
+                    e.preventDefault();
+                    return;
+                }
+                if (!nbPencilTouch.panActive || fingers.length !== 1) { nbPencilTouch.panActive = false; return; }
+                const t = fingers[0];
+                const dx = t.clientX - nbPencilTouch.lastX, dy = t.clientY - nbPencilTouch.lastY;
+                nbPencilTouch.lastX = t.clientX;
+                nbPencilTouch.lastY = t.clientY;
+                const wrap = document.getElementById('nbCanvasWrap');
+                if (wrap) { wrap.scrollLeft -= dx; wrap.scrollTop -= dy; }
+                e.preventDefault();
+            }, { passive: false });
+            const end = (e) => {
+                nbPencilTouch.panActive = false;
+                const p = nbPencilTouch.pinch;
+                if (!p || e.touches.length >= 2) return;
+                nbPencilTouch.pinch = null;
+                resetPinchPreview();
+                nbCommitPinchZoom(p);
+            };
+            c.addEventListener('touchend', end, { passive: true });
+            c.addEventListener('touchcancel', end, { passive: true });
+        }
+        // 双指缩放结束：按 5% 步进落到 nbZoomSet，并让捏合中心下的页面点保持在原屏幕位置
+        function nbCommitPinchZoom(p) {
+            const wrap = document.getElementById('nbCanvasWrap');
+            const box = document.getElementById('nbPageBox');
+            const pct = Math.round(p.startZoom * p.scale * 20) * 5;
+            if (!wrap || !box || pct === Math.round(nbState.zoom * 100)) return;
+            const before = nbDisplayScale();
+            const pageX = p.ox / before, pageY = p.oy / before;
+            nbZoomSet(pct);
+            const after = nbDisplayScale();
+            const r = box.getBoundingClientRect();
+            wrap.scrollLeft += (r.left + pageX * after) - p.cx;
+            wrap.scrollTop += (r.top + pageY * after) - p.cy;
         }
 
         function nbPointerDown(e) {
             if (e.button === 2) return;
+            // Apple Pencil 模式（同阅读页）：只有触控笔可以在画布上书写、擦除、套索与画图形；
+            // 手指等其它指针不落笔，改由上方的 touch 处理器用于滚动画布与双指缩放。
+            if (applePencilMode && !booxReaderIsPen(e)) return;
             nbHidePanel();
             nbHideOutline();
             nbHideTextToolbar();
@@ -30455,8 +30623,25 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             const minDue = nbAt20(nbAddDays(new Date(), 1));   // 至少留到明晚
             return new Date(Math.max(planned.getTime(), minDue.getTime())).toISOString();
         }
+        // 复习记录的删除采用“墓碑”而非直接移除：云端 metadata 与本机按 id 合并并取 updatedAt
+        // 较新的一方，直接移除后下一次 CAS 合并或启动拉取会把云端仍存在的副本重新加回来，
+        // 表现为“删不掉”。墓碑保留 id 与归属，把 updatedAt 推到删除时刻，因而在所有设备上
+        // 都以删除为准；所有读取复习列表的地方一律通过 nbLiveReviews() 过滤墓碑。
+        function nbReviewIsDeleted(r) { return !!(r && (r.deleted === true || r.status === 'deleted')); }
+        function nbLiveReviews() { return (nbData().reviews || []).filter(r => !nbReviewIsDeleted(r)); }
+        function nbTombstoneReview(r) {
+            const now = new Date().toISOString();
+            for (const key of Object.keys(r)) {
+                if (!['id', 'notebookId', 'pageId', 'createdAt'].includes(key)) delete r[key];
+            }
+            r.status = 'deleted';
+            r.deleted = true;
+            r.deletedAt = now;
+            r.updatedAt = now;
+            r.quizzes = [];
+        }
         function nbFindReviewForPage(pageId) {
-            return nbData().reviews.find(r => r.pageId === pageId);
+            return nbLiveReviews().find(r => r.pageId === pageId);
         }
         function nbTouchReview(r) { r.updatedAt = new Date().toISOString(); }
 
@@ -30464,7 +30649,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         function nbRefreshReviewStates() {
             const now = Date.now();
             let changed = false;
-            for (const r of nbData().reviews) {
+            for (const r of nbLiveReviews()) {
                 if (r.status !== 'pending' || !r.dueAt) continue;
                 const due = Date.parse(r.dueAt);
                 if (isNaN(due)) continue;
@@ -30512,7 +30697,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         function renderNbReviewList() {
             const el = document.getElementById('nbReviewList');
             if (!el) return;
-            const reviews = nbData().reviews.slice();
+            const reviews = nbLiveReviews();
             document.getElementById('nbReviewCount').textContent = reviews.filter(r => r.status === 'pending').length;
             if (!reviews.length) {
                 el.innerHTML = `<div class="empty-state"><p>${i18n('review_empty_hint')}</p></div>`;
@@ -30611,7 +30796,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
         function nbReviewCardMenu(e, id) {
             closeLongPressMenu();
-            const r = nbData().reviews.find(x => x.id === id);
+            const r = nbFindReviewById(id);
             if (!r) return;
             const overlay = document.createElement('div');
             overlay.className = 'longpress-overlay';
@@ -30640,7 +30825,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         }
 
         function nbFindReviewById(id) {
-            return nbData().reviews.find(x => x.id === id);
+            return nbLiveReviews().find(x => x.id === id);
         }
 
         function nbDeleteReviewQuizById(id) {
@@ -30658,8 +30843,10 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         function nbDeleteReviewQuiz(r) {
             if (!r || !confirm(i18n('confirm_delete_review_quiz'))) return;
             const reviews = nbData().reviews;
-            const idx = reviews.findIndex(x => x.id === r.id);
-            if (idx >= 0) reviews.splice(idx, 1);
+            // 同 id 的记录（含历史合并残留）全部置为墓碑，保证云端合并后不再复活
+            const targets = reviews.filter(x => x && x.id === r.id);
+            if (!targets.length) targets.push(r);
+            targets.forEach(nbTombstoneReview);
             saveData();
             nbUpdateReviewBtn();
             renderNbReviewList();
@@ -30799,6 +30986,8 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 else if (nbState.content && nbState.content.recognized) task += i18n('prompt_recognized_note', nbState.content.recognized.text);
                 content.push({ type: 'text', text: task });
                 const quizText = await callAI(sys, [{ role: 'user', content }]);
+                // 生成期间该复习已被删除（墓碑）→ 丢弃结果，不能把墓碑重新激活
+                if (nbReviewIsDeleted(r)) return;
                 const generatedAt = new Date().toISOString();
                 r.quizzes.push({
                     id: nbUid('quiz'),
@@ -30816,6 +31005,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 showToast(i18n('quiz_generated', isExtra ? i18n('practice') : nbStageName(stage)));
             } catch (e) {
                 console.error('[nb] Quiz 生成失败:', e);
+                if (nbReviewIsDeleted(r)) return;
                 r.genFailed = true;
                 nbTouchReview(r);
                 saveData();
@@ -31103,7 +31293,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
         // ---------- 复习列表点击 → 打开 quiz ----------
         function nbOpenReview(id) {
-            const r = nbData().reviews.find(x => x.id === id);
+            const r = nbFindReviewById(id);
             if (!r) return;
             if (r.status === 'invalid') {
                 if (confirm(i18n('confirm_restart_invalid_review'))) nbRestartReview(r);
@@ -31125,7 +31315,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         }
 
         function nbOpenReviewQuiz(reviewId, quizId, readOnly = false) {
-            const r = nbData().reviews.find(x => x.id === reviewId);
+            const r = nbFindReviewById(reviewId);
             const quiz = r && (r.quizzes || []).find(q => q.id === quizId);
             if (!r || !quiz) return;
             nbShowQuiz(r, quiz, readOnly || !!quiz.completedAt);
@@ -31191,7 +31381,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
         function nbSaveQuizDraftToReview(syncCloud = true) {
             if (!qzCurrentReviewId || qzCurrentReadOnly || !qzCanvasCtx) return false;
-            const r = nbData().reviews.find(x => x.id === qzCurrentReviewId);
+            const r = nbFindReviewById(qzCurrentReviewId);
             const quiz = r && (r.quizzes || []).find(q => q.id === qzCurrentQuizId);
             if (!r || !quiz || quiz.completedAt) return false;
             const canvas = document.getElementById('nbQuizFsCanvas');
@@ -31229,7 +31419,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
         function nbGoToReviewPageFs() {
             if (!qzCurrentReviewId) return;
-            const r = nbData().reviews.find(x => x.id === qzCurrentReviewId);
+            const r = nbFindReviewById(qzCurrentReviewId);
             if (!r) return;
             const nb = nbGetNotebook(r.notebookId);
             if (!nb) { showToast(i18n('deleted_notebook')); return; }
@@ -31240,7 +31430,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         }
 
         function nbGoToReviewPage(id) {
-            const r = nbData().reviews.find(x => x.id === id);
+            const r = nbFindReviewById(id);
             if (!r) return;
             const nb = nbGetNotebook(r.notebookId);
             if (!nb) { showToast(i18n('deleted_notebook')); return; }
@@ -31253,7 +31443,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         // 完成 Quiz：截取画布 → 发给 AI 评分 → 显示结果 → 推进复习流程
         async function nbCompleteQuizFs() {
             if (!qzCurrentReviewId) return;
-            const r = nbData().reviews.find(x => x.id === qzCurrentReviewId);
+            const r = nbFindReviewById(qzCurrentReviewId);
             if (!r) return;
             const quiz = (r.quizzes || []).find(q => q.id === qzCurrentQuizId);
             if (!quiz || quiz.completedAt) { nbCloseQuizFullscreen(); return; }

--- a/app/src/main/java/com/mathreader/boox/DownloadBridge.java
+++ b/app/src/main/java/com/mathreader/boox/DownloadBridge.java
@@ -17,38 +17,145 @@ import java.io.FileOutputStream;
 import java.io.OutputStream;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
 
 /**
- * PWA 通过 blob URL + a[download] 导出文件（PDF/JSON），WebView 不支持 blob 下载，
- * boox-pen.js 拦截后把内容转 base64 经此桥接保存到系统下载目录。
+ * PWA 通过 blob URL + a[download] 导出文件（PDF / 数据备份 ZIP / JSON），WebView 不支持
+ * blob 下载，boox-pen.js 拦截后经此桥接保存到系统下载目录。
+ *
+ * 小文件可一次 {@link #saveBase64}。完整数据备份 ZIP 常有几十到几百 MB，整体 base64 会
+ * 超出 JS 字符串长度与 JS 桥单次消息的上限而静默失败，因此 boox-pen.js 以分片流式写入：
+ * {@link #beginSave} → {@link #appendBase64}… → {@link #finishSave}。两条路径最终都经由
+ * 同一个 {@link #open}，保证 ZIP 与导出的 PDF 落在完全相同的位置（Android 10+ 为系统
+ * 下载目录 Download/，旧系统为公共下载目录，不可写时退到应用私有下载目录）。
  */
 public class DownloadBridge {
     private static final String TAG = "DownloadBridge";
 
     private final Activity activity;
+    private final Map<String, PendingSave> pending = new HashMap<>();
+
+    /** 一次进行中的写入：Android 10+ 对应 MediaStore 条目，旧系统对应直接文件。 */
+    private static final class PendingSave {
+        final String name;
+        final OutputStream stream;
+        final Uri mediaUri;
+        final File file;
+        final String location;
+        long bytes;
+
+        PendingSave(String name, OutputStream stream, Uri mediaUri, File file, String location) {
+            this.name = name;
+            this.stream = stream;
+            this.mediaUri = mediaUri;
+            this.file = file;
+            this.location = location;
+        }
+    }
 
     public DownloadBridge(Activity activity) {
         this.activity = activity;
     }
 
+    /** 小文件一次写入（PDF、JSON 等）。 */
     @JavascriptInterface
     public void saveBase64(String fileName, String mimeType, String base64) {
+        PendingSave save = null;
         try {
             byte[] data = Base64.decode(base64, Base64.DEFAULT);
-            String name = sanitizeName(fileName);
-            String mime = (mimeType == null || mimeType.trim().isEmpty())
-                    ? "application/octet-stream" : mimeType.trim();
-            String location = save(name, mime, data);
-            toast("已保存到 " + location);
+            save = open(sanitizeName(fileName), normalizeMime(mimeType));
+            save.stream.write(data);
+            save.bytes += data.length;
+            complete(save);
         } catch (Throwable t) {
             Log.w(TAG, "saveBase64 failed", t);
+            if (save != null) {
+                discard(save);
+            }
             toast("保存失败: " + t.getMessage());
         }
     }
 
+    /** 分片写入：打开目标文件并返回会话 token，失败返回空串。 */
+    @JavascriptInterface
+    public String beginSave(String fileName, String mimeType) {
+        try {
+            PendingSave save = open(sanitizeName(fileName), normalizeMime(mimeType));
+            String token = UUID.randomUUID().toString();
+            synchronized (pending) {
+                pending.put(token, save);
+            }
+            return token;
+        } catch (Throwable t) {
+            Log.w(TAG, "beginSave failed", t);
+            toast("保存失败: " + t.getMessage());
+            return "";
+        }
+    }
+
+    /** 追加一个 base64 分片（每片独立解码，分片边界无需按 3 字节对齐）。 */
+    @JavascriptInterface
+    public boolean appendBase64(String token, String base64) {
+        PendingSave save;
+        synchronized (pending) {
+            save = pending.get(token);
+        }
+        if (save == null) {
+            return false;
+        }
+        try {
+            byte[] data = Base64.decode(base64, Base64.DEFAULT);
+            save.stream.write(data);
+            save.bytes += data.length;
+            return true;
+        } catch (Throwable t) {
+            Log.w(TAG, "appendBase64 failed", t);
+            abortSave(token, t.getMessage());
+            return false;
+        }
+    }
+
+    /** 全部分片写完：关闭流并发布文件。 */
+    @JavascriptInterface
+    public boolean finishSave(String token) {
+        PendingSave save;
+        synchronized (pending) {
+            save = pending.remove(token);
+        }
+        if (save == null) {
+            return false;
+        }
+        try {
+            complete(save);
+            return true;
+        } catch (Throwable t) {
+            Log.w(TAG, "finishSave failed", t);
+            discard(save);
+            toast("保存失败: " + t.getMessage());
+            return false;
+        }
+    }
+
+    /** 中止分片写入并删除半成品。 */
+    @JavascriptInterface
+    public void abortSave(String token, String reason) {
+        PendingSave save;
+        synchronized (pending) {
+            save = pending.remove(token);
+        }
+        if (save == null) {
+            return;
+        }
+        discard(save);
+        toast("保存失败: " + (reason == null || reason.trim().isEmpty() ? save.name : reason));
+    }
+
     /** DownloadListener 收到 data: URL 时调用 */
     public void saveDataUrl(String dataUrl) {
+        PendingSave save = null;
         try {
             int comma = dataUrl.indexOf(',');
             if (comma < 0) {
@@ -69,39 +176,100 @@ public class DownloadBridge {
             String ext = MimeTypeMap.getSingleton().getExtensionFromMimeType(mime);
             String name = "download_" + new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(new Date())
                     + (ext != null ? "." + ext : ".bin");
-            String location = save(name, mime, data);
-            toast("已保存到 " + location);
+            save = open(name, mime);
+            save.stream.write(data);
+            save.bytes += data.length;
+            complete(save);
         } catch (Throwable t) {
             Log.w(TAG, "saveDataUrl failed", t);
+            if (save != null) {
+                discard(save);
+            }
             toast("保存失败: " + t.getMessage());
         }
     }
 
-    private String save(String name, String mime, byte[] data) throws Exception {
+    /** 所有导出（PDF、ZIP、JSON）共用的目标位置：系统下载目录。 */
+    private PendingSave open(String name, String mime) throws Exception {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             ContentValues values = new ContentValues();
             values.put(MediaStore.Downloads.DISPLAY_NAME, name);
             values.put(MediaStore.Downloads.MIME_TYPE, mime);
+            // 写入期间标记为 pending，写完再发布，避免半成品出现在下载列表里
+            values.put(MediaStore.Downloads.IS_PENDING, 1);
             Uri uri = activity.getContentResolver()
                     .insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values);
             if (uri == null) {
                 throw new IllegalStateException("MediaStore insert failed");
             }
-            try (OutputStream os = activity.getContentResolver().openOutputStream(uri)) {
-                os.write(data);
+            OutputStream os = activity.getContentResolver().openOutputStream(uri);
+            if (os == null) {
+                activity.getContentResolver().delete(uri, null, null);
+                throw new IllegalStateException("MediaStore open failed");
             }
-            return "下载/" + name;
+            return new PendingSave(name, os, uri, null, "下载/" + name);
         }
         File dir = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS);
         if (dir == null || !(dir.isDirectory() || dir.mkdirs()) || !dir.canWrite()) {
             // 公共目录不可写（缺存储权限）时退到应用私有目录
             dir = activity.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS);
         }
-        File out = new File(dir, name);
-        try (FileOutputStream fos = new FileOutputStream(out)) {
-            fos.write(data);
+        if (dir == null || !(dir.isDirectory() || dir.mkdirs())) {
+            throw new IllegalStateException("no writable download directory");
         }
-        return out.getAbsolutePath();
+        File out = uniqueFile(dir, name);
+        return new PendingSave(name, new FileOutputStream(out), null, out, out.getAbsolutePath());
+    }
+
+    private void complete(PendingSave save) throws Exception {
+        save.stream.flush();
+        save.stream.close();
+        if (save.mediaUri != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ContentValues values = new ContentValues();
+            values.put(MediaStore.Downloads.IS_PENDING, 0);
+            activity.getContentResolver().update(save.mediaUri, values, null, null);
+        }
+        Log.i(TAG, "saved " + save.name + " (" + save.bytes + " bytes) to " + save.location);
+        toast("已保存到 " + save.location);
+    }
+
+    private void discard(PendingSave save) {
+        try {
+            save.stream.close();
+        } catch (Throwable ignored) {
+        }
+        try {
+            if (save.mediaUri != null) {
+                activity.getContentResolver().delete(save.mediaUri, null, null);
+            } else if (save.file != null && save.file.exists() && !save.file.delete()) {
+                Log.w(TAG, "could not delete partial file " + save.file);
+            }
+        } catch (Throwable t) {
+            Log.w(TAG, "discard failed", t);
+        }
+    }
+
+    /** 同名文件已存在时追加序号，避免同一天的多次导出互相覆盖。 */
+    private static File uniqueFile(File dir, String name) {
+        File out = new File(dir, name);
+        if (!out.exists()) {
+            return out;
+        }
+        int dot = name.lastIndexOf('.');
+        String base = dot > 0 ? name.substring(0, dot) : name;
+        String ext = dot > 0 ? name.substring(dot) : "";
+        for (int i = 1; i < 1000; i++) {
+            File candidate = new File(dir, base + " (" + i + ")" + ext);
+            if (!candidate.exists()) {
+                return candidate;
+            }
+        }
+        return new File(dir, base + "-" + System.currentTimeMillis() + ext);
+    }
+
+    private static String normalizeMime(String mimeType) {
+        return (mimeType == null || mimeType.trim().isEmpty())
+                ? "application/octet-stream" : mimeType.trim();
     }
 
     private static String sanitizeName(String fileName) {

--- a/app/src/main/java/com/mathreader/boox/MainActivity.java
+++ b/app/src/main/java/com/mathreader/boox/MainActivity.java
@@ -11,6 +11,7 @@ import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
 import android.os.Looper;
+import android.provider.MediaStore;
 import android.util.Log;
 import android.view.ViewGroup;
 import android.webkit.PermissionRequest;
@@ -28,15 +29,22 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
+import androidx.core.content.FileProvider;
 
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.webkit.WebViewAssetLoader;
 
 import java.io.BufferedReader;
+import java.io.File;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 public class MainActivity extends AppCompatActivity {
@@ -44,7 +52,10 @@ public class MainActivity extends AppCompatActivity {
     // https 同源加载，localStorage / IndexedDB / ServiceWorker 才能正常持久化
     private static final String START_URL = "https://appassets.androidplatform.net/www/index.html";
     private static final int REQUEST_FILE_CHOOSER = 1001;
-    private static final int REQUEST_RECORD_AUDIO = 1002;
+    private static final int REQUEST_WEB_PERMISSION = 1002;
+    private static final int REQUEST_CAMERA_CAPTURE = 1003;
+    private static final int REQUEST_CAMERA_PERMISSION = 1004;
+    private static final String CAMERA_CACHE_DIR = "camera";
 
     private WebView webView;
     private BooxPenBridge penBridge;
@@ -52,6 +63,10 @@ public class MainActivity extends AppCompatActivity {
     private RecordingBridge recordingBridge;
     private ValueCallback<Uri[]> filePathCallback;
     private PermissionRequest pendingWebPermission;
+    /** 等待 CAMERA 运行时授权期间暂存的文件选择参数（授权失败时退回文件选择器） */
+    private WebChromeClient.FileChooserParams pendingChooserParams;
+    /** 正在拍摄的照片输出 URI（FileProvider） */
+    private Uri cameraOutputUri;
     private String adapterJs;
 
     @SuppressLint("SetJavaScriptEnabled")
@@ -169,6 +184,8 @@ public class MainActivity extends AppCompatActivity {
                     filePathCallback = null;
                 }
                 pendingWebPermission = null;
+                pendingChooserParams = null;
+                cameraOutputUri = null;
                 if (view.getParent() instanceof ViewGroup) {
                     ((ViewGroup) view.getParent()).removeView(view);
                 }
@@ -193,32 +210,59 @@ public class MainActivity extends AppCompatActivity {
                     filePathCallback.onReceiveValue(null);
                 }
                 filePathCallback = callback;
-                try {
-                    startActivityForResult(params.createIntent(), REQUEST_FILE_CHOOSER);
-                } catch (Exception e) {
-                    filePathCallback = null;
-                    Toast.makeText(MainActivity.this, "无法打开文件选择器", Toast.LENGTH_SHORT).show();
-                    return false;
+                pendingChooserParams = null;
+                if (wantsImageCapture(params)) {
+                    // 课堂「拍照」按钮对应 <input accept="image/*" capture>。params.createIntent()
+                    // 只会打开文件选择器（仅能上传已有照片）；这里改为启动系统相机。声明了
+                    // CAMERA 权限的应用必须先取得运行时授权，否则相机 Intent 会被拒绝。
+                    if (ContextCompat.checkSelfPermission(MainActivity.this,
+                            Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED) {
+                        if (launchCamera()) {
+                            return true;
+                        }
+                        Toast.makeText(MainActivity.this, R.string.camera_unavailable,
+                                Toast.LENGTH_SHORT).show();
+                    } else {
+                        pendingChooserParams = params;
+                        ActivityCompat.requestPermissions(MainActivity.this,
+                                new String[]{Manifest.permission.CAMERA}, REQUEST_CAMERA_PERMISSION);
+                        return true;
+                    }
                 }
-                return true;
+                if (launchFileChooser(params)) {
+                    return true;
+                }
+                filePathCallback = null;
+                return false;
             }
 
             @Override
             public void onPermissionRequest(final PermissionRequest request) {
+                // 页面 getUserMedia：麦克风（课堂录音）与摄像头分别映射到 RECORD_AUDIO / CAMERA
+                List<String> missing = new ArrayList<>();
+                boolean supported = false;
                 for (String res : request.getResources()) {
-                    if (PermissionRequest.RESOURCE_AUDIO_CAPTURE.equals(res)) {
-                        if (ContextCompat.checkSelfPermission(MainActivity.this,
-                                Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED) {
-                            request.grant(new String[]{PermissionRequest.RESOURCE_AUDIO_CAPTURE});
-                        } else {
-                            pendingWebPermission = request;
-                            ActivityCompat.requestPermissions(MainActivity.this,
-                                    new String[]{Manifest.permission.RECORD_AUDIO}, REQUEST_RECORD_AUDIO);
-                        }
-                        return;
+                    String permission = androidPermissionFor(res);
+                    if (permission == null) {
+                        continue;
+                    }
+                    supported = true;
+                    if (ContextCompat.checkSelfPermission(MainActivity.this, permission)
+                            != PackageManager.PERMISSION_GRANTED) {
+                        missing.add(permission);
                     }
                 }
-                super.onPermissionRequest(request);
+                if (!supported) {
+                    super.onPermissionRequest(request);
+                    return;
+                }
+                if (missing.isEmpty()) {
+                    request.grant(grantableWebResources(request));
+                    return;
+                }
+                pendingWebPermission = request;
+                ActivityCompat.requestPermissions(MainActivity.this,
+                        missing.toArray(new String[0]), REQUEST_WEB_PERMISSION);
             }
         });
 
@@ -270,6 +314,97 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
+    /** 页面权限资源 → Android 运行时权限；不支持的资源返回 null。 */
+    private static String androidPermissionFor(String resource) {
+        if (PermissionRequest.RESOURCE_AUDIO_CAPTURE.equals(resource)) {
+            return Manifest.permission.RECORD_AUDIO;
+        }
+        if (PermissionRequest.RESOURCE_VIDEO_CAPTURE.equals(resource)) {
+            return Manifest.permission.CAMERA;
+        }
+        return null;
+    }
+
+    /** 请求中已经取得对应 Android 权限、可以授予页面的资源。 */
+    private String[] grantableWebResources(PermissionRequest request) {
+        List<String> granted = new ArrayList<>();
+        for (String res : request.getResources()) {
+            String permission = androidPermissionFor(res);
+            if (permission != null && ContextCompat.checkSelfPermission(this, permission)
+                    == PackageManager.PERMISSION_GRANTED) {
+                granted.add(res);
+            }
+        }
+        return granted.toArray(new String[0]);
+    }
+
+    /** &lt;input type="file" accept="image/*" capture&gt;：页面要求直接拍照。 */
+    private static boolean wantsImageCapture(WebChromeClient.FileChooserParams params) {
+        if (params == null || !params.isCaptureEnabled()) {
+            return false;
+        }
+        String[] types = params.getAcceptTypes();
+        if (types == null || types.length == 0) {
+            return true;
+        }
+        for (String type : types) {
+            String t = type == null ? "" : type.trim();
+            if (t.isEmpty() || t.startsWith("image/")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean launchFileChooser(WebChromeClient.FileChooserParams params) {
+        try {
+            startActivityForResult(params.createIntent(), REQUEST_FILE_CHOOSER);
+            return true;
+        } catch (Exception e) {
+            Log.w(TAG, "open file chooser failed", e);
+            Toast.makeText(this, R.string.file_chooser_unavailable, Toast.LENGTH_SHORT).show();
+            return false;
+        }
+    }
+
+    /** 启动系统相机，照片写入应用缓存目录并经 FileProvider 授权；成功返回 true。 */
+    private boolean launchCamera() {
+        try {
+            File dir = new File(getCacheDir(), CAMERA_CACHE_DIR);
+            if (!dir.isDirectory() && !dir.mkdirs()) {
+                return false;
+            }
+            cleanupCameraCache(dir);
+            File photo = new File(dir, "IMG_"
+                    + new SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(new Date()) + ".jpg");
+            Uri output = FileProvider.getUriForFile(this, getPackageName() + ".fileprovider", photo);
+            Intent intent = new Intent(MediaStore.ACTION_IMAGE_CAPTURE);
+            intent.putExtra(MediaStore.EXTRA_OUTPUT, output);
+            intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+            cameraOutputUri = output;
+            startActivityForResult(intent, REQUEST_CAMERA_CAPTURE);
+            return true;
+        } catch (Exception e) {
+            Log.w(TAG, "launch camera failed", e);
+            cameraOutputUri = null;
+            return false;
+        }
+    }
+
+    /** 页面读取完照片后文件仍留在缓存目录；启动相机前清掉一天前的旧照片。 */
+    private static void cleanupCameraCache(File dir) {
+        File[] files = dir.listFiles();
+        if (files == null) {
+            return;
+        }
+        long cutoff = System.currentTimeMillis() - 24L * 60 * 60 * 1000;
+        for (File f : files) {
+            if (f.isFile() && f.lastModified() < cutoff && !f.delete()) {
+                Log.w(TAG, "could not delete stale camera file " + f);
+            }
+        }
+    }
+
     private static long parseLongQuery(Uri uri, String key, long fallback) {
         try {
             String value = uri.getQueryParameter(key);
@@ -304,19 +439,51 @@ public class MainActivity extends AppCompatActivity {
             filePathCallback.onReceiveValue(
                     WebChromeClient.FileChooserParams.parseResult(resultCode, data));
             filePathCallback = null;
+            return;
+        }
+        if (requestCode == REQUEST_CAMERA_CAPTURE) {
+            Uri[] result = (resultCode == RESULT_OK && cameraOutputUri != null)
+                    ? new Uri[]{cameraOutputUri} : null;
+            cameraOutputUri = null;
+            if (filePathCallback != null) {
+                filePathCallback.onReceiveValue(result);
+                filePathCallback = null;
+            }
         }
     }
 
     @Override
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
                                            @NonNull int[] grantResults) {
-        if (requestCode == REQUEST_RECORD_AUDIO && pendingWebPermission != null) {
-            if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                pendingWebPermission.grant(new String[]{PermissionRequest.RESOURCE_AUDIO_CAPTURE});
-            } else {
-                pendingWebPermission.deny();
-            }
+        if (requestCode == REQUEST_WEB_PERMISSION && pendingWebPermission != null) {
+            PermissionRequest request = pendingWebPermission;
             pendingWebPermission = null;
+            String[] grantable = grantableWebResources(request);
+            if (grantable.length > 0) {
+                request.grant(grantable);
+            } else {
+                request.deny();
+            }
+            return;
+        }
+        if (requestCode == REQUEST_CAMERA_PERMISSION) {
+            WebChromeClient.FileChooserParams params = pendingChooserParams;
+            pendingChooserParams = null;
+            if (filePathCallback == null) {
+                return;
+            }
+            boolean granted = grantResults.length > 0
+                    && grantResults[0] == PackageManager.PERMISSION_GRANTED;
+            if (granted && launchCamera()) {
+                return;
+            }
+            Toast.makeText(this, granted ? R.string.camera_unavailable : R.string.camera_permission_denied,
+                    Toast.LENGTH_LONG).show();
+            // 未授权或无法启动相机：退回系统文件选择器，仍可上传已有照片
+            if (params == null || !launchFileChooser(params)) {
+                filePathCallback.onReceiveValue(null);
+                filePathCallback = null;
+            }
             return;
         }
         super.onRequestPermissionsResult(requestCode, permissions, grantResults);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,7 @@
 <resources>
     <string name="app_name">数学阅读</string>
     <string name="reader_process_restarted">阅读器进程已恢复，已返回书架</string>
+    <string name="file_chooser_unavailable">无法打开文件选择器</string>
+    <string name="camera_permission_denied">未授予相机权限，改为从相册选择照片</string>
+    <string name="camera_unavailable">无法启动相机，改为从相册选择照片</string>
 </resources>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <!-- 课堂拍照临时输出：getCacheDir()/camera/ -->
+    <cache-path name="camera" path="camera/" />
+</paths>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4532,18 +4532,32 @@
             background: var(--bg-secondary);
             display: none;
             flex-direction: column;
+            /* 顶栏实际高度由 nbLayout() 量测后写入，窄屏换行为两行时左栏/画布区随之下移 */
+            --nb-topbar-h: 52px;
         }
         .nb-editor.show { display: flex; }
         .nb-topbar {
-            height: 52px; flex-shrink: 0;
+            min-height: 52px; flex-shrink: 0;
             background: var(--bg-primary);
             border-bottom: 1px solid var(--border-color, rgba(0,0,0,0.08));
             display: flex; align-items: center; justify-content: space-between;
             padding: 0 10px; gap: 8px; z-index: 3010;
         }
         .nb-topbar-left { display: flex; align-items: center; gap: 8px; min-width: 0; flex: 1; }
-        .nb-topbar-right { display: flex; align-items: center; gap: 4px; flex-shrink: 0; }
+        .nb-topbar-right, .nb-topbar-nav { display: flex; align-items: center; gap: 4px; flex-shrink: 0; }
         .nb-title { font-size: 15px; font-weight: 700; color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 30vw; }
+        /* 手机等窄屏：笔刷/橡皮/撤销重做换行到第二行；退出、标题与翻页留在首行，
+           顶栏不再横向溢出屏幕，退出与下一页按钮始终可点 */
+        @media (max-width: 640px) {
+            .nb-topbar { flex-wrap: wrap; padding: 4px 8px; row-gap: 2px; column-gap: 6px; }
+            .nb-topbar-left { order: 0; min-height: 40px; }
+            .nb-topbar-nav { order: 1; min-height: 40px; }
+            .nb-topbar-nav .nb-tb-sep { display: none; }
+            .nb-topbar-right { order: 2; flex: 1 1 100%; justify-content: center; gap: 6px; min-height: 40px; }
+            .nb-title { max-width: none; }
+            .nb-topbar .nb-tb-btn, .nb-topbar .nb-brush-btn { width: 36px; height: 36px; }
+            .nb-pageno { padding: 6px 8px; }
+        }
         .nb-tb-btn {
             width: 38px; height: 38px; border: none; background: none; border-radius: 10px;
             display: flex; align-items: center; justify-content: center; cursor: pointer;
@@ -4569,7 +4583,7 @@
 
         /* ---------- 左栏 ---------- */
         .nb-leftbar {
-            position: absolute; left: 0; top: 52px; bottom: 0; width: 56px;
+            position: absolute; left: 0; top: var(--nb-topbar-h, 52px); bottom: 0; width: 56px;
             background: var(--bg-primary);
             border-right: 1px solid var(--border-color, rgba(0,0,0,0.08));
             display: flex; flex-direction: column; align-items: center;
@@ -4589,7 +4603,7 @@
 
         /* ---------- 画布区 ---------- */
         .nb-canvas-wrap {
-            position: absolute; left: 56px; right: 0; top: 52px; bottom: 0;
+            position: absolute; left: 56px; right: 0; top: var(--nb-topbar-h, 52px); bottom: 0;
             overflow: auto;
             display: block;
             background: var(--bg-secondary);
@@ -4608,6 +4622,13 @@
         #nbTextLayer { position: absolute; left: 0; top: 0; z-index: 4; pointer-events: none; transform-origin: 0 0; }
         #nbTextLayer > * { pointer-events: auto; }
         body.nb-text-mode #nbTextLayer { cursor: text; }
+        /* iOS/iPadOS：书写区与工具栏禁止原生文本选择和长按呼出菜单，避免长按或 Pencil 抖动
+           唤起浏览器选区/放大镜（同阅读页画笔模式的处理）；正在编辑的文本框保留原生光标与选区 */
+        .nb-editor .nb-topbar, .nb-editor .nb-leftbar, .nb-editor .nb-canvas-wrap,
+        .nb-editor .nb-canvas-wrap *:not([contenteditable="true"]) {
+            -webkit-user-select: none; user-select: none; -webkit-touch-callout: none;
+        }
+        .nb-editor .nb-textbox-inner[contenteditable="true"] { -webkit-user-select: text; user-select: text; }
 
         .nb-textbox {
             position: absolute;
@@ -4681,7 +4702,7 @@
 
         /* ---------- 页面大纲抽屉 ---------- */
         .nb-outline {
-            position: absolute; right: 0; top: 52px; bottom: 0; width: 330px; max-width: 85vw;
+            position: absolute; right: 0; top: var(--nb-topbar-h, 52px); bottom: 0; width: 330px; max-width: 85vw;
             background: var(--bg-primary);
             box-shadow: -4px 0 16px rgba(0,0,0,0.12);
             z-index: 3040; display: none; flex-direction: column; padding: 12px;
@@ -6134,6 +6155,8 @@
                 <button class="nb-tb-btn" id="nbRedoBtn" onclick="nbRedo()" title="重做" data-i18n="redo" data-i18n-attr="title">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 14 20 9 15 4"/><path d="M4 20v-7a4 4 0 014-4h12"/></svg>
                 </button>
+            </div>
+            <div class="nb-topbar-nav">
                 <div class="nb-tb-sep"></div>
                 <button class="nb-tb-btn" onclick="nbPrevPage()" title="上一页" data-i18n="prev_page" data-i18n-attr="title">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg>
@@ -6961,7 +6984,7 @@
             local_class_material_missing:'本地课堂素材缺失：{0}', class_material_index_changed:'课堂素材索引已变化：{0}', class_note_content_missing:'课堂讲义内容缺失：{0}', class_note_index_changed:'课堂讲义索引已变化：{0}', delete_cloud_class_material_failed:'删除云端课堂素材失败：{0}', delete_cloud_class_note_failed:'删除云端课堂讲义失败：{0}',
             notification_lecture_sync_title:'讲义同步完成', notification_lecture_sync_body:'讲义已同步到云端', notification_abstract_sync_title:'摘要同步完成', notification_abstract_sync_body:'摘要已同步到云端', network_endpoint_cors_error:'网络、Endpoint 或 CORS 配置错误', permission_key_error:'权限或密钥错误', bucket_not_found:'未找到存储桶',
             local_recording_chunk_corrupt:'本地录音分块 {0} 损坏', recording_source_size_failed:'无法确认录音源文件大小', cloud_recording_manifest_invalid:'云端录音清单无效', cloud_recording_chunk_invalid:'云端录音分块 {0} 无效', cloud_recording_chunk_hash_failed:'云端录音分块 {0} 校验失败', delete_cloud_recording_manifest_failed:'删除云端录音清单失败：{0}', delete_cloud_recording_chunk_failed:'删除云端录音分块失败：{0}', delete_legacy_cloud_recording_failed:'删除旧版云端录音失败：{0}',
-            confirm_empty_local_overwrite_cloud:'本地数据为空。确定要覆盖非空的云端数据吗？', upload_cancelled:'上传已取消', recording_not_fully_saved:'录音尚未完整保存：{0}', cloud_index_repaired:'云端索引已修复', count_lectures:'{0} 篇讲义', count_abstracts:'{0} 篇摘要', count_class_materials:'{0} 个课堂素材', count_exercise_files:'{0} 个习题文件', count_note_pages:'{0} 页笔记', count_note_media:'{0} 个笔记媒体', confirm_empty_cloud_overwrite_local:'云端数据为空。确定要覆盖本地数据吗？', restore_cancelled:'恢复已取消', restore_notebook_detail:'，另恢复 {0} 页笔记和 {1} 个媒体文件',
+            confirm_empty_local_overwrite_cloud:'本地数据为空。确定要覆盖非空的云端数据吗？', upload_cancelled:'上传已取消', recording_not_fully_saved:'录音尚未完整保存：{0}', sync_skipped_class_items:'；{0} 个课堂素材在本机缺失已跳过，云端已有内容保持不变', cloud_index_repaired:'云端索引已修复', count_lectures:'{0} 篇讲义', count_abstracts:'{0} 篇摘要', count_class_materials:'{0} 个课堂素材', count_exercise_files:'{0} 个习题文件', count_note_pages:'{0} 页笔记', count_note_media:'{0} 个笔记媒体', confirm_empty_cloud_overwrite_local:'云端数据为空。确定要覆盖本地数据吗？', restore_cancelled:'恢复已取消', restore_notebook_detail:'，另恢复 {0} 页笔记和 {1} 个媒体文件',
             backup_file_too_large:'备份文件过大', compressed_zip_unsupported:'不支持压缩格式的 ZIP 条目', zip_descriptor_unsupported:'不支持带数据描述符的 ZIP 条目', recording_backup_source_size_invalid:'录音备份源大小无效：{0}', recording_backup_manifest_invalid:'录音备份清单无效：{0}', recording_backup_chunk_missing:'录音 {0} 的第 {1} 个备份分块缺失', recording_backup_length_failed:'录音备份长度校验失败：{0}', unknown_recording_backup_source:'未知的录音备份源：{0}', legacy_recording_missing:'旧版录音缺失：{0}', recording_backup_chunk_length_failed:'录音备份分块长度校验失败：{0}', recording_backup_chunk_missing_simple:'录音备份分块缺失：{0}', recording_has_no_backup_data:'录音没有可备份的数据：{0}', stop_recording_before_backup:'请先停止录音再备份', packing_zip_backup:'正在打包 ZIP 备份…', recording_added_during_export:'导出期间新增的录音',
             export_local_files_detail:'（含 {0} 个本地文件）', export_missing_recordings_detail:'（另含 {0} 个补充录音）', export_failed:'导出失败：', confirm_import_zip_overwrite:'导入 ZIP 备份将覆盖当前数据，是否继续？', parsing_zip_backup:'正在解析 ZIP 备份…', backup_missing_metadata:'备份中缺少 metadata.json', missing_recordings_manifest_invalid:'补充录音清单无效', missing_recordings_manifest_invalid_id:'补充录音清单包含无效 ID', recording_backup_index_invalid:'录音备份索引无效', recording_backup_chunk_invalid:'录音 {0} 的第 {1} 个备份分块无效', import_complete_files:'导入完成，共恢复 {0} 个文件', import_failed:'导入失败：',
             indexeddb_unavailable:'IndexedDB 不可用', transaction_aborted:'事务被中止：{0}', unknown_reason:'未知原因', recording_transaction_failed:'录音事务失败', recording_transaction_aborted:'录音事务被中止', class_file_transaction_failed:'课堂文件事务失败', class_file_transaction_aborted:'课堂文件事务被中止', recording_storage_module_not_loaded:'录音存储模块未加载', class_lecture_content_empty:'课堂讲义内容为空', data_structure_corrupt:'数据结构损坏：books/papers 不是数组'
@@ -6980,7 +7003,7 @@
             local_class_material_missing:'Local class material is missing: {0}', class_material_index_changed:'The class material index changed: {0}', class_note_content_missing:'Class lecture content is missing: {0}', class_note_index_changed:'The class lecture index changed: {0}', delete_cloud_class_material_failed:'Failed to delete cloud class material: {0}', delete_cloud_class_note_failed:'Failed to delete cloud class lecture: {0}',
             notification_lecture_sync_title:'Lecture sync complete', notification_lecture_sync_body:'The lecture was synced to the cloud', notification_abstract_sync_title:'Abstract sync complete', notification_abstract_sync_body:'The abstract was synced to the cloud', network_endpoint_cors_error:'Network, endpoint, or CORS configuration error', permission_key_error:'Permission or credential error', bucket_not_found:'Bucket not found',
             local_recording_chunk_corrupt:'Local recording chunk {0} is corrupted', recording_source_size_failed:'Could not verify the recording source size', cloud_recording_manifest_invalid:'The cloud recording manifest is invalid', cloud_recording_chunk_invalid:'Cloud recording chunk {0} is invalid', cloud_recording_chunk_hash_failed:'Cloud recording chunk {0} failed verification', delete_cloud_recording_manifest_failed:'Failed to delete cloud recording manifest: {0}', delete_cloud_recording_chunk_failed:'Failed to delete cloud recording chunk: {0}', delete_legacy_cloud_recording_failed:'Failed to delete legacy cloud recording: {0}',
-            confirm_empty_local_overwrite_cloud:'Local data is empty. Overwrite non-empty cloud data?', upload_cancelled:'Upload cancelled', recording_not_fully_saved:'Recording is not fully saved: {0}', cloud_index_repaired:'Cloud index repaired', count_lectures:'{0} lectures', count_abstracts:'{0} abstracts', count_class_materials:'{0} class materials', count_exercise_files:'{0} exercise files', count_note_pages:'{0} note pages', count_note_media:'{0} note media files', confirm_empty_cloud_overwrite_local:'Cloud data is empty. Overwrite local data?', restore_cancelled:'Restore cancelled', restore_notebook_detail:', plus {0} note pages and {1} media files',
+            confirm_empty_local_overwrite_cloud:'Local data is empty. Overwrite non-empty cloud data?', upload_cancelled:'Upload cancelled', recording_not_fully_saved:'Recording is not fully saved: {0}', sync_skipped_class_items:'; {0} class materials missing locally were skipped; existing cloud copies were kept', cloud_index_repaired:'Cloud index repaired', count_lectures:'{0} lectures', count_abstracts:'{0} abstracts', count_class_materials:'{0} class materials', count_exercise_files:'{0} exercise files', count_note_pages:'{0} note pages', count_note_media:'{0} note media files', confirm_empty_cloud_overwrite_local:'Cloud data is empty. Overwrite local data?', restore_cancelled:'Restore cancelled', restore_notebook_detail:', plus {0} note pages and {1} media files',
             backup_file_too_large:'Backup file is too large', compressed_zip_unsupported:'Compressed ZIP entries are not supported', zip_descriptor_unsupported:'ZIP data descriptors are not supported', recording_backup_source_size_invalid:'Invalid recording backup source size: {0}', recording_backup_manifest_invalid:'Invalid recording backup manifest: {0}', recording_backup_chunk_missing:'Backup chunk {1} is missing for recording {0}', recording_backup_length_failed:'Recording backup length verification failed: {0}', unknown_recording_backup_source:'Unknown recording backup source: {0}', legacy_recording_missing:'Legacy recording is missing: {0}', recording_backup_chunk_length_failed:'Recording backup chunk length verification failed: {0}', recording_backup_chunk_missing_simple:'Recording backup chunk is missing: {0}', recording_has_no_backup_data:'Recording has no data to back up: {0}', stop_recording_before_backup:'Stop recording before creating a backup', packing_zip_backup:'Packing ZIP backup…', recording_added_during_export:'Recording added during export',
             export_local_files_detail:' ({0} local files included)', export_missing_recordings_detail:' ({0} supplemental recordings included)', export_failed:'Export failed: ', confirm_import_zip_overwrite:'Importing this ZIP backup will overwrite current data. Continue?', parsing_zip_backup:'Parsing ZIP backup…', backup_missing_metadata:'metadata.json is missing from the backup', missing_recordings_manifest_invalid:'Supplemental recording manifest is invalid', missing_recordings_manifest_invalid_id:'Supplemental recording manifest contains an invalid ID', recording_backup_index_invalid:'Recording backup index is invalid', recording_backup_chunk_invalid:'Backup chunk {1} is invalid for recording {0}', import_complete_files:'Import complete: {0} files restored', import_failed:'Import failed: ',
             indexeddb_unavailable:'IndexedDB is unavailable', transaction_aborted:'Transaction aborted: {0}', unknown_reason:'Unknown reason', recording_transaction_failed:'Recording transaction failed', recording_transaction_aborted:'Recording transaction was aborted', class_file_transaction_failed:'Class file transaction failed', class_file_transaction_aborted:'Class file transaction was aborted', recording_storage_module_not_loaded:'Recording storage module is not loaded', class_lecture_content_empty:'Class lecture content is empty', data_structure_corrupt:'Corrupted data structure: books/papers must be arrays'
@@ -6999,7 +7022,7 @@
             local_class_material_missing:'Support de cours local manquant : {0}', class_material_index_changed:"L’index des supports de cours a changé : {0}", class_note_content_missing:'Contenu du cours manquant : {0}', class_note_index_changed:"L’index des cours a changé : {0}", delete_cloud_class_material_failed:'Échec de suppression du support cloud : {0}', delete_cloud_class_note_failed:'Échec de suppression du cours cloud : {0}',
             notification_lecture_sync_title:'Synchronisation du cours terminée', notification_lecture_sync_body:'Le cours a été synchronisé dans le cloud', notification_abstract_sync_title:'Synchronisation du résumé terminée', notification_abstract_sync_body:'Le résumé a été synchronisé dans le cloud', network_endpoint_cors_error:'Erreur de réseau, d’endpoint ou de configuration CORS', permission_key_error:'Erreur d’autorisation ou d’identifiants', bucket_not_found:'Bucket introuvable',
             local_recording_chunk_corrupt:"Le segment local d’enregistrement {0} est corrompu", recording_source_size_failed:"Impossible de vérifier la taille de l’enregistrement source", cloud_recording_manifest_invalid:"Le manifeste cloud de l’enregistrement est invalide", cloud_recording_chunk_invalid:'Le segment cloud {0} est invalide', cloud_recording_chunk_hash_failed:'Échec de vérification du segment cloud {0}', delete_cloud_recording_manifest_failed:'Échec de suppression du manifeste cloud : {0}', delete_cloud_recording_chunk_failed:'Échec de suppression du segment cloud : {0}', delete_legacy_cloud_recording_failed:"Échec de suppression de l’ancien enregistrement cloud : {0}",
-            confirm_empty_local_overwrite_cloud:'Les données locales sont vides. Remplacer les données cloud non vides ?', upload_cancelled:'Envoi annulé', recording_not_fully_saved:"L’enregistrement n’est pas entièrement sauvegardé : {0}", cloud_index_repaired:'Index cloud réparé', count_lectures:'{0} cours', count_abstracts:'{0} résumés', count_class_materials:'{0} supports de cours', count_exercise_files:'{0} fichiers d’exercices', count_note_pages:'{0} pages de notes', count_note_media:'{0} médias de notes', confirm_empty_cloud_overwrite_local:'Les données cloud sont vides. Remplacer les données locales ?', restore_cancelled:'Restauration annulée', restore_notebook_detail:', plus {0} pages de notes et {1} médias',
+            confirm_empty_local_overwrite_cloud:'Les données locales sont vides. Remplacer les données cloud non vides ?', upload_cancelled:'Envoi annulé', recording_not_fully_saved:"L’enregistrement n’est pas entièrement sauvegardé : {0}", sync_skipped_class_items:' ; {0} supports de cours absents localement ont été ignorés ; les copies cloud existantes ont été conservées', cloud_index_repaired:'Index cloud réparé', count_lectures:'{0} cours', count_abstracts:'{0} résumés', count_class_materials:'{0} supports de cours', count_exercise_files:'{0} fichiers d’exercices', count_note_pages:'{0} pages de notes', count_note_media:'{0} médias de notes', confirm_empty_cloud_overwrite_local:'Les données cloud sont vides. Remplacer les données locales ?', restore_cancelled:'Restauration annulée', restore_notebook_detail:', plus {0} pages de notes et {1} médias',
             backup_file_too_large:'Le fichier de sauvegarde est trop volumineux', compressed_zip_unsupported:'Les entrées ZIP compressées ne sont pas prises en charge', zip_descriptor_unsupported:'Les descripteurs de données ZIP ne sont pas pris en charge', recording_backup_source_size_invalid:'Taille de source de sauvegarde invalide : {0}', recording_backup_manifest_invalid:'Manifeste de sauvegarde invalide : {0}', recording_backup_chunk_missing:"Le segment {1} de l’enregistrement {0} manque dans la sauvegarde", recording_backup_length_failed:'Échec de vérification de la longueur de la sauvegarde : {0}', unknown_recording_backup_source:'Source de sauvegarde inconnue : {0}', legacy_recording_missing:'Ancien enregistrement manquant : {0}', recording_backup_chunk_length_failed:'Échec de vérification de la longueur du segment : {0}', recording_backup_chunk_missing_simple:'Segment de sauvegarde manquant : {0}', recording_has_no_backup_data:"L’enregistrement ne contient aucune donnée à sauvegarder : {0}", stop_recording_before_backup:"Arrêtez l’enregistrement avant de créer une sauvegarde", packing_zip_backup:'Création de la sauvegarde ZIP…', recording_added_during_export:'Enregistrement ajouté pendant l’exportation',
             export_local_files_detail:' ({0} fichiers locaux inclus)', export_missing_recordings_detail:' ({0} enregistrements supplémentaires inclus)', export_failed:"Échec de l’exportation : ", confirm_import_zip_overwrite:'Importer cette sauvegarde ZIP remplacera les données actuelles. Continuer ?', parsing_zip_backup:'Analyse de la sauvegarde ZIP…', backup_missing_metadata:'metadata.json manque dans la sauvegarde', missing_recordings_manifest_invalid:'Le manifeste des enregistrements supplémentaires est invalide', missing_recordings_manifest_invalid_id:'Le manifeste contient un identifiant invalide', recording_backup_index_invalid:"L’index de sauvegarde des enregistrements est invalide", recording_backup_chunk_invalid:'Le segment {1} de l’enregistrement {0} est invalide', import_complete_files:'Importation terminée : {0} fichiers restaurés', import_failed:"Échec de l’importation : ",
             indexeddb_unavailable:'IndexedDB est indisponible', transaction_aborted:'Transaction interrompue : {0}', unknown_reason:'Raison inconnue', recording_transaction_failed:"Échec de la transaction d’enregistrement", recording_transaction_aborted:"La transaction d’enregistrement a été interrompue", class_file_transaction_failed:'Échec de la transaction du fichier de cours', class_file_transaction_aborted:'La transaction du fichier de cours a été interrompue', recording_storage_module_not_loaded:"Le module de stockage des enregistrements n’est pas chargé", class_lecture_content_empty:'Le contenu du cours est vide', data_structure_corrupt:'Structure de données corrompue : books/papers doivent être des tableaux'
@@ -15918,26 +15941,43 @@
                     }
                     allowEmptyMetadataOverwrite = true;
                 }
-                // 课堂正文（录音、照片/文件、AI 讲义）必须全部先于 metadata 提交。
+                // 课堂正文（录音、照片/文件、AI 讲义）先于 metadata 提交。单个素材在本机缺失
+                // （仅存在于云端尚未下载、录音尚未完整保存等）或上传失败时只跳过该素材，不中止
+                // 整次手动同步：跳过项不会上传任何空正文；其云端已有的正文对象原样保留，云端索引
+                // 中的对应条目也由随后的 CAS 合并按云端副本保留（同 id 以云端为准，本机 pending
+                // 条目不会进入出站索引），因此不会被本机的空数据覆盖。
                 let uploadedMaterials = 0;
                 let uploadedClassroomNotes = 0;
+                const skippedClassroomItems = [];
+                const skipClassroomItem = (item, reason) => {
+                    skippedClassroomItems.push({ id: item?.id, name: item?.name || item?.title || '', reason });
+                    console.warn('[sync] 课堂素材已跳过，云端已有内容保持不变:', item?.id, reason);
+                };
                 for (const listKey of ['courses', 'seminars']) {
                     for (const folder of (appData.classroom?.[listKey] || [])) {
                         for (const session of (folder.sessions || [])) {
                             for (const mat of (session.sourceFolder || [])) {
-                                if (mat.type === 'recording') {
-                                    if (!await r2SyncRecording(mat)) {
-                                        throw new Error(i18n('recording_not_fully_saved', mat.id));
+                                try {
+                                    if (mat.type === 'recording') {
+                                        if (!await r2SyncRecording(mat)) {
+                                            skipClassroomItem(mat, i18n('recording_not_fully_saved', mat.id));
+                                        }
+                                    } else {
+                                        await r2SyncClassroomAsset(mat);
+                                        uploadedMaterials++;
                                     }
-                                } else {
-                                    await r2SyncClassroomAsset(mat);
-                                    uploadedMaterials++;
+                                } catch (err) {
+                                    skipClassroomItem(mat, (err && err.message) || String(err));
                                 }
                             }
                             for (const note of (session.notes || [])) {
                                 if (!note.contentKey) continue;
-                                await r2SyncClassroomNote(note);
-                                uploadedClassroomNotes++;
+                                try {
+                                    await r2SyncClassroomNote(note);
+                                    uploadedClassroomNotes++;
+                                } catch (err) {
+                                    skipClassroomItem(note, (err && err.message) || String(err));
+                                }
                             }
                         }
                     }
@@ -16050,7 +16090,10 @@
                     }
                 }
 
-                showToast(i18n('sync_done_detail', uploadedFiles, uploadedLectures, uploadedAbstracts));
+                showToast(i18n('sync_done_detail', uploadedFiles, uploadedLectures, uploadedAbstracts) +
+                    (skippedClassroomItems.length
+                        ? i18n('sync_skipped_class_items', skippedClassroomItems.length)
+                        : ''));
             } catch (err) {
                 console.error('Sync to R2 failed:', err);
                 showToast(i18n('toast_sync_failed') + err.message);
@@ -28496,8 +28539,12 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
         // ==================== 布局与渲染 ====================
         function nbLayout() {
+            const editor = document.getElementById('nbEditor');
             const wrap = document.getElementById('nbCanvasWrap');
-            if (!wrap || !document.getElementById('nbEditor').classList.contains('show')) return;
+            if (!wrap || !editor || !editor.classList.contains('show')) return;
+            // 顶栏在窄屏会换行为两行：左栏与画布区的顶部偏移跟随顶栏实际高度
+            const topbar = editor.querySelector('.nb-topbar');
+            if (topbar) editor.style.setProperty('--nb-topbar-h', topbar.offsetHeight + 'px');
             const availW = wrap.clientWidth, availH = wrap.clientHeight;
             if (availW <= 0 || availH <= 0) return;
             nbState.fitScale = Math.min(availW / NB_PAGE_W, availH / NB_PAGE_H);
@@ -28893,10 +28940,131 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             c.addEventListener('pointerup', nbPointerUp);
             c.addEventListener('pointercancel', nbPointerUp);
             c.addEventListener('contextmenu', e => e.preventDefault());
+            nbInitPencilModeTouch(c);
+        }
+
+        // ---------- iOS/iPadOS 原生选区拦截（同阅读页画笔模式） ----------
+        // Safari 在长按、Pencil 抖动或跨元素拖动时会尝试建立原生文本选区并弹出放大镜/菜单，
+        // 打断书写。编辑器显示期间，在捕获阶段拦截书写区与工具栏上的 selectstart / dragstart /
+        // contextmenu，并清掉已经形成的选区；正在编辑的文本框与输入控件不受影响。
+        function nbNativeSelectionGuardOwns(target) {
+            const editor = document.getElementById('nbEditor');
+            if (!editor || !editor.classList.contains('show') || !target) return false;
+            const el = target.nodeType === Node.TEXT_NODE ? target.parentElement : target;
+            if (!el || typeof el.closest !== 'function') return false;
+            if (el.closest('[contenteditable="true"], input, textarea, select')) return false;
+            return !!el.closest('#nbEditor .nb-topbar, #nbEditor .nb-leftbar, #nbCanvasWrap');
+        }
+        function nbBlockNativeSelection(e) {
+            if (!e || !nbNativeSelectionGuardOwns(e.target)) return;
+            e.preventDefault();
+            if (typeof e.stopPropagation === 'function') e.stopPropagation();
+        }
+        function nbClearNativeSelection() {
+            const editor = document.getElementById('nbEditor');
+            if (!editor || !editor.classList.contains('show')) return;
+            const selection = typeof window.getSelection === 'function' ? window.getSelection() : null;
+            if (!selection || !selection.rangeCount) return;
+            if (nbNativeSelectionGuardOwns(selection.anchorNode) || nbNativeSelectionGuardOwns(selection.focusNode)) {
+                selection.removeAllRanges();
+            }
+        }
+        ['selectstart', 'dragstart', 'contextmenu'].forEach(type => {
+            document.addEventListener(type, nbBlockNativeSelection, true);
+        });
+        document.addEventListener('selectionchange', nbClearNativeSelection, true);
+
+        // ---------- Apple Pencil 模式：手指单指滚动画布、双指缩放（同阅读页） ----------
+        // 画布 touch-action:none 以防 Safari 把 Pencil 竖向笔迹当成滚动并发 pointercancel，
+        // 因此 Pencil 模式下手指的滚动与缩放需手动实现。touchType==='stylus' 的触点是 Pencil，
+        // 交给 pointer 事件正常落笔；只有全部触点都是手指时才进入滚动/缩放。
+        const nbPencilTouch = { panActive: false, lastX: 0, lastY: 0, pinch: null };
+        function nbInitPencilModeTouch(c) {
+            const isStylus = t => !!t && t.touchType === 'stylus';
+            const fingersOf = e => Array.from(e.touches).filter(t => !isStylus(t));
+            const pinchGeom = fingers => ({
+                dist: Math.hypot(fingers[1].clientX - fingers[0].clientX, fingers[1].clientY - fingers[0].clientY),
+                cx: (fingers[0].clientX + fingers[1].clientX) / 2,
+                cy: (fingers[0].clientY + fingers[1].clientY) / 2
+            });
+            const resetPinchPreview = () => {
+                const box = document.getElementById('nbPageBox');
+                if (box) { box.style.transform = ''; box.style.transformOrigin = ''; }
+            };
+            c.addEventListener('touchstart', (e) => {
+                nbPencilTouch.panActive = false;
+                if (!applePencilMode) return;
+                const fingers = fingersOf(e);
+                if (fingers.length !== e.touches.length) return;   // 有 Pencil 参与 → 交给 pointer 事件
+                if (fingers.length === 1 && !nbPencilTouch.pinch) {
+                    nbPencilTouch.panActive = true;
+                    nbPencilTouch.lastX = fingers[0].clientX;
+                    nbPencilTouch.lastY = fingers[0].clientY;
+                } else if (fingers.length === 2) {
+                    const g = pinchGeom(fingers);
+                    const box = document.getElementById('nbPageBox');
+                    const br = box ? box.getBoundingClientRect() : { left: 0, top: 0 };
+                    nbPencilTouch.pinch = {
+                        startDist: Math.max(1, g.dist), startZoom: nbState.zoom, scale: 1,
+                        cx: g.cx, cy: g.cy, ox: g.cx - br.left, oy: g.cy - br.top
+                    };
+                    if (box) box.style.transformOrigin = nbPencilTouch.pinch.ox + 'px ' + nbPencilTouch.pinch.oy + 'px';
+                }
+            }, { passive: true });
+            c.addEventListener('touchmove', (e) => {
+                if (!applePencilMode) { nbPencilTouch.panActive = false; return; }
+                const fingers = fingersOf(e);
+                if (fingers.length !== e.touches.length) { nbPencilTouch.panActive = false; return; }
+                const p = nbPencilTouch.pinch;
+                if (p && fingers.length === 2) {
+                    const g = pinchGeom(fingers);
+                    const target = Math.max(0.5, Math.min(2, p.startZoom * (g.dist / p.startDist)));
+                    p.scale = target / p.startZoom;
+                    const box = document.getElementById('nbPageBox');
+                    if (box) box.style.transform = 'scale(' + p.scale + ')';
+                    e.preventDefault();
+                    return;
+                }
+                if (!nbPencilTouch.panActive || fingers.length !== 1) { nbPencilTouch.panActive = false; return; }
+                const t = fingers[0];
+                const dx = t.clientX - nbPencilTouch.lastX, dy = t.clientY - nbPencilTouch.lastY;
+                nbPencilTouch.lastX = t.clientX;
+                nbPencilTouch.lastY = t.clientY;
+                const wrap = document.getElementById('nbCanvasWrap');
+                if (wrap) { wrap.scrollLeft -= dx; wrap.scrollTop -= dy; }
+                e.preventDefault();
+            }, { passive: false });
+            const end = (e) => {
+                nbPencilTouch.panActive = false;
+                const p = nbPencilTouch.pinch;
+                if (!p || e.touches.length >= 2) return;
+                nbPencilTouch.pinch = null;
+                resetPinchPreview();
+                nbCommitPinchZoom(p);
+            };
+            c.addEventListener('touchend', end, { passive: true });
+            c.addEventListener('touchcancel', end, { passive: true });
+        }
+        // 双指缩放结束：按 5% 步进落到 nbZoomSet，并让捏合中心下的页面点保持在原屏幕位置
+        function nbCommitPinchZoom(p) {
+            const wrap = document.getElementById('nbCanvasWrap');
+            const box = document.getElementById('nbPageBox');
+            const pct = Math.round(p.startZoom * p.scale * 20) * 5;
+            if (!wrap || !box || pct === Math.round(nbState.zoom * 100)) return;
+            const before = nbDisplayScale();
+            const pageX = p.ox / before, pageY = p.oy / before;
+            nbZoomSet(pct);
+            const after = nbDisplayScale();
+            const r = box.getBoundingClientRect();
+            wrap.scrollLeft += (r.left + pageX * after) - p.cx;
+            wrap.scrollTop += (r.top + pageY * after) - p.cy;
         }
 
         function nbPointerDown(e) {
             if (e.button === 2) return;
+            // Apple Pencil 模式（同阅读页）：只有触控笔可以在画布上书写、擦除、套索与画图形；
+            // 手指等其它指针不落笔，改由上方的 touch 处理器用于滚动画布与双指缩放。
+            if (applePencilMode && !booxReaderIsPen(e)) return;
             nbHidePanel();
             nbHideOutline();
             nbHideTextToolbar();
@@ -30455,8 +30623,25 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             const minDue = nbAt20(nbAddDays(new Date(), 1));   // 至少留到明晚
             return new Date(Math.max(planned.getTime(), minDue.getTime())).toISOString();
         }
+        // 复习记录的删除采用“墓碑”而非直接移除：云端 metadata 与本机按 id 合并并取 updatedAt
+        // 较新的一方，直接移除后下一次 CAS 合并或启动拉取会把云端仍存在的副本重新加回来，
+        // 表现为“删不掉”。墓碑保留 id 与归属，把 updatedAt 推到删除时刻，因而在所有设备上
+        // 都以删除为准；所有读取复习列表的地方一律通过 nbLiveReviews() 过滤墓碑。
+        function nbReviewIsDeleted(r) { return !!(r && (r.deleted === true || r.status === 'deleted')); }
+        function nbLiveReviews() { return (nbData().reviews || []).filter(r => !nbReviewIsDeleted(r)); }
+        function nbTombstoneReview(r) {
+            const now = new Date().toISOString();
+            for (const key of Object.keys(r)) {
+                if (!['id', 'notebookId', 'pageId', 'createdAt'].includes(key)) delete r[key];
+            }
+            r.status = 'deleted';
+            r.deleted = true;
+            r.deletedAt = now;
+            r.updatedAt = now;
+            r.quizzes = [];
+        }
         function nbFindReviewForPage(pageId) {
-            return nbData().reviews.find(r => r.pageId === pageId);
+            return nbLiveReviews().find(r => r.pageId === pageId);
         }
         function nbTouchReview(r) { r.updatedAt = new Date().toISOString(); }
 
@@ -30464,7 +30649,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         function nbRefreshReviewStates() {
             const now = Date.now();
             let changed = false;
-            for (const r of nbData().reviews) {
+            for (const r of nbLiveReviews()) {
                 if (r.status !== 'pending' || !r.dueAt) continue;
                 const due = Date.parse(r.dueAt);
                 if (isNaN(due)) continue;
@@ -30512,7 +30697,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         function renderNbReviewList() {
             const el = document.getElementById('nbReviewList');
             if (!el) return;
-            const reviews = nbData().reviews.slice();
+            const reviews = nbLiveReviews();
             document.getElementById('nbReviewCount').textContent = reviews.filter(r => r.status === 'pending').length;
             if (!reviews.length) {
                 el.innerHTML = `<div class="empty-state"><p>${i18n('review_empty_hint')}</p></div>`;
@@ -30611,7 +30796,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
         function nbReviewCardMenu(e, id) {
             closeLongPressMenu();
-            const r = nbData().reviews.find(x => x.id === id);
+            const r = nbFindReviewById(id);
             if (!r) return;
             const overlay = document.createElement('div');
             overlay.className = 'longpress-overlay';
@@ -30640,7 +30825,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         }
 
         function nbFindReviewById(id) {
-            return nbData().reviews.find(x => x.id === id);
+            return nbLiveReviews().find(x => x.id === id);
         }
 
         function nbDeleteReviewQuizById(id) {
@@ -30658,8 +30843,10 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         function nbDeleteReviewQuiz(r) {
             if (!r || !confirm(i18n('confirm_delete_review_quiz'))) return;
             const reviews = nbData().reviews;
-            const idx = reviews.findIndex(x => x.id === r.id);
-            if (idx >= 0) reviews.splice(idx, 1);
+            // 同 id 的记录（含历史合并残留）全部置为墓碑，保证云端合并后不再复活
+            const targets = reviews.filter(x => x && x.id === r.id);
+            if (!targets.length) targets.push(r);
+            targets.forEach(nbTombstoneReview);
             saveData();
             nbUpdateReviewBtn();
             renderNbReviewList();
@@ -30799,6 +30986,8 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 else if (nbState.content && nbState.content.recognized) task += i18n('prompt_recognized_note', nbState.content.recognized.text);
                 content.push({ type: 'text', text: task });
                 const quizText = await callAI(sys, [{ role: 'user', content }]);
+                // 生成期间该复习已被删除（墓碑）→ 丢弃结果，不能把墓碑重新激活
+                if (nbReviewIsDeleted(r)) return;
                 const generatedAt = new Date().toISOString();
                 r.quizzes.push({
                     id: nbUid('quiz'),
@@ -30816,6 +31005,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 showToast(i18n('quiz_generated', isExtra ? i18n('practice') : nbStageName(stage)));
             } catch (e) {
                 console.error('[nb] Quiz 生成失败:', e);
+                if (nbReviewIsDeleted(r)) return;
                 r.genFailed = true;
                 nbTouchReview(r);
                 saveData();
@@ -31103,7 +31293,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
         // ---------- 复习列表点击 → 打开 quiz ----------
         function nbOpenReview(id) {
-            const r = nbData().reviews.find(x => x.id === id);
+            const r = nbFindReviewById(id);
             if (!r) return;
             if (r.status === 'invalid') {
                 if (confirm(i18n('confirm_restart_invalid_review'))) nbRestartReview(r);
@@ -31125,7 +31315,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         }
 
         function nbOpenReviewQuiz(reviewId, quizId, readOnly = false) {
-            const r = nbData().reviews.find(x => x.id === reviewId);
+            const r = nbFindReviewById(reviewId);
             const quiz = r && (r.quizzes || []).find(q => q.id === quizId);
             if (!r || !quiz) return;
             nbShowQuiz(r, quiz, readOnly || !!quiz.completedAt);
@@ -31191,7 +31381,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
         function nbSaveQuizDraftToReview(syncCloud = true) {
             if (!qzCurrentReviewId || qzCurrentReadOnly || !qzCanvasCtx) return false;
-            const r = nbData().reviews.find(x => x.id === qzCurrentReviewId);
+            const r = nbFindReviewById(qzCurrentReviewId);
             const quiz = r && (r.quizzes || []).find(q => q.id === qzCurrentQuizId);
             if (!r || !quiz || quiz.completedAt) return false;
             const canvas = document.getElementById('nbQuizFsCanvas');
@@ -31229,7 +31419,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
         function nbGoToReviewPageFs() {
             if (!qzCurrentReviewId) return;
-            const r = nbData().reviews.find(x => x.id === qzCurrentReviewId);
+            const r = nbFindReviewById(qzCurrentReviewId);
             if (!r) return;
             const nb = nbGetNotebook(r.notebookId);
             if (!nb) { showToast(i18n('deleted_notebook')); return; }
@@ -31240,7 +31430,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         }
 
         function nbGoToReviewPage(id) {
-            const r = nbData().reviews.find(x => x.id === id);
+            const r = nbFindReviewById(id);
             if (!r) return;
             const nb = nbGetNotebook(r.notebookId);
             if (!nb) { showToast(i18n('deleted_notebook')); return; }
@@ -31253,7 +31443,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         // 完成 Quiz：截取画布 → 发给 AI 评分 → 显示结果 → 推进复习流程
         async function nbCompleteQuizFs() {
             if (!qzCurrentReviewId) return;
-            const r = nbData().reviews.find(x => x.id === qzCurrentReviewId);
+            const r = nbFindReviewById(qzCurrentReviewId);
             if (!r) return;
             const quiz = (r.quizzes || []).find(q => q.id === qzCurrentQuizId);
             if (!quiz || quiz.completedAt) { nbCloseQuizFullscreen(); return; }


### PR DESCRIPTION
## 修复内容

### 1. 手机端笔记顶栏溢出（无法新建下一页 / 无法退出）
- `.nb-topbar` 在 ≤640px 宽度下换行为两行：首行为退出、标题与翻页组（新增 `.nb-topbar-nav`），第二行为笔刷、橡皮、撤销/重做。
- `nbLayout()` 量测顶栏实际高度写入 `--nb-topbar-h`，左栏、画布区与大纲抽屉的 `top` 随之下移；宽屏保持原 52px 布局不变。
- Chromium 375×812 实测：顶栏不再横向溢出，点击「下一页」新建页面、点击「退出」关闭编辑器均正常。

### 2. 设置页手动同步到云端：课堂素材缺失不再阻塞
- 仅修改 `syncToR2()`（手动入口），自动云同步代码未改动。
- 单个课堂素材 / 录音 / 讲义在本机缺失或上传失败时只跳过该项并继续同步，完成提示中给出跳过数量。
- 跳过项不上传任何空正文；其云端已有正文原样保留，云端索引中的对应条目由 CAS 合并按云端副本保留（同 id 以云端为准，本机 pending 条目不会进入出站索引），不会被空数据覆盖。

### 3. iOS 笔记书写页触发浏览器原生选择
- 参照阅读页画笔模式的做法：编辑器显示期间在捕获阶段拦截书写区与工具栏上的 `selectstart` / `dragstart` / `contextmenu`，并在 `selectionchange` 时清除落在书写区的选区；CSS 对书写区与工具栏设置 `user-select: none` 与 `-webkit-touch-callout: none`。
- 正在编辑的文本框（contenteditable）与输入控件不受影响；大纲抽屉的右键/长按菜单不受影响。

### 4. 复习列表无法彻底删除
- 根因：云端 metadata 与本机按 id 合并并取 `updatedAt` 较新的一方，直接 splice 删除后，下一次 CAS 合并或启动拉取会把云端仍存在的副本加回来。
- 改为写入墓碑（保留 id/归属，`status: 'deleted'`、`deleted: true`、`updatedAt` 推到删除时刻），所有读取复习列表的地方通过 `nbLiveReviews()` 过滤；生成中的 Quiz 若其复习已删除则丢弃结果。
- 已在浏览器内验证两方向合并（本机墓碑 vs 云端活跃副本、云端墓碑 vs 本机活跃副本）均以删除为准。

### 5. Apple Pencil 模式对笔记页面生效
- `nbPointerDown` 与阅读页一致：Pencil 模式下只有触控笔（`booxReaderIsPen`）可以书写、擦除、套索、画图形。
- 手指单指在画布上滚动画布容器；双指捏合缩放（手势中以 transform 预览，结束时按 5% 步进落到 `nbZoomSet` 并保持捏合中心不动）。

### 6. BOOX 导出数据得不到 ZIP
- ZIP 与 PDF 原本就走同一 `DownloadBridge.save()`，但整体 base64 经 JS 桥一次传递对大 ZIP 会静默失败。
- `boox-pen.js` 改为 2 MB 分片：`beginSave → appendBase64… → finishSave`，Java 侧逐片解码追加，Android 10+ 写入期间标记 `IS_PENDING`，失败时删除半成品；所有导出仍落在同一下载目录（Toast「已保存到 下载/…」）。

### 7. 安卓 APK 课堂拍照权限
- Manifest 增加 `CAMERA` 权限、`android.hardware.camera.any`（非必需）、`IMAGE_CAPTURE` 的 `<queries>`，以及 FileProvider（`res/xml/file_paths.xml`）。
- `onShowFileChooser` 检测 `<input accept="image/*" capture>`：已授权则直接启动系统相机，未授权先申请；拒绝或无相机时退回文件选择器仍可上传照片。
- `onPermissionRequest` 同时映射麦克风 → `RECORD_AUDIO`、摄像头 → `CAMERA`。

## 验证
- `node --check` 通过（index.html 主脚本、boox-pen.js）；`node --test tests/*.test.js` 通过。
- Chromium（375×812 与 1024×768）内验证：顶栏布局、翻页/退出点击、选区拦截、Pencil 模式指针过滤、复习墓碑合并。
- `MainActivity.java`、`DownloadBridge.java` 使用 Android 框架 jar 与 androidx 桩离线 `javac` 编译通过；完整 APK 构建由 CI 执行。
- `docs/index.html` 已与 `app/src/main/assets/www/index.html` 同步。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01693RQFYwD6ARqH2z3FG4z6

---
_Generated by [Claude Code](https://claude.ai/code/session_01693RQFYwD6ARqH2z3FG4z6)_