### PR TITLE
Stream the backup ZIP; make manual cloud sync a full push and manual restore a full pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ AI 识题完成前不要关闭任务页面。照片应尽量正对、无阴影�
 
 1. 在 **R2 云同步配置** 填写 Access Key ID、Secret Access Key、Endpoint 和 Bucket；自定义域名可选。
 2. 点击 **测试连接**，成功后保存配置。
-3. 可手动使用 **同步到云端** / **从云端恢复**，也可开启定时同步和“文件变更时自动同步”。
+3. 可手动使用 **同步到云端** / **从云端恢复**，也可开启定时同步和“文件变更时自动同步”。手动 **同步到云端** 是全量推送：上传全部本地正文，并以本机数据覆盖云端索引（本机已删除的条目不会从云端合并回来）；手动 **从云端恢复** 是全量恢复：笔记本索引直接采用云端快照，并按云端副本覆盖本地全部笔记页正文。
 4. API Key 和 R2 配置本身只保留在设备本地，不随 R2 元数据上传；新设备仍需自行配置这些凭据。
 5. 首次迁移或准备清空设备时，优先保留一份完整 ZIP。R2 是同步副本，不应作为唯一备份。
 6. 讲义阅读进度在阅读时只写本地，退出讲义或应用切到后台时统一上传一次；讲义正文只在重新生成后才会上传，未改动的章节不会被重复传输。
@@ -310,7 +310,7 @@ Settings include user/AI profiles, notifications, photo retention, exercise time
 
 **Full ZIP backup** includes metadata, source documents, annotations, lectures, classroom material/recordings, exercise writing, notebooks, and local settings. Import replaces the current local books, notes, classes, exercises, lectures, and notebooks. A ZIP may contain credentials, private documents, chats, and recordings; never post it publicly. **Clear All Data** is irreversible.
 
-**Cloudflare R2 sync** is optional. Enter the access key, secret, endpoint, and bucket, test the connection, then use manual upload/restore or enable scheduled/on-change sync. API keys and the R2 configuration itself remain local and must be configured again on a new device. Keep a full ZIP for migrations; R2 should not be the only backup. Lecture reading progress is written locally while you read and uploaded once when you leave the lecture or the app goes to the background; lecture bodies are uploaded only after they are regenerated, so unchanged chapters are never re-sent.
+**Cloudflare R2 sync** is optional. Enter the access key, secret, endpoint, and bucket, test the connection, then use manual upload/restore or enable scheduled/on-change sync. Manual upload is a full push: it uploads every local body and replaces the cloud index with the local snapshot (items deleted locally are not merged back), and manual restore is a full pull: the notebook index is taken from the cloud snapshot and every local notebook page body is overwritten with the cloud copy. API keys and the R2 configuration itself remain local and must be configured again on a new device. Keep a full ZIP for migrations; R2 should not be the only backup. Lecture reading progress is written locally while you read and uploaded once when you leave the lecture or the app goes to the background; lecture bodies are uploaded only after they are regenerated, so unchanged chapters are never re-sent.
 
 ### 10. BOOX / E Ink compatibility
 

--- a/app/src/main/assets/boox-pen.js
+++ b/app/src/main/assets/boox-pen.js
@@ -7,7 +7,8 @@
  *    探测完全基于 PWA 已有的通用信号（可见性 + pointer-events），不依赖其内部状态。
  * 2. 抬笔后原生回传整笔触点，本脚本以合成 PointerEvent 回放给画布元素，
  *    PWA 自己的绘制/撤销/保存逻辑零修改全部复用。
- * 3. 拦截 blob: 下载（PWA 导出 PDF / 数据备份 ZIP / JSON），分片转交原生保存到下载目录。
+ * 3. 拦截 blob: 下载（PWA 导出 PDF / JSON 等），分片转交原生保存到下载目录；
+ *    数据备份 ZIP 由页面直接经 DownloadBridge 流式写入，不经过此处。
  *
  * index.html 含阅读器套索模式的 Boox 集成补丁，升级上游时需保留对应接口。
  */

--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -6984,8 +6984,8 @@
             local_class_material_missing:'本地课堂素材缺失：{0}', class_material_index_changed:'课堂素材索引已变化：{0}', class_note_content_missing:'课堂讲义内容缺失：{0}', class_note_index_changed:'课堂讲义索引已变化：{0}', delete_cloud_class_material_failed:'删除云端课堂素材失败：{0}', delete_cloud_class_note_failed:'删除云端课堂讲义失败：{0}',
             notification_lecture_sync_title:'讲义同步完成', notification_lecture_sync_body:'讲义已同步到云端', notification_abstract_sync_title:'摘要同步完成', notification_abstract_sync_body:'摘要已同步到云端', network_endpoint_cors_error:'网络、Endpoint 或 CORS 配置错误', permission_key_error:'权限或密钥错误', bucket_not_found:'未找到存储桶',
             local_recording_chunk_corrupt:'本地录音分块 {0} 损坏', recording_source_size_failed:'无法确认录音源文件大小', cloud_recording_manifest_invalid:'云端录音清单无效', cloud_recording_chunk_invalid:'云端录音分块 {0} 无效', cloud_recording_chunk_hash_failed:'云端录音分块 {0} 校验失败', delete_cloud_recording_manifest_failed:'删除云端录音清单失败：{0}', delete_cloud_recording_chunk_failed:'删除云端录音分块失败：{0}', delete_legacy_cloud_recording_failed:'删除旧版云端录音失败：{0}',
-            confirm_empty_local_overwrite_cloud:'本地数据为空。确定要覆盖非空的云端数据吗？', upload_cancelled:'上传已取消', recording_not_fully_saved:'录音尚未完整保存：{0}', sync_skipped_class_items:'；{0} 个课堂素材在本机缺失已跳过，云端已有内容保持不变', cloud_index_repaired:'云端索引已修复', count_lectures:'{0} 篇讲义', count_abstracts:'{0} 篇摘要', count_class_materials:'{0} 个课堂素材', count_exercise_files:'{0} 个习题文件', count_note_pages:'{0} 页笔记', count_note_media:'{0} 个笔记媒体', confirm_empty_cloud_overwrite_local:'云端数据为空。确定要覆盖本地数据吗？', restore_cancelled:'恢复已取消', restore_notebook_detail:'，另恢复 {0} 页笔记和 {1} 个媒体文件',
-            backup_file_too_large:'备份文件过大', compressed_zip_unsupported:'不支持压缩格式的 ZIP 条目', zip_descriptor_unsupported:'不支持带数据描述符的 ZIP 条目', recording_backup_source_size_invalid:'录音备份源大小无效：{0}', recording_backup_manifest_invalid:'录音备份清单无效：{0}', recording_backup_chunk_missing:'录音 {0} 的第 {1} 个备份分块缺失', recording_backup_length_failed:'录音备份长度校验失败：{0}', unknown_recording_backup_source:'未知的录音备份源：{0}', legacy_recording_missing:'旧版录音缺失：{0}', recording_backup_chunk_length_failed:'录音备份分块长度校验失败：{0}', recording_backup_chunk_missing_simple:'录音备份分块缺失：{0}', recording_has_no_backup_data:'录音没有可备份的数据：{0}', stop_recording_before_backup:'请先停止录音再备份', packing_zip_backup:'正在打包 ZIP 备份…', recording_added_during_export:'导出期间新增的录音',
+            confirm_empty_local_overwrite_cloud:'本地数据为空。确定要覆盖非空的云端数据吗？', upload_cancelled:'上传已取消', recording_not_fully_saved:'录音尚未完整保存：{0}', sync_skipped_class_items:'；{0} 个课堂素材在本机缺失已跳过，云端已有内容保持不变', sync_progress_materials:'正在上传课堂素材 {0}/{1}…', sync_progress_lectures:'正在上传讲义与笔记页…', sync_progress_pages:'正在上传笔记页 {0}/{1}…', sync_progress_metadata:'正在发布云端索引…', sync_progress_files:'正在上传文件 {0}/{1}…', upload_timeout:'上传超时：{0}', restore_progress_files:'正在恢复文件 {0}/{1}…', restore_progress_pages:'正在恢复笔记页 {0}/{1}…', restore_notebook_failed_detail:'，{0} 页笔记未能从云端取回', cloud_index_repaired:'云端索引已修复', count_lectures:'{0} 篇讲义', count_abstracts:'{0} 篇摘要', count_class_materials:'{0} 个课堂素材', count_exercise_files:'{0} 个习题文件', count_note_pages:'{0} 页笔记', count_note_media:'{0} 个笔记媒体', confirm_empty_cloud_overwrite_local:'云端数据为空。确定要覆盖本地数据吗？', restore_cancelled:'恢复已取消', restore_notebook_detail:'，另恢复 {0} 页笔记和 {1} 个媒体文件',
+            backup_file_too_large:'备份文件过大', compressed_zip_unsupported:'不支持压缩格式的 ZIP 条目', zip_descriptor_unsupported:'不支持带数据描述符的 ZIP 条目', recording_backup_source_size_invalid:'录音备份源大小无效：{0}', recording_backup_manifest_invalid:'录音备份清单无效：{0}', recording_backup_chunk_missing:'录音 {0} 的第 {1} 个备份分块缺失', recording_backup_length_failed:'录音备份长度校验失败：{0}', unknown_recording_backup_source:'未知的录音备份源：{0}', legacy_recording_missing:'旧版录音缺失：{0}', recording_backup_chunk_length_failed:'录音备份分块长度校验失败：{0}', recording_backup_chunk_missing_simple:'录音备份分块缺失：{0}', recording_has_no_backup_data:'录音没有可备份的数据：{0}', stop_recording_before_backup:'请先停止录音再备份', packing_zip_backup:'正在打包 ZIP 备份…', export_progress:'正在打包 ZIP 备份…已写入 {0} 个文件', export_native_open_failed:'无法在下载目录创建 ZIP 文件', export_native_write_failed:'写入 ZIP 文件失败', recording_added_during_export:'导出期间新增的录音',
             export_local_files_detail:'（含 {0} 个本地文件）', export_missing_recordings_detail:'（另含 {0} 个补充录音）', export_failed:'导出失败：', confirm_import_zip_overwrite:'导入 ZIP 备份将覆盖当前数据，是否继续？', parsing_zip_backup:'正在解析 ZIP 备份…', backup_missing_metadata:'备份中缺少 metadata.json', missing_recordings_manifest_invalid:'补充录音清单无效', missing_recordings_manifest_invalid_id:'补充录音清单包含无效 ID', recording_backup_index_invalid:'录音备份索引无效', recording_backup_chunk_invalid:'录音 {0} 的第 {1} 个备份分块无效', import_complete_files:'导入完成，共恢复 {0} 个文件', import_failed:'导入失败：',
             indexeddb_unavailable:'IndexedDB 不可用', transaction_aborted:'事务被中止：{0}', unknown_reason:'未知原因', recording_transaction_failed:'录音事务失败', recording_transaction_aborted:'录音事务被中止', class_file_transaction_failed:'课堂文件事务失败', class_file_transaction_aborted:'课堂文件事务被中止', recording_storage_module_not_loaded:'录音存储模块未加载', class_lecture_content_empty:'课堂讲义内容为空', data_structure_corrupt:'数据结构损坏：books/papers 不是数组'
         });
@@ -7003,8 +7003,8 @@
             local_class_material_missing:'Local class material is missing: {0}', class_material_index_changed:'The class material index changed: {0}', class_note_content_missing:'Class lecture content is missing: {0}', class_note_index_changed:'The class lecture index changed: {0}', delete_cloud_class_material_failed:'Failed to delete cloud class material: {0}', delete_cloud_class_note_failed:'Failed to delete cloud class lecture: {0}',
             notification_lecture_sync_title:'Lecture sync complete', notification_lecture_sync_body:'The lecture was synced to the cloud', notification_abstract_sync_title:'Abstract sync complete', notification_abstract_sync_body:'The abstract was synced to the cloud', network_endpoint_cors_error:'Network, endpoint, or CORS configuration error', permission_key_error:'Permission or credential error', bucket_not_found:'Bucket not found',
             local_recording_chunk_corrupt:'Local recording chunk {0} is corrupted', recording_source_size_failed:'Could not verify the recording source size', cloud_recording_manifest_invalid:'The cloud recording manifest is invalid', cloud_recording_chunk_invalid:'Cloud recording chunk {0} is invalid', cloud_recording_chunk_hash_failed:'Cloud recording chunk {0} failed verification', delete_cloud_recording_manifest_failed:'Failed to delete cloud recording manifest: {0}', delete_cloud_recording_chunk_failed:'Failed to delete cloud recording chunk: {0}', delete_legacy_cloud_recording_failed:'Failed to delete legacy cloud recording: {0}',
-            confirm_empty_local_overwrite_cloud:'Local data is empty. Overwrite non-empty cloud data?', upload_cancelled:'Upload cancelled', recording_not_fully_saved:'Recording is not fully saved: {0}', sync_skipped_class_items:'; {0} class materials missing locally were skipped; existing cloud copies were kept', cloud_index_repaired:'Cloud index repaired', count_lectures:'{0} lectures', count_abstracts:'{0} abstracts', count_class_materials:'{0} class materials', count_exercise_files:'{0} exercise files', count_note_pages:'{0} note pages', count_note_media:'{0} note media files', confirm_empty_cloud_overwrite_local:'Cloud data is empty. Overwrite local data?', restore_cancelled:'Restore cancelled', restore_notebook_detail:', plus {0} note pages and {1} media files',
-            backup_file_too_large:'Backup file is too large', compressed_zip_unsupported:'Compressed ZIP entries are not supported', zip_descriptor_unsupported:'ZIP data descriptors are not supported', recording_backup_source_size_invalid:'Invalid recording backup source size: {0}', recording_backup_manifest_invalid:'Invalid recording backup manifest: {0}', recording_backup_chunk_missing:'Backup chunk {1} is missing for recording {0}', recording_backup_length_failed:'Recording backup length verification failed: {0}', unknown_recording_backup_source:'Unknown recording backup source: {0}', legacy_recording_missing:'Legacy recording is missing: {0}', recording_backup_chunk_length_failed:'Recording backup chunk length verification failed: {0}', recording_backup_chunk_missing_simple:'Recording backup chunk is missing: {0}', recording_has_no_backup_data:'Recording has no data to back up: {0}', stop_recording_before_backup:'Stop recording before creating a backup', packing_zip_backup:'Packing ZIP backup…', recording_added_during_export:'Recording added during export',
+            confirm_empty_local_overwrite_cloud:'Local data is empty. Overwrite non-empty cloud data?', upload_cancelled:'Upload cancelled', recording_not_fully_saved:'Recording is not fully saved: {0}', sync_skipped_class_items:'; {0} class materials missing locally were skipped; existing cloud copies were kept', sync_progress_materials:'Uploading class materials {0}/{1}…', sync_progress_lectures:'Uploading lectures and note pages…', sync_progress_pages:'Uploading note pages {0}/{1}…', sync_progress_metadata:'Publishing cloud index…', sync_progress_files:'Uploading files {0}/{1}…', upload_timeout:'Upload timed out: {0}', restore_progress_files:'Restoring files {0}/{1}…', restore_progress_pages:'Restoring note pages {0}/{1}…', restore_notebook_failed_detail:', {0} note pages could not be fetched from the cloud', cloud_index_repaired:'Cloud index repaired', count_lectures:'{0} lectures', count_abstracts:'{0} abstracts', count_class_materials:'{0} class materials', count_exercise_files:'{0} exercise files', count_note_pages:'{0} note pages', count_note_media:'{0} note media files', confirm_empty_cloud_overwrite_local:'Cloud data is empty. Overwrite local data?', restore_cancelled:'Restore cancelled', restore_notebook_detail:', plus {0} note pages and {1} media files',
+            backup_file_too_large:'Backup file is too large', compressed_zip_unsupported:'Compressed ZIP entries are not supported', zip_descriptor_unsupported:'ZIP data descriptors are not supported', recording_backup_source_size_invalid:'Invalid recording backup source size: {0}', recording_backup_manifest_invalid:'Invalid recording backup manifest: {0}', recording_backup_chunk_missing:'Backup chunk {1} is missing for recording {0}', recording_backup_length_failed:'Recording backup length verification failed: {0}', unknown_recording_backup_source:'Unknown recording backup source: {0}', legacy_recording_missing:'Legacy recording is missing: {0}', recording_backup_chunk_length_failed:'Recording backup chunk length verification failed: {0}', recording_backup_chunk_missing_simple:'Recording backup chunk is missing: {0}', recording_has_no_backup_data:'Recording has no data to back up: {0}', stop_recording_before_backup:'Stop recording before creating a backup', packing_zip_backup:'Packing ZIP backup…', export_progress:'Packing ZIP backup… {0} files written', export_native_open_failed:'Could not create the ZIP file in Downloads', export_native_write_failed:'Failed to write the ZIP file', recording_added_during_export:'Recording added during export',
             export_local_files_detail:' ({0} local files included)', export_missing_recordings_detail:' ({0} supplemental recordings included)', export_failed:'Export failed: ', confirm_import_zip_overwrite:'Importing this ZIP backup will overwrite current data. Continue?', parsing_zip_backup:'Parsing ZIP backup…', backup_missing_metadata:'metadata.json is missing from the backup', missing_recordings_manifest_invalid:'Supplemental recording manifest is invalid', missing_recordings_manifest_invalid_id:'Supplemental recording manifest contains an invalid ID', recording_backup_index_invalid:'Recording backup index is invalid', recording_backup_chunk_invalid:'Backup chunk {1} is invalid for recording {0}', import_complete_files:'Import complete: {0} files restored', import_failed:'Import failed: ',
             indexeddb_unavailable:'IndexedDB is unavailable', transaction_aborted:'Transaction aborted: {0}', unknown_reason:'Unknown reason', recording_transaction_failed:'Recording transaction failed', recording_transaction_aborted:'Recording transaction was aborted', class_file_transaction_failed:'Class file transaction failed', class_file_transaction_aborted:'Class file transaction was aborted', recording_storage_module_not_loaded:'Recording storage module is not loaded', class_lecture_content_empty:'Class lecture content is empty', data_structure_corrupt:'Corrupted data structure: books/papers must be arrays'
         });
@@ -7022,8 +7022,8 @@
             local_class_material_missing:'Support de cours local manquant : {0}', class_material_index_changed:"L’index des supports de cours a changé : {0}", class_note_content_missing:'Contenu du cours manquant : {0}', class_note_index_changed:"L’index des cours a changé : {0}", delete_cloud_class_material_failed:'Échec de suppression du support cloud : {0}', delete_cloud_class_note_failed:'Échec de suppression du cours cloud : {0}',
             notification_lecture_sync_title:'Synchronisation du cours terminée', notification_lecture_sync_body:'Le cours a été synchronisé dans le cloud', notification_abstract_sync_title:'Synchronisation du résumé terminée', notification_abstract_sync_body:'Le résumé a été synchronisé dans le cloud', network_endpoint_cors_error:'Erreur de réseau, d’endpoint ou de configuration CORS', permission_key_error:'Erreur d’autorisation ou d’identifiants', bucket_not_found:'Bucket introuvable',
             local_recording_chunk_corrupt:"Le segment local d’enregistrement {0} est corrompu", recording_source_size_failed:"Impossible de vérifier la taille de l’enregistrement source", cloud_recording_manifest_invalid:"Le manifeste cloud de l’enregistrement est invalide", cloud_recording_chunk_invalid:'Le segment cloud {0} est invalide', cloud_recording_chunk_hash_failed:'Échec de vérification du segment cloud {0}', delete_cloud_recording_manifest_failed:'Échec de suppression du manifeste cloud : {0}', delete_cloud_recording_chunk_failed:'Échec de suppression du segment cloud : {0}', delete_legacy_cloud_recording_failed:"Échec de suppression de l’ancien enregistrement cloud : {0}",
-            confirm_empty_local_overwrite_cloud:'Les données locales sont vides. Remplacer les données cloud non vides ?', upload_cancelled:'Envoi annulé', recording_not_fully_saved:"L’enregistrement n’est pas entièrement sauvegardé : {0}", sync_skipped_class_items:' ; {0} supports de cours absents localement ont été ignorés ; les copies cloud existantes ont été conservées', cloud_index_repaired:'Index cloud réparé', count_lectures:'{0} cours', count_abstracts:'{0} résumés', count_class_materials:'{0} supports de cours', count_exercise_files:'{0} fichiers d’exercices', count_note_pages:'{0} pages de notes', count_note_media:'{0} médias de notes', confirm_empty_cloud_overwrite_local:'Les données cloud sont vides. Remplacer les données locales ?', restore_cancelled:'Restauration annulée', restore_notebook_detail:', plus {0} pages de notes et {1} médias',
-            backup_file_too_large:'Le fichier de sauvegarde est trop volumineux', compressed_zip_unsupported:'Les entrées ZIP compressées ne sont pas prises en charge', zip_descriptor_unsupported:'Les descripteurs de données ZIP ne sont pas pris en charge', recording_backup_source_size_invalid:'Taille de source de sauvegarde invalide : {0}', recording_backup_manifest_invalid:'Manifeste de sauvegarde invalide : {0}', recording_backup_chunk_missing:"Le segment {1} de l’enregistrement {0} manque dans la sauvegarde", recording_backup_length_failed:'Échec de vérification de la longueur de la sauvegarde : {0}', unknown_recording_backup_source:'Source de sauvegarde inconnue : {0}', legacy_recording_missing:'Ancien enregistrement manquant : {0}', recording_backup_chunk_length_failed:'Échec de vérification de la longueur du segment : {0}', recording_backup_chunk_missing_simple:'Segment de sauvegarde manquant : {0}', recording_has_no_backup_data:"L’enregistrement ne contient aucune donnée à sauvegarder : {0}", stop_recording_before_backup:"Arrêtez l’enregistrement avant de créer une sauvegarde", packing_zip_backup:'Création de la sauvegarde ZIP…', recording_added_during_export:'Enregistrement ajouté pendant l’exportation',
+            confirm_empty_local_overwrite_cloud:'Les données locales sont vides. Remplacer les données cloud non vides ?', upload_cancelled:'Envoi annulé', recording_not_fully_saved:"L’enregistrement n’est pas entièrement sauvegardé : {0}", sync_skipped_class_items:' ; {0} supports de cours absents localement ont été ignorés ; les copies cloud existantes ont été conservées', sync_progress_materials:'Envoi des supports de cours {0}/{1}…', sync_progress_lectures:'Envoi des cours et des pages de notes…', sync_progress_pages:'Envoi des pages de notes {0}/{1}…', sync_progress_metadata:'Publication de l’index cloud…', sync_progress_files:'Envoi des fichiers {0}/{1}…', upload_timeout:'Délai d’envoi dépassé : {0}', restore_progress_files:'Restauration des fichiers {0}/{1}…', restore_progress_pages:'Restauration des pages de notes {0}/{1}…', restore_notebook_failed_detail:', {0} pages de notes n’ont pas pu être récupérées du cloud', cloud_index_repaired:'Index cloud réparé', count_lectures:'{0} cours', count_abstracts:'{0} résumés', count_class_materials:'{0} supports de cours', count_exercise_files:'{0} fichiers d’exercices', count_note_pages:'{0} pages de notes', count_note_media:'{0} médias de notes', confirm_empty_cloud_overwrite_local:'Les données cloud sont vides. Remplacer les données locales ?', restore_cancelled:'Restauration annulée', restore_notebook_detail:', plus {0} pages de notes et {1} médias',
+            backup_file_too_large:'Le fichier de sauvegarde est trop volumineux', compressed_zip_unsupported:'Les entrées ZIP compressées ne sont pas prises en charge', zip_descriptor_unsupported:'Les descripteurs de données ZIP ne sont pas pris en charge', recording_backup_source_size_invalid:'Taille de source de sauvegarde invalide : {0}', recording_backup_manifest_invalid:'Manifeste de sauvegarde invalide : {0}', recording_backup_chunk_missing:"Le segment {1} de l’enregistrement {0} manque dans la sauvegarde", recording_backup_length_failed:'Échec de vérification de la longueur de la sauvegarde : {0}', unknown_recording_backup_source:'Source de sauvegarde inconnue : {0}', legacy_recording_missing:'Ancien enregistrement manquant : {0}', recording_backup_chunk_length_failed:'Échec de vérification de la longueur du segment : {0}', recording_backup_chunk_missing_simple:'Segment de sauvegarde manquant : {0}', recording_has_no_backup_data:"L’enregistrement ne contient aucune donnée à sauvegarder : {0}", stop_recording_before_backup:"Arrêtez l’enregistrement avant de créer une sauvegarde", packing_zip_backup:'Création de la sauvegarde ZIP…', export_progress:'Création de la sauvegarde ZIP… {0} fichiers écrits', export_native_open_failed:'Impossible de créer le fichier ZIP dans Téléchargements', export_native_write_failed:'Échec de l’écriture du fichier ZIP', recording_added_during_export:'Enregistrement ajouté pendant l’exportation',
             export_local_files_detail:' ({0} fichiers locaux inclus)', export_missing_recordings_detail:' ({0} enregistrements supplémentaires inclus)', export_failed:"Échec de l’exportation : ", confirm_import_zip_overwrite:'Importer cette sauvegarde ZIP remplacera les données actuelles. Continuer ?', parsing_zip_backup:'Analyse de la sauvegarde ZIP…', backup_missing_metadata:'metadata.json manque dans la sauvegarde', missing_recordings_manifest_invalid:'Le manifeste des enregistrements supplémentaires est invalide', missing_recordings_manifest_invalid_id:'Le manifeste contient un identifiant invalide', recording_backup_index_invalid:"L’index de sauvegarde des enregistrements est invalide", recording_backup_chunk_invalid:'Le segment {1} de l’enregistrement {0} est invalide', import_complete_files:'Importation terminée : {0} fichiers restaurés', import_failed:"Échec de l’importation : ",
             indexeddb_unavailable:'IndexedDB est indisponible', transaction_aborted:'Transaction interrompue : {0}', unknown_reason:'Raison inconnue', recording_transaction_failed:"Échec de la transaction d’enregistrement", recording_transaction_aborted:"La transaction d’enregistrement a été interrompue", class_file_transaction_failed:'Échec de la transaction du fichier de cours', class_file_transaction_aborted:'La transaction du fichier de cours a été interrompue', recording_storage_module_not_loaded:"Le module de stockage des enregistrements n’est pas chargé", class_lecture_content_empty:'Le contenu du cours est vide', data_structure_corrupt:'Structure de données corrompue : books/papers doivent être des tableaux'
         });
@@ -9303,11 +9303,12 @@
         }
 
         // ==================== Toast ====================
-        function showToast(msg) {
+        function showToast(msg, durationMs = 2000) {
             const t = document.getElementById('toast');
             t.textContent = msg;
             t.classList.add('show');
-            setTimeout(() => t.classList.remove('show'), 2000);
+            clearTimeout(showToast._timer);
+            showToast._timer = setTimeout(() => t.classList.remove('show'), durationMs);
         }
 
         // ==================== Modal Helpers (from original) ====================
@@ -14433,6 +14434,19 @@
                 const mergedIntent = remoteClassroomCount === 0 && localClassroomCount > 0
                     ? localClassroom
                     : mergeClassroomData(remoteClassroom, localClassroom, remoteBaseline);
+                let candidate;
+                if (options.fullOverwrite) {
+                    // 手动「同步到云端」是全量推送：云端索引以本机快照为准，不与云端旧索引合并
+                    // （合并会把本机已删除的笔记本/讲义/课堂条目从云端加回来）。仍保留：
+                    // 课堂删除墓碑取并集、pending 正文不进入索引、ETag CAS 防止与并发写入互相覆盖。
+                    candidate = {
+                        ...localMetadata,
+                        notebooks: localMetadata.notebooks || { items: [], reviews: [] },
+                        classroom: stripClassroomData(localClassroom, true),
+                        classroomTombstones: tombstones,
+                        syncedAt: new Date().toISOString()
+                    };
+                } else {
                 let candidateBase = options.classroomOnly && remoteMetadata
                     ? remoteMetadata
                     : localMetadata;
@@ -14462,7 +14476,7 @@
                     mergedNotebooks.reviews = (mergedNotebooks.reviews || [])
                         .filter(review => review?.notebookId !== options.notebookDeletedId);
                 }
-                const candidate = {
+                candidate = {
                     ...candidateBase,
                     lectures: mergeLecturesData(
                         remoteMetadata?.lectures,
@@ -14474,6 +14488,7 @@
                     classroomTombstones: tombstones,
                     syncedAt: new Date().toISOString()
                 };
+                }
 
                 if (!options.allowEmpty &&
                     !await r2ProtectMetadataOverwrite(candidate, remoteResult?.data || null, remoteMetadata)) {
@@ -14490,6 +14505,15 @@
                         : {};
                 try {
                     await r2PutObject('metadata.json', JSON.stringify(candidate), 'application/json', conditions);
+
+                    if (options.fullOverwrite) {
+                        // 全量覆盖：云端已等于本机快照，只需记录墓碑并清除课堂 pending 标记
+                        appData.classroomTombstones = mergeClassroomTombstones(
+                            appData.classroomTombstones, candidate.classroomTombstones);
+                        await markClassroomMetadataCloudCommitted(candidate.classroom);
+                        saveData();
+                        return { metadata: candidate, casCommitted: true };
+                    }
 
                     // 把本轮 CAS 读取到的其它设备课堂新增项合并回当前活对象；等待网络
                     // 期间刚创建的本地 pending 项仍由 merge 规则保留。
@@ -14807,9 +14831,25 @@
                 .flatMap(nb => nb.pages || [])
                 .find(pg => pg && pg.id === pageId);
             const mediaIds = new Set();
-            let pgData = await getFileData('nbpage_' + pageId).catch(() => null);
+            let pgData;
+            try {
+                pgData = await getFileData('nbpage_' + pageId);
+            } catch (e) {
+                // 本地读取失败（IndexedDB 连接异常等）绝不能当成空白页：旧实现会用空内容
+                // 覆盖本地正文并上传到云端，表现为恢复后「笔画不全」。这里直接跳过本页。
+                console.warn('[nb-sync] 读取笔记页失败，跳过上传:', pageId, e);
+                return;
+            }
             let pageContent = null;
-            try { pageContent = pgData ? JSON.parse(pgData) : null; } catch (e) {}
+            if (pgData) {
+                try {
+                    pageContent = JSON.parse(pgData);
+                } catch (e) {
+                    console.warn('[nb-sync] 笔记页内容损坏，跳过上传:', pageId, e);
+                    return;
+                }
+            }
+            // 从未书写过的页面本地没有记录，按空白页上传即可
             if (!pageContent && page) pageContent = { strokes: [], texts: [], media: [], recognized: null };
             if (pageContent) {
                 if (!pageContent.updatedAt) {
@@ -14820,9 +14860,8 @@
                     page.updatedAt = pageContent.updatedAt;
                     saveData();
                 }
-                pgData = JSON.stringify(pageContent);
-                await saveFileData('nbpage_' + pageId, pgData);
-                await r2PutObject('notebooks/pages/nbpage_' + pageId, pgData, 'application/json');
+                // 不再把规范化后的内容写回本地：写回会与编辑器的保存竞争并覆盖用户刚写的笔画
+                await r2PutObject('notebooks/pages/nbpage_' + pageId, JSON.stringify(pageContent), 'application/json');
                 (pageContent.media || []).forEach(m => { if (m.mediaId) mediaIds.add(m.mediaId); });
             }
             if (page && page.bgImage) mediaIds.add(page.bgImage);
@@ -14832,12 +14871,21 @@
             }
         }
 
-        async function r2SyncAllNotebookPages() {
-            for (const nb of (appData.notebooks?.items || [])) {
-                for (const pg of (nb.pages || [])) {
-                    if (pg && pg.id) await r2SyncNotebookPageBundle(pg.id);
+        // options.concurrency：手动全量推送时并发上传若干页以缩短耗时（默认逐页，行为同旧版）
+        async function r2SyncAllNotebookPages(onProgress, options = {}) {
+            const pages = (appData.notebooks?.items || [])
+                .flatMap(nb => (nb.pages || []).filter(pg => pg && pg.id));
+            const concurrency = Math.max(1, Math.min(8, Number(options.concurrency) || 1));
+            let done = 0, next = 0;
+            const worker = async () => {
+                while (next < pages.length) {
+                    const pg = pages[next++];
+                    await r2SyncNotebookPageBundle(pg.id);
+                    done++;
+                    if (onProgress) onProgress(done, pages.length);
                 }
-            }
+            };
+            await Promise.all(Array.from({ length: Math.min(concurrency, pages.length) }, worker));
         }
 
         function r2NotebookMediaIdsFromPage(page, pageJson) {
@@ -14854,10 +14902,18 @@
 
         async function r2PullNotebookAssetsFromCloud(options = {}) {
             const missingOnly = options.missingOnly !== false;
-            let pages = 0, media = 0;
+            // 手动恢复给单个对象一个下载上限，避免网络停滞让整次恢复无声挂起；启动拉取保持原样
+            const getObject = key => options.timeoutMs
+                ? r2GetObjectWithTimeout(key, options.timeoutMs)
+                : r2GetObject(key);
+            const total = (appData.notebooks?.items || [])
+                .reduce((sum, nb) => sum + (nb.pages || []).filter(page => page && page.id).length, 0);
+            let pages = 0, media = 0, failed = 0, visited = 0;
             for (const nb of (appData.notebooks?.items || [])) {
                 for (const page of (nb.pages || [])) {
                     if (!page || !page.id) continue;
+                    visited++;
+                    if (options.onProgress) options.onProgress(visited, total);
                     let pageJson = await getFileData('nbpage_' + page.id).catch(() => null);
                     let localPageUpdatedAt = 0;
                     try {
@@ -14868,20 +14924,26 @@
                         (cloudPageUpdatedAt > 0 && cloudPageUpdatedAt > localPageUpdatedAt);
                     if (shouldPullPage) {
                         try {
-                            const cloudPage = await r2GetObject('notebooks/pages/nbpage_' + page.id);
+                            const cloudPage = await getObject('notebooks/pages/nbpage_' + page.id);
                             if (cloudPage) {
                                 pageJson = cloudPage;
                                 await saveFileData('nbpage_' + page.id, cloudPage);
                                 pages++;
+                            } else if (!pageJson) {
+                                failed++;
+                                console.warn('[sync] 云端没有该笔记页正文:', page.id);
                             }
-                        } catch (e) { console.warn('[startup-sync] 拉取笔记页失败:', page.id, e); }
+                        } catch (e) {
+                            failed++;
+                            console.warn('[startup-sync] 拉取笔记页失败:', page.id, e);
+                        }
                     }
                     const mediaIds = r2NotebookMediaIdsFromPage(page, pageJson);
                     for (const mediaId of mediaIds) {
                         const localMedia = await getFileData('nbmedia_' + mediaId).catch(() => null);
                         if (missingOnly && localMedia) continue;
                         try {
-                            const cloudMedia = await r2GetObject('notebooks/media/nbmedia_' + mediaId);
+                            const cloudMedia = await getObject('notebooks/media/nbmedia_' + mediaId);
                             if (cloudMedia) {
                                 await saveFileData('nbmedia_' + mediaId, cloudMedia);
                                 media++;
@@ -14890,7 +14952,7 @@
                     }
                 }
             }
-            return { pages, media };
+            return { pages, media, failed };
         }
 
         function r2NotebookPositionKey(notebookId) {
@@ -15352,6 +15414,7 @@
             return await hmac(kService, 'aws4_request');
         }
 
+        const R2_UNSIGNED_PAYLOAD_BYTES = 4 * 1024 * 1024;
         async function r2PutObject(key, data, contentType = 'application/octet-stream', options = {}) {
             const config = appData.settings.r2Config;
             // 移除endpoint末尾的斜杠
@@ -15360,7 +15423,15 @@
             const url = endpoint + '/' + path;
             
             const isBinary = data instanceof Blob || data instanceof ArrayBuffer || ArrayBuffer.isView(data);
-            const payload = typeof data === 'string' || isBinary ? data : JSON.stringify(data);
+            let payload = typeof data === 'string' || isBinary ? data : JSON.stringify(data);
+            const payloadBytes = payload instanceof Blob ? payload.size
+                : (payload instanceof ArrayBuffer || ArrayBuffer.isView(payload)) ? payload.byteLength
+                : payload.length;
+            // 大对象（书籍 PDF、课堂照片等在 IndexedDB 中多为 base64 字符串）：整段 SHA-256 需要再
+            // 复制一份字节，fetch 发送字符串时又复制一份，低内存 WebView（Boox）会被系统杀掉。
+            // 改用 R2 支持的 UNSIGNED-PAYLOAD 跳过正文哈希，并把正文转成 Blob 交给 blob 存储流式上传。
+            const largePayload = payloadBytes >= R2_UNSIGNED_PAYLOAD_BYTES;
+            if (largePayload && !(payload instanceof Blob)) payload = new Blob([payload], { type: contentType });
             
             // 构建请求头 - 不包含浏览器禁止的头
             const headers = new Headers();
@@ -15375,7 +15446,7 @@
             const now = new Date();
             const amzDate = now.toISOString().replace(/[:-]|\.\d{3}/g, '');
             const dateStamp = amzDate.slice(0, 8);
-            const contentSha256 = await sha256Hex(payload);
+            const contentSha256 = largePayload ? 'UNSIGNED-PAYLOAD' : await sha256Hex(payload);
             
             // 签名用的头（包含host用于计算，但不发送）
             const headersToSign = {
@@ -15421,12 +15492,26 @@
             if (options.ifMatch) headers.set('If-Match', String(options.ifMatch));
             if (options.ifNoneMatch) headers.set('If-None-Match', String(options.ifNoneMatch));
             
-            const response = await fetch(url, {
-                method: 'PUT',
-                headers: headers,
-                body: payload,
-                mode: 'cors'
-            });
+            // 上传没有内建超时：网络停滞会让手动同步永远停在「正在同步」而无任何提示。
+            // 按大小给一个宽松上限（基础 5 分钟 + 每 10 MB 1 分钟），只用于兜底。
+            const controller = typeof AbortController === 'function' ? new AbortController() : null;
+            const timeoutMs = 5 * 60 * 1000 + Math.ceil(payloadBytes / (10 * 1024 * 1024)) * 60 * 1000;
+            const timer = controller ? setTimeout(() => controller.abort(), timeoutMs) : null;
+            let response;
+            try {
+                response = await fetch(url, {
+                    method: 'PUT',
+                    headers: headers,
+                    body: payload,
+                    mode: 'cors',
+                    signal: controller ? controller.signal : undefined
+                });
+            } catch (e) {
+                if (controller && controller.signal.aborted) throw new Error(i18n('upload_timeout', key));
+                throw e;
+            } finally {
+                if (timer) clearTimeout(timer);
+            }
             
             if (!response.ok) {
                 const errText = await response.text().catch(() => '');
@@ -15911,6 +15996,15 @@
 
             r2SyncInProgress = true;
             showToast(i18n('toast_syncing'));
+            // 全量推送在 Boox 等设备上可能持续数分钟：按阶段给出节流的进度提示，
+            // 结束时的成功/失败提示停留更久，避免被误认为「没有提示」。
+            let lastSyncProgressAt = 0;
+            const syncProgress = (key, done, total) => {
+                const now = Date.now();
+                if (done < total && now - lastSyncProgressAt < 2500) return;
+                lastSyncProgressAt = now;
+                showToast(i18n(key, done, total), 4000);
+            };
             
             try {
                 // 1. 上传元数据 (不包含PDF数据，但保留annotations)
@@ -15953,10 +16047,20 @@
                     skippedClassroomItems.push({ id: item?.id, name: item?.name || item?.title || '', reason });
                     console.warn('[sync] 课堂素材已跳过，云端已有内容保持不变:', item?.id, reason);
                 };
+                let classroomTotal = 0, classroomDone = 0;
+                for (const listKey of ['courses', 'seminars']) {
+                    for (const folder of (appData.classroom?.[listKey] || [])) {
+                        for (const session of (folder.sessions || [])) {
+                            classroomTotal += (session.sourceFolder || []).length +
+                                (session.notes || []).filter(note => note.contentKey).length;
+                        }
+                    }
+                }
                 for (const listKey of ['courses', 'seminars']) {
                     for (const folder of (appData.classroom?.[listKey] || [])) {
                         for (const session of (folder.sessions || [])) {
                             for (const mat of (session.sourceFolder || [])) {
+                                syncProgress('sync_progress_materials', ++classroomDone, classroomTotal);
                                 try {
                                     if (mat.type === 'recording') {
                                         if (!await r2SyncRecording(mat)) {
@@ -15972,6 +16076,7 @@
                             }
                             for (const note of (session.notes || [])) {
                                 if (!note.contentKey) continue;
+                                syncProgress('sync_progress_materials', ++classroomDone, classroomTotal);
                                 try {
                                     await r2SyncClassroomNote(note);
                                     uploadedClassroomNotes++;
@@ -15983,14 +16088,21 @@
                     }
                 }
                 // 手动"同步到云端"是全量推送，同时充当云端正文丢失后的修复入口。
+                showToast(i18n('sync_progress_lectures'), 4000);
                 const uploadedLectures = await r2SyncChangedLectureContents({ force: true });
-                await r2SyncAllNotebookPages();
+                // 笔记页全量上传（本机内容覆盖云端），并发 3 路以缩短耗时
+                if (nbState.dirty) await nbSavePageNow();
+                await r2SyncAllNotebookPages((done, total) => syncProgress('sync_progress_pages', done, total),
+                    { concurrency: 3 });
                 metadata.lectures = stripLectureContent(appData.lectures);
                 metadata.notebooks = appData.notebooks || { items: [], reviews: [] };
                 metadata.classroom = stripClassroomData(appData.classroom, true);
                 metadata.syncedAt = new Date().toISOString();
+                // 全量覆盖云端索引（见 r2PublishMetadataWithCas 的 fullOverwrite 说明）
+                showToast(i18n('sync_progress_metadata'), 4000);
                 const metadataPublishResult = await r2PublishMetadataWithCas(metadata,
                     stripClassroomData(appData.classroom, false), {
+                        fullOverwrite: true,
                         allowEmpty: allowEmptyMetadataOverwrite ||
                             (appData.classroomSyncOutbox || []).length > 0
                     });
@@ -16002,7 +16114,10 @@
                 let uploadedFiles = 0;
                 const allDocs = [...appData.books, ...appData.papers];
                 
-                for (const doc of allDocs) {
+                for (let docIndex = 0; docIndex < allDocs.length; docIndex++) {
+                    const doc = allDocs[docIndex];
+                    syncProgress('sync_progress_files', docIndex + 1, allDocs.length);
+                    // 每份 PDF 只在本轮迭代中驻留内存
                     const fileData = await getFileData(doc.id);
                     if (fileData) {
                         const fileKey = 'files/' + doc.id + '.pdf';
@@ -16093,10 +16208,10 @@
                 showToast(i18n('sync_done_detail', uploadedFiles, uploadedLectures, uploadedAbstracts) +
                     (skippedClassroomItems.length
                         ? i18n('sync_skipped_class_items', skippedClassroomItems.length)
-                        : ''));
+                        : ''), 6000);
             } catch (err) {
                 console.error('Sync to R2 failed:', err);
-                showToast(i18n('toast_sync_failed') + err.message);
+                showToast(i18n('toast_sync_failed') + err.message, 6000);
             } finally {
                 r2SyncInProgress = false;
                 if (r2PendingSyncQueue.length > 0) {
@@ -16906,6 +17021,7 @@
             }
         }
 
+        const R2_RESTORE_OBJECT_TIMEOUT_MS = 20 * 60 * 1000;
         async function syncFromR2() {
             const config = appData.settings.r2Config;
             if (!config || !config.accessKeyId) {
@@ -16925,6 +17041,13 @@
             
             r2SyncInProgress = true;
             showToast(i18n('toast_restoring'));
+            let lastRestoreProgressAt = 0;
+            const restoreProgress = (key, done, total) => {
+                const now = Date.now();
+                if (done < total && now - lastRestoreProgressAt < 2500) return;
+                lastRestoreProgressAt = now;
+                showToast(i18n(key, done, total), 4000);
+            };
             
             try {
                 // 1. 下载元数据
@@ -16953,7 +17076,6 @@
                 // syncFromR2 自己的作用域内，供后面的课堂合并使用。
                 const localClassroomBeforeRestore = appData.classroom || { courses: [], seminars: [] };
                 const localLecturesBeforeRestore = appData.lectures || {};
-                const localNotebooksBeforeRestore = appData.notebooks || { items: [], reviews: [] };
                 const cloudRestoreSyncedAtMs = syncTimestamp(metadata.syncedAt);
                 appData.classroomTombstones = mergeClassroomTombstones(
                     metadata.classroomTombstones, appData.classroomTombstones);
@@ -16997,11 +17119,13 @@
                 appData.classroom = mergedClassroom;
                 appData.exercises = metadata.exercises || { folders: [], wrongByFolder: {}, archivedWrong: {} };
                 if (!appData.exercises.archivedWrong) appData.exercises.archivedWrong = {};
-                appData.notebooks = mergeNotebooksData(
-                    metadata.notebooks,
-                    localNotebooksBeforeRestore,
-                    cloudRestoreSyncedAtMs
-                );
+                // 手动「从云端恢复」是全量恢复：笔记本索引（含页面列表、复习记录与墓碑）直接采用
+                // 云端快照，不与本机合并——合并会让本机较新的条目留下、云端的页面列表被改写，
+                // 随后逐页拉取时只能取回部分页面的笔画。页面正文在第 7 步按云端副本逐页覆盖。
+                appData.notebooks = {
+                    items: Array.isArray(metadata.notebooks?.items) ? metadata.notebooks.items : [],
+                    reviews: Array.isArray(metadata.notebooks?.reviews) ? metadata.notebooks.reviews : []
+                };
                 appData.settings = { ...metadata.settings, ...localApiSettings, r2Config: localR2Config };
                 // 用户主动从云端完整恢复，数据可信，允许后续上传
                 appDataLoaded = true;
@@ -17012,10 +17136,12 @@
                 let downloadedFiles = 0;
                 const allDocs = [...appData.books, ...appData.papers];
                 
-                for (const doc of allDocs) {
+                for (let docIndex = 0; docIndex < allDocs.length; docIndex++) {
+                    const doc = allDocs[docIndex];
+                    restoreProgress('restore_progress_files', docIndex + 1, allDocs.length);
                     const fileKey = 'files/' + doc.id + '.pdf';
                     try {
-                        const fileData = await r2GetObject(fileKey);
+                        const fileData = await r2GetObjectWithTimeout(fileKey, R2_RESTORE_OBJECT_TIMEOUT_MS);
                         if (fileData) {
                             await saveFileData(doc.id, fileData);
                             downloadedFiles++;
@@ -17191,8 +17317,25 @@
                     }
                 }
 
-                // 7. 下载笔记本页面与媒体
-                const downloadedNotebooks = await r2PullNotebookAssetsFromCloud({ missingOnly: false });
+                // 7. 下载笔记本页面与媒体（全部按云端副本覆盖本地正文）
+                const downloadedNotebooks = await r2PullNotebookAssetsFromCloud({
+                    missingOnly: false,
+                    timeoutMs: R2_RESTORE_OBJECT_TIMEOUT_MS,
+                    onProgress: (done, total) => restoreProgress('restore_progress_pages', done, total)
+                });
+                // 缩略图/摘要缓存按页缓存，恢复后必须作废，否则大纲与导出面板仍显示恢复前的内容；
+                // 若笔记本编辑器正打开着，按恢复后的正文重新载入当前页。
+                Object.keys(nbThumbCache).forEach(key => { delete nbThumbCache[key]; });
+                Object.keys(nbSnippetCache).forEach(key => { delete nbSnippetCache[key]; });
+                if (document.getElementById('nbEditor')?.classList.contains('show') && nbState.notebookId) {
+                    nbState.dirty = false;
+                    if (nbGetNotebook(nbState.notebookId)) {
+                        await nbLoadPage(nbState.pageIndex, false);
+                        nbRefreshOutline();
+                    } else {
+                        await nbCloseEditor();
+                    }
+                }
 
                 renderLibrary();
                 renderNotesPage();
@@ -17203,10 +17346,12 @@
                 // immediately reflect the restored data without needing a refresh.
                 try { applySettings(); } catch (e) { console.warn('applySettings failed', e); }
                 try { initR2AutoSync(); } catch (e) { console.warn('initR2AutoSync failed', e); }
-                showToast(i18n('restore_done_detail', downloadedFiles, downloadedLectures, downloadedAbstracts) + (downloadedNotebooks.pages || downloadedNotebooks.media ? i18n('restore_notebook_detail', downloadedNotebooks.pages, downloadedNotebooks.media) : ''));
+                showToast(i18n('restore_done_detail', downloadedFiles, downloadedLectures, downloadedAbstracts) +
+                    (downloadedNotebooks.pages || downloadedNotebooks.media ? i18n('restore_notebook_detail', downloadedNotebooks.pages, downloadedNotebooks.media) : '') +
+                    (downloadedNotebooks.failed ? i18n('restore_notebook_failed_detail', downloadedNotebooks.failed) : ''), 6000);
             } catch (err) {
                 console.error('Sync from R2 failed:', err);
-                showToast(i18n('toast_restore_failed') + err.message);
+                showToast(i18n('toast_restore_failed') + err.message, 6000);
             } finally {
                 r2SyncInProgress = false;
                 if (r2PendingSyncQueue.length > 0) {
@@ -17229,50 +17374,167 @@
             for (let i = 0; i < bytes.length; i++) crc = (crc >>> 8) ^ dataZipCrc32.table[(crc ^ bytes[i]) & 0xff];
             return (crc ^ -1) >>> 0;
         }
-        async function dataZipCrc32Blob(blob) {
-            if (!dataZipCrc32.table) dataZipCrc32(new Uint8Array(0));
-            let crc = 0 ^ -1;
-            const step = 4 * 1024 * 1024;
-            for (let offset = 0; offset < blob.size; offset += step) {
-                const bytes = new Uint8Array(await blob.slice(offset, Math.min(blob.size, offset + step)).arrayBuffer());
-                for (let i = 0; i < bytes.length; i++) {
-                    crc = (crc >>> 8) ^ dataZipCrc32.table[(crc ^ bytes[i]) & 0xff];
-                }
-            }
-            return (crc ^ -1) >>> 0;
-        }
         function dataZipU16(n) { return [n & 255, (n >>> 8) & 255]; }
         function dataZipU32(n) { return [n & 255, (n >>> 8) & 255, (n >>> 16) & 255, (n >>> 24) & 255]; }
         function dataZipDosDate(d = new Date()) {
             return { time: (d.getHours() << 11) | (d.getMinutes() << 5) | Math.floor(d.getSeconds() / 2), date: ((d.getFullYear() - 1980) << 9) | ((d.getMonth() + 1) << 5) | d.getDate() };
         }
-        function dataZipEncode(value) {
-            if (value instanceof Uint8Array) return value;
-            if (value instanceof ArrayBuffer) return new Uint8Array(value);
-            return new TextEncoder().encode(String(value ?? ''));
+
+        // ---------- 流式 ZIP 写入 ----------
+        // 备份 ZIP 常达数百 MB，而书籍 PDF、课堂照片、笔记媒体在 IndexedDB 中多以 base64
+        // 字符串保存。旧实现把全部条目及其 UTF-8 编码同时驻留在 JS 堆里再合成一个 Blob，
+        // Boox 等低内存 WebView 会在此处被系统杀掉渲染进程（表现为「阅读器进程已恢复，
+        // 已返回书架」而得不到 ZIP）。现在逐条目处理：第一遍只累计 CRC/长度，第二遍按
+        // 2 MB 分片写入 sink，任何时刻堆内仅保留一个分片；条目仍为 stored（不压缩）且不带
+        // 数据描述符，与 dataZipRead 的读取方式完全一致。
+        const DATA_ZIP_CHUNK = 2 * 1024 * 1024;
+
+        // 字符串按不拆分代理对的边界切片编码为 UTF-8，避免整段编码再翻倍占用内存
+        function* dataZipStringChunks(str, chunkChars = DATA_ZIP_CHUNK) {
+            const encoder = new TextEncoder();
+            for (let start = 0; start < str.length;) {
+                let end = Math.min(str.length, start + chunkChars);
+                const code = str.charCodeAt(end - 1);
+                if (end < str.length && code >= 0xd800 && code <= 0xdbff) end++;
+                yield encoder.encode(str.slice(start, end));
+                start = end;
+            }
         }
-        async function dataZipCreate(files) {
-            const chunks = [], central = [];
+        // 逐分片遍历条目数据：Blob | ArrayBuffer | TypedArray | string
+        async function* dataZipDataChunks(data) {
+            if (data instanceof Blob) {
+                for (let offset = 0; offset < data.size; offset += DATA_ZIP_CHUNK) {
+                    yield new Uint8Array(await data.slice(offset, Math.min(data.size, offset + DATA_ZIP_CHUNK)).arrayBuffer());
+                }
+            } else if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
+                const bytes = data instanceof ArrayBuffer
+                    ? new Uint8Array(data)
+                    : new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+                for (let offset = 0; offset < bytes.length; offset += DATA_ZIP_CHUNK) {
+                    yield bytes.subarray(offset, Math.min(bytes.length, offset + DATA_ZIP_CHUNK));
+                }
+            } else {
+                yield* dataZipStringChunks(String(data ?? ''));
+            }
+        }
+        function dataZipCrc32Update(crc, bytes) {
+            if (!dataZipCrc32.table) dataZipCrc32(new Uint8Array(0));
+            const table = dataZipCrc32.table;
+            for (let i = 0; i < bytes.length; i++) crc = (crc >>> 8) ^ table[(crc ^ bytes[i]) & 0xff];
+            return crc;
+        }
+        // 第一遍：只统计 CRC 与字节数，不保留数据
+        async function dataZipMeasure(data) {
+            let crc = 0 ^ -1, size = 0;
+            for await (const bytes of dataZipDataChunks(data)) {
+                crc = dataZipCrc32Update(crc, bytes);
+                size += bytes.length;
+            }
+            return { crc: (crc ^ -1) >>> 0, size };
+        }
+        // entries：同步或异步可迭代的 { name, data }；sink：{ write(bytes), writeBlob?(blob), finish(), abort() }
+        async function dataZipStream(entries, sink, onEntry) {
+            const central = [];
             let offset = 0;
+            let count = 0;
             const dt = dataZipDosDate();
-            for (const f of files) {
+            for await (const f of entries) {
                 const name = new TextEncoder().encode(f.name);
-                const data = f.data instanceof Blob ? f.data : dataZipEncode(f.data);
-                const size = data instanceof Blob ? data.size : data.length;
-                if (size > 0xffffffff) throw new Error(i18n('backup_file_too_large'));
-                const crc = data instanceof Blob ? await dataZipCrc32Blob(data) : dataZipCrc32(data);
+                const { crc, size } = await dataZipMeasure(f.data);
+                if (size > 0xffffffff || offset + size > 0xffffffff) throw new Error(i18n('backup_file_too_large'));
                 const local = new Uint8Array([0x50,0x4b,3,4, ...dataZipU16(20), ...dataZipU16(0x0800), ...dataZipU16(0), ...dataZipU16(dt.time), ...dataZipU16(dt.date), ...dataZipU32(crc), ...dataZipU32(size), ...dataZipU32(size), ...dataZipU16(name.length), 0,0, ...name]);
-                chunks.push(local, data);
+                await sink.write(local);
+                if (f.data instanceof Blob && typeof sink.writeBlob === 'function') {
+                    await sink.writeBlob(f.data);
+                } else {
+                    for await (const bytes of dataZipDataChunks(f.data)) await sink.write(bytes);
+                }
                 central.push({ name, crc, size, offset });
                 offset += local.length + size;
+                count++;
+                if (onEntry) onEntry(count, f.name);
             }
             const centralStart = offset;
             for (const c of central) {
-                const hdr = new Uint8Array([0x50,0x4b,1,2, ...dataZipU16(20), ...dataZipU16(20), ...dataZipU16(0x0800), ...dataZipU16(0), ...dataZipU16(dt.time), ...dataZipU16(dt.date), ...dataZipU32(c.crc), ...dataZipU32(c.size), ...dataZipU32(c.size), ...dataZipU16(c.name.length), 0,0, 0,0, 0,0, 0,0,0,0, ...dataZipU32(c.offset), ...c.name]);
-                chunks.push(hdr); offset += hdr.length;
+                // 中央目录头固定部分为 46 字节：文件名长度之后依次是扩展区长度(2)、注释长度(2)、
+                // 起始磁盘号(2)、内部属性(2)、外部属性(4)、本地文件头偏移(4)。旧实现少写了 2 字节，
+                // 应用自身导入只读本地文件头所以不受影响，但外部解压工具会判定归档损坏。
+                const hdr = new Uint8Array([0x50,0x4b,1,2, ...dataZipU16(20), ...dataZipU16(20), ...dataZipU16(0x0800), ...dataZipU16(0), ...dataZipU16(dt.time), ...dataZipU16(dt.date), ...dataZipU32(c.crc), ...dataZipU32(c.size), ...dataZipU32(c.size), ...dataZipU16(c.name.length), 0,0, 0,0, 0,0, 0,0, 0,0,0,0, ...dataZipU32(c.offset), ...c.name]);
+                await sink.write(hdr); offset += hdr.length;
             }
-            chunks.push(new Uint8Array([0x50,0x4b,5,6, 0,0, 0,0, ...dataZipU16(central.length), ...dataZipU16(central.length), ...dataZipU32(offset - centralStart), ...dataZipU32(centralStart), 0,0]));
-            return new Blob(chunks, { type: 'application/zip' });
+            await sink.write(new Uint8Array([0x50,0x4b,5,6, 0,0, 0,0, ...dataZipU16(central.length), ...dataZipU16(central.length), ...dataZipU32(offset - centralStart), ...dataZipU32(centralStart), 0,0]));
+            return { count, bytes: offset };
+        }
+        // Blob sink：每积累 4 MB 就把已写字节封成 Blob 交给浏览器的 blob 存储（可落盘），
+        // JS 堆里不再同时保留整个 ZIP；来自 IndexedDB 的 Blob 直接引用，不复制。
+        function dataZipBlobSink() {
+            const parts = [];
+            let pending = [], pendingBytes = 0;
+            const flush = () => {
+                if (!pending.length) return;
+                parts.push(new Blob(pending));
+                pending = []; pendingBytes = 0;
+            };
+            return {
+                write(bytes) {
+                    pending.push(bytes);
+                    pendingBytes += bytes.length;
+                    if (pendingBytes >= 2 * DATA_ZIP_CHUNK) flush();
+                },
+                writeBlob(blob) { flush(); parts.push(blob); },
+                finish() { flush(); return new Blob(parts, { type: 'application/zip' }); },
+                abort() { pending = []; pendingBytes = 0; parts.length = 0; }
+            };
+        }
+        function dataZipBytesToBase64(bytes) {
+            let binary = '';
+            const step = 0x8000;
+            for (let i = 0; i < bytes.length; i += step) {
+                binary += String.fromCharCode.apply(null, bytes.subarray(i, Math.min(bytes.length, i + step)));
+            }
+            return btoa(binary);
+        }
+        // Boox 原生 sink：经 DownloadBridge 分片流式写入系统下载目录（与导出 PDF 相同位置），
+        // 全程不构造整块 Blob，也不再经过 blob URL → fetch → 整体 base64 的旧路径。
+        function dataZipNativeSink(fileName) {
+            const dl = window.BooxDownloadNative;
+            const token = dl.beginSave(fileName, 'application/zip');
+            if (!token) throw new Error(i18n('export_native_open_failed'));
+            let pending = [], pendingBytes = 0;
+            const flush = () => {
+                if (!pendingBytes) return;
+                let buf = pending[0];
+                if (pending.length > 1) {
+                    buf = new Uint8Array(pendingBytes);
+                    let at = 0;
+                    for (const part of pending) { buf.set(part, at); at += part.length; }
+                }
+                pending = []; pendingBytes = 0;
+                if (!dl.appendBase64(token, dataZipBytesToBase64(buf))) {
+                    throw new Error(i18n('export_native_write_failed'));
+                }
+            };
+            return {
+                write(bytes) {
+                    pending.push(bytes);
+                    pendingBytes += bytes.length;
+                    if (pendingBytes >= DATA_ZIP_CHUNK) flush();
+                },
+                finish() {
+                    flush();
+                    if (!dl.finishSave(token)) throw new Error(i18n('export_native_write_failed'));
+                    return null;
+                },
+                abort(reason) {
+                    pending = []; pendingBytes = 0;
+                    try { dl.abortSave(token, String(reason || '')); } catch (e) { /* 忽略 */ }
+                }
+            };
+        }
+        async function dataZipCreate(files) {
+            const sink = dataZipBlobSink();
+            await dataZipStream(files, sink);
+            return sink.finish();
         }
         function dataZipReadU16(v, p) { return v.getUint16(p, true); }
         function dataZipReadU32(v, p) { return v.getUint32(p, true); }
@@ -17604,7 +17866,6 @@
                         }))
                     };
                 }
-                const files = [{ name: 'metadata.json', data: JSON.stringify(metadata, null, 2) }];
                 const verifiedIdbData = new Map();
                 for (const prepared of exportedRecordings) {
                     for (const entry of (prepared.idbEntries || [])) {
@@ -17621,80 +17882,108 @@
                     .filter(key => verifiedIdbData.has(key) || typeof key !== 'string' ||
                         (!key.startsWith(recordingManifestPrefix) &&
                          !key.startsWith(recordingChunkPrefix)));
-                const idbIndex = [];
-                let fileIndex = 0;
-                for (const key of keys) {
-                    const data = verifiedIdbData.has(key)
-                        ? verifiedIdbData.get(key)
-                        : await getFileData(key).catch(() => null);
-                    if (data === null || data === undefined) continue;
-                    const base = 'idb/data/' + String(fileIndex++).padStart(8, '0');
-                    if (data instanceof Blob) {
-                        const path = base + '.bin';
-                        files.push({ name: path, data });
-                        idbIndex.push({ id: key, path, kind: 'blob', mime: data.type || 'application/octet-stream', size: data.size });
-                    } else if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
-                        const path = base + '.bin';
-                        const blob = new Blob([data], { type: 'application/octet-stream' });
-                        files.push({ name: path, data: blob });
-                        idbIndex.push({ id: key, path, kind: 'blob', mime: blob.type, size: blob.size });
-                    } else if (typeof data === 'string') {
-                        const path = base + '.txt';
-                        files.push({ name: path, data });
-                        idbIndex.push({ id: key, path, kind: 'string' });
-                    } else {
-                        const path = base + '.json';
-                        files.push({ name: path, data: JSON.stringify(data) });
-                        idbIndex.push({ id: key, path, kind: 'json' });
-                    }
-                }
-                files.push({ name: 'idb/index.json', data: JSON.stringify(idbIndex) });
 
-                // Native, legacy, and known-incomplete IDB sources use bounded,
-                // hashed portable entries. Only fully verified IDB journals stay in
-                // the generic IDB index.
-                const portableRecordings = [];
-                let portableIndex = 0;
-                for (const prepared of exportedRecordings) {
-                    if (!prepared.chunks) continue;
-                    const item = {
-                        id: prepared.material.id,
-                        mimeType: prepared.mimeType,
-                        duration: prepared.material.duration || 0,
-                        startedAt: prepared.material.uploadedAt,
-                        byteLength: prepared.byteLength,
-                        incomplete: prepared.incomplete,
-                        material: prepared.context,
-                        chunks: []
-                    };
-                    for (const chunk of prepared.chunks) {
-                        const path = 'recordings/data/' + String(portableIndex++).padStart(8, '0') + '.bin';
-                        files.push({ name: path, data: chunk.data });
-                        item.chunks.push({ path, size: chunk.size, sha256: chunk.sha256 });
+                // 条目按需生成并立即写入 ZIP（见 dataZipStream）：每个 IndexedDB 记录只在
+                // 本轮迭代中驻留内存，索引文件在其数据条目之后写出（dataZipRead 按名字取用，
+                // 不依赖顺序）。
+                async function* backupEntries() {
+                    yield { name: 'metadata.json', data: JSON.stringify(metadata, null, 2) };
+                    const idbIndex = [];
+                    let fileIndex = 0;
+                    for (const key of keys) {
+                        const data = verifiedIdbData.has(key)
+                            ? verifiedIdbData.get(key)
+                            : await getFileData(key).catch(() => null);
+                        if (data === null || data === undefined) continue;
+                        const base = 'idb/data/' + String(fileIndex++).padStart(8, '0');
+                        if (data instanceof Blob) {
+                            const path = base + '.bin';
+                            idbIndex.push({ id: key, path, kind: 'blob', mime: data.type || 'application/octet-stream', size: data.size });
+                            yield { name: path, data };
+                        } else if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
+                            const path = base + '.bin';
+                            idbIndex.push({ id: key, path, kind: 'blob', mime: 'application/octet-stream', size: data.byteLength });
+                            yield { name: path, data };
+                        } else if (typeof data === 'string') {
+                            const path = base + '.txt';
+                            idbIndex.push({ id: key, path, kind: 'string' });
+                            yield { name: path, data };
+                        } else {
+                            const path = base + '.json';
+                            idbIndex.push({ id: key, path, kind: 'json' });
+                            yield { name: path, data: JSON.stringify(data) };
+                        }
                     }
-                    portableRecordings.push(item);
+                    yield { name: 'idb/index.json', data: JSON.stringify(idbIndex) };
+
+                    // Native, legacy, and known-incomplete IDB sources use bounded,
+                    // hashed portable entries. Only fully verified IDB journals stay in
+                    // the generic IDB index.
+                    const portableRecordings = [];
+                    let portableIndex = 0;
+                    for (const prepared of exportedRecordings) {
+                        if (!prepared.chunks) continue;
+                        const item = {
+                            id: prepared.material.id,
+                            mimeType: prepared.mimeType,
+                            duration: prepared.material.duration || 0,
+                            startedAt: prepared.material.uploadedAt,
+                            byteLength: prepared.byteLength,
+                            incomplete: prepared.incomplete,
+                            material: prepared.context,
+                            chunks: []
+                        };
+                        for (const chunk of prepared.chunks) {
+                            const path = 'recordings/data/' + String(portableIndex++).padStart(8, '0') + '.bin';
+                            item.chunks.push({ path, size: chunk.size, sha256: chunk.sha256 });
+                            yield { name: path, data: chunk.data };
+                        }
+                        portableRecordings.push(item);
+                    }
+                    if (portableRecordings.length) {
+                        yield { name: 'recordings/index.json', data: JSON.stringify(portableRecordings) };
+                    }
+                    if (exportedMissingRecordings.length) {
+                        yield {
+                            name: 'recordings/missing.json',
+                            data: JSON.stringify({
+                                format: 'math-reader-missing-recordings-v1',
+                                exportedAt: metadata.exportedAt,
+                                items: exportedMissingRecordings
+                            }, null, 2)
+                        };
+                    }
                 }
-                if (portableRecordings.length) {
-                    files.push({ name: 'recordings/index.json', data: JSON.stringify(portableRecordings) });
-                }
-                if (exportedMissingRecordings.length) {
-                    files.push({
-                        name: 'recordings/missing.json',
-                        data: JSON.stringify({
-                            format: 'math-reader-missing-recordings-v1',
-                            exportedAt: metadata.exportedAt,
-                            items: exportedMissingRecordings
-                        }, null, 2)
+
+                // Boox APK：直接经原生桥流式写入系统下载目录（与导出 PDF 相同位置）；
+                // 其它平台：分块交给 blob 存储后按 a[download] 下载。
+                const zipName = 'math-reader-full-export-' + new Date().toISOString().slice(0,10) + '.zip';
+                const useNativeSink = typeof window.BooxDownloadNative?.beginSave === 'function';
+                const sink = useNativeSink ? dataZipNativeSink(zipName) : dataZipBlobSink();
+                let lastProgressAt = Date.now();
+                let written;
+                let zipBlob = null;
+                try {
+                    written = await dataZipStream(backupEntries(), sink, (count) => {
+                        const now = Date.now();
+                        if (now - lastProgressAt < 2500) return;
+                        lastProgressAt = now;
+                        showToast(i18n('export_progress', count));
                     });
+                    zipBlob = sink.finish();
+                } catch (err) {
+                    try { sink.abort(err?.message || String(err)); } catch (e) { /* 忽略 */ }
+                    throw err;
                 }
-                const blob = await dataZipCreate(files);
-                const url = URL.createObjectURL(blob);
-                const a = document.createElement('a');
-                a.href = url;
-                a.download = 'math-reader-full-export-' + new Date().toISOString().slice(0,10) + '.zip';
-                a.click();
-                setTimeout(() => URL.revokeObjectURL(url), 30000);
-                showToast(i18n('toast_export_success') + i18n('export_local_files_detail', files.length - 1) +
+                if (zipBlob) {
+                    const url = URL.createObjectURL(zipBlob);
+                    const a = document.createElement('a');
+                    a.href = url;
+                    a.download = zipName;
+                    a.click();
+                    setTimeout(() => URL.revokeObjectURL(url), 30000);
+                }
+                showToast(i18n('toast_export_success') + i18n('export_local_files_detail', written.count - 1) +
                     (exportedMissingRecordings.length
                         ? i18n('export_missing_recordings_detail', exportedMissingRecordings.length)
                         : ''));

--- a/docs/index.html
+++ b/docs/index.html
@@ -6984,8 +6984,8 @@
             local_class_material_missing:'本地课堂素材缺失：{0}', class_material_index_changed:'课堂素材索引已变化：{0}', class_note_content_missing:'课堂讲义内容缺失：{0}', class_note_index_changed:'课堂讲义索引已变化：{0}', delete_cloud_class_material_failed:'删除云端课堂素材失败：{0}', delete_cloud_class_note_failed:'删除云端课堂讲义失败：{0}',
             notification_lecture_sync_title:'讲义同步完成', notification_lecture_sync_body:'讲义已同步到云端', notification_abstract_sync_title:'摘要同步完成', notification_abstract_sync_body:'摘要已同步到云端', network_endpoint_cors_error:'网络、Endpoint 或 CORS 配置错误', permission_key_error:'权限或密钥错误', bucket_not_found:'未找到存储桶',
             local_recording_chunk_corrupt:'本地录音分块 {0} 损坏', recording_source_size_failed:'无法确认录音源文件大小', cloud_recording_manifest_invalid:'云端录音清单无效', cloud_recording_chunk_invalid:'云端录音分块 {0} 无效', cloud_recording_chunk_hash_failed:'云端录音分块 {0} 校验失败', delete_cloud_recording_manifest_failed:'删除云端录音清单失败：{0}', delete_cloud_recording_chunk_failed:'删除云端录音分块失败：{0}', delete_legacy_cloud_recording_failed:'删除旧版云端录音失败：{0}',
-            confirm_empty_local_overwrite_cloud:'本地数据为空。确定要覆盖非空的云端数据吗？', upload_cancelled:'上传已取消', recording_not_fully_saved:'录音尚未完整保存：{0}', sync_skipped_class_items:'；{0} 个课堂素材在本机缺失已跳过，云端已有内容保持不变', cloud_index_repaired:'云端索引已修复', count_lectures:'{0} 篇讲义', count_abstracts:'{0} 篇摘要', count_class_materials:'{0} 个课堂素材', count_exercise_files:'{0} 个习题文件', count_note_pages:'{0} 页笔记', count_note_media:'{0} 个笔记媒体', confirm_empty_cloud_overwrite_local:'云端数据为空。确定要覆盖本地数据吗？', restore_cancelled:'恢复已取消', restore_notebook_detail:'，另恢复 {0} 页笔记和 {1} 个媒体文件',
-            backup_file_too_large:'备份文件过大', compressed_zip_unsupported:'不支持压缩格式的 ZIP 条目', zip_descriptor_unsupported:'不支持带数据描述符的 ZIP 条目', recording_backup_source_size_invalid:'录音备份源大小无效：{0}', recording_backup_manifest_invalid:'录音备份清单无效：{0}', recording_backup_chunk_missing:'录音 {0} 的第 {1} 个备份分块缺失', recording_backup_length_failed:'录音备份长度校验失败：{0}', unknown_recording_backup_source:'未知的录音备份源：{0}', legacy_recording_missing:'旧版录音缺失：{0}', recording_backup_chunk_length_failed:'录音备份分块长度校验失败：{0}', recording_backup_chunk_missing_simple:'录音备份分块缺失：{0}', recording_has_no_backup_data:'录音没有可备份的数据：{0}', stop_recording_before_backup:'请先停止录音再备份', packing_zip_backup:'正在打包 ZIP 备份…', recording_added_during_export:'导出期间新增的录音',
+            confirm_empty_local_overwrite_cloud:'本地数据为空。确定要覆盖非空的云端数据吗？', upload_cancelled:'上传已取消', recording_not_fully_saved:'录音尚未完整保存：{0}', sync_skipped_class_items:'；{0} 个课堂素材在本机缺失已跳过，云端已有内容保持不变', sync_progress_materials:'正在上传课堂素材 {0}/{1}…', sync_progress_lectures:'正在上传讲义与笔记页…', sync_progress_pages:'正在上传笔记页 {0}/{1}…', sync_progress_metadata:'正在发布云端索引…', sync_progress_files:'正在上传文件 {0}/{1}…', upload_timeout:'上传超时：{0}', restore_progress_files:'正在恢复文件 {0}/{1}…', restore_progress_pages:'正在恢复笔记页 {0}/{1}…', restore_notebook_failed_detail:'，{0} 页笔记未能从云端取回', cloud_index_repaired:'云端索引已修复', count_lectures:'{0} 篇讲义', count_abstracts:'{0} 篇摘要', count_class_materials:'{0} 个课堂素材', count_exercise_files:'{0} 个习题文件', count_note_pages:'{0} 页笔记', count_note_media:'{0} 个笔记媒体', confirm_empty_cloud_overwrite_local:'云端数据为空。确定要覆盖本地数据吗？', restore_cancelled:'恢复已取消', restore_notebook_detail:'，另恢复 {0} 页笔记和 {1} 个媒体文件',
+            backup_file_too_large:'备份文件过大', compressed_zip_unsupported:'不支持压缩格式的 ZIP 条目', zip_descriptor_unsupported:'不支持带数据描述符的 ZIP 条目', recording_backup_source_size_invalid:'录音备份源大小无效：{0}', recording_backup_manifest_invalid:'录音备份清单无效：{0}', recording_backup_chunk_missing:'录音 {0} 的第 {1} 个备份分块缺失', recording_backup_length_failed:'录音备份长度校验失败：{0}', unknown_recording_backup_source:'未知的录音备份源：{0}', legacy_recording_missing:'旧版录音缺失：{0}', recording_backup_chunk_length_failed:'录音备份分块长度校验失败：{0}', recording_backup_chunk_missing_simple:'录音备份分块缺失：{0}', recording_has_no_backup_data:'录音没有可备份的数据：{0}', stop_recording_before_backup:'请先停止录音再备份', packing_zip_backup:'正在打包 ZIP 备份…', export_progress:'正在打包 ZIP 备份…已写入 {0} 个文件', export_native_open_failed:'无法在下载目录创建 ZIP 文件', export_native_write_failed:'写入 ZIP 文件失败', recording_added_during_export:'导出期间新增的录音',
             export_local_files_detail:'（含 {0} 个本地文件）', export_missing_recordings_detail:'（另含 {0} 个补充录音）', export_failed:'导出失败：', confirm_import_zip_overwrite:'导入 ZIP 备份将覆盖当前数据，是否继续？', parsing_zip_backup:'正在解析 ZIP 备份…', backup_missing_metadata:'备份中缺少 metadata.json', missing_recordings_manifest_invalid:'补充录音清单无效', missing_recordings_manifest_invalid_id:'补充录音清单包含无效 ID', recording_backup_index_invalid:'录音备份索引无效', recording_backup_chunk_invalid:'录音 {0} 的第 {1} 个备份分块无效', import_complete_files:'导入完成，共恢复 {0} 个文件', import_failed:'导入失败：',
             indexeddb_unavailable:'IndexedDB 不可用', transaction_aborted:'事务被中止：{0}', unknown_reason:'未知原因', recording_transaction_failed:'录音事务失败', recording_transaction_aborted:'录音事务被中止', class_file_transaction_failed:'课堂文件事务失败', class_file_transaction_aborted:'课堂文件事务被中止', recording_storage_module_not_loaded:'录音存储模块未加载', class_lecture_content_empty:'课堂讲义内容为空', data_structure_corrupt:'数据结构损坏：books/papers 不是数组'
         });
@@ -7003,8 +7003,8 @@
             local_class_material_missing:'Local class material is missing: {0}', class_material_index_changed:'The class material index changed: {0}', class_note_content_missing:'Class lecture content is missing: {0}', class_note_index_changed:'The class lecture index changed: {0}', delete_cloud_class_material_failed:'Failed to delete cloud class material: {0}', delete_cloud_class_note_failed:'Failed to delete cloud class lecture: {0}',
             notification_lecture_sync_title:'Lecture sync complete', notification_lecture_sync_body:'The lecture was synced to the cloud', notification_abstract_sync_title:'Abstract sync complete', notification_abstract_sync_body:'The abstract was synced to the cloud', network_endpoint_cors_error:'Network, endpoint, or CORS configuration error', permission_key_error:'Permission or credential error', bucket_not_found:'Bucket not found',
             local_recording_chunk_corrupt:'Local recording chunk {0} is corrupted', recording_source_size_failed:'Could not verify the recording source size', cloud_recording_manifest_invalid:'The cloud recording manifest is invalid', cloud_recording_chunk_invalid:'Cloud recording chunk {0} is invalid', cloud_recording_chunk_hash_failed:'Cloud recording chunk {0} failed verification', delete_cloud_recording_manifest_failed:'Failed to delete cloud recording manifest: {0}', delete_cloud_recording_chunk_failed:'Failed to delete cloud recording chunk: {0}', delete_legacy_cloud_recording_failed:'Failed to delete legacy cloud recording: {0}',
-            confirm_empty_local_overwrite_cloud:'Local data is empty. Overwrite non-empty cloud data?', upload_cancelled:'Upload cancelled', recording_not_fully_saved:'Recording is not fully saved: {0}', sync_skipped_class_items:'; {0} class materials missing locally were skipped; existing cloud copies were kept', cloud_index_repaired:'Cloud index repaired', count_lectures:'{0} lectures', count_abstracts:'{0} abstracts', count_class_materials:'{0} class materials', count_exercise_files:'{0} exercise files', count_note_pages:'{0} note pages', count_note_media:'{0} note media files', confirm_empty_cloud_overwrite_local:'Cloud data is empty. Overwrite local data?', restore_cancelled:'Restore cancelled', restore_notebook_detail:', plus {0} note pages and {1} media files',
-            backup_file_too_large:'Backup file is too large', compressed_zip_unsupported:'Compressed ZIP entries are not supported', zip_descriptor_unsupported:'ZIP data descriptors are not supported', recording_backup_source_size_invalid:'Invalid recording backup source size: {0}', recording_backup_manifest_invalid:'Invalid recording backup manifest: {0}', recording_backup_chunk_missing:'Backup chunk {1} is missing for recording {0}', recording_backup_length_failed:'Recording backup length verification failed: {0}', unknown_recording_backup_source:'Unknown recording backup source: {0}', legacy_recording_missing:'Legacy recording is missing: {0}', recording_backup_chunk_length_failed:'Recording backup chunk length verification failed: {0}', recording_backup_chunk_missing_simple:'Recording backup chunk is missing: {0}', recording_has_no_backup_data:'Recording has no data to back up: {0}', stop_recording_before_backup:'Stop recording before creating a backup', packing_zip_backup:'Packing ZIP backup…', recording_added_during_export:'Recording added during export',
+            confirm_empty_local_overwrite_cloud:'Local data is empty. Overwrite non-empty cloud data?', upload_cancelled:'Upload cancelled', recording_not_fully_saved:'Recording is not fully saved: {0}', sync_skipped_class_items:'; {0} class materials missing locally were skipped; existing cloud copies were kept', sync_progress_materials:'Uploading class materials {0}/{1}…', sync_progress_lectures:'Uploading lectures and note pages…', sync_progress_pages:'Uploading note pages {0}/{1}…', sync_progress_metadata:'Publishing cloud index…', sync_progress_files:'Uploading files {0}/{1}…', upload_timeout:'Upload timed out: {0}', restore_progress_files:'Restoring files {0}/{1}…', restore_progress_pages:'Restoring note pages {0}/{1}…', restore_notebook_failed_detail:', {0} note pages could not be fetched from the cloud', cloud_index_repaired:'Cloud index repaired', count_lectures:'{0} lectures', count_abstracts:'{0} abstracts', count_class_materials:'{0} class materials', count_exercise_files:'{0} exercise files', count_note_pages:'{0} note pages', count_note_media:'{0} note media files', confirm_empty_cloud_overwrite_local:'Cloud data is empty. Overwrite local data?', restore_cancelled:'Restore cancelled', restore_notebook_detail:', plus {0} note pages and {1} media files',
+            backup_file_too_large:'Backup file is too large', compressed_zip_unsupported:'Compressed ZIP entries are not supported', zip_descriptor_unsupported:'ZIP data descriptors are not supported', recording_backup_source_size_invalid:'Invalid recording backup source size: {0}', recording_backup_manifest_invalid:'Invalid recording backup manifest: {0}', recording_backup_chunk_missing:'Backup chunk {1} is missing for recording {0}', recording_backup_length_failed:'Recording backup length verification failed: {0}', unknown_recording_backup_source:'Unknown recording backup source: {0}', legacy_recording_missing:'Legacy recording is missing: {0}', recording_backup_chunk_length_failed:'Recording backup chunk length verification failed: {0}', recording_backup_chunk_missing_simple:'Recording backup chunk is missing: {0}', recording_has_no_backup_data:'Recording has no data to back up: {0}', stop_recording_before_backup:'Stop recording before creating a backup', packing_zip_backup:'Packing ZIP backup…', export_progress:'Packing ZIP backup… {0} files written', export_native_open_failed:'Could not create the ZIP file in Downloads', export_native_write_failed:'Failed to write the ZIP file', recording_added_during_export:'Recording added during export',
             export_local_files_detail:' ({0} local files included)', export_missing_recordings_detail:' ({0} supplemental recordings included)', export_failed:'Export failed: ', confirm_import_zip_overwrite:'Importing this ZIP backup will overwrite current data. Continue?', parsing_zip_backup:'Parsing ZIP backup…', backup_missing_metadata:'metadata.json is missing from the backup', missing_recordings_manifest_invalid:'Supplemental recording manifest is invalid', missing_recordings_manifest_invalid_id:'Supplemental recording manifest contains an invalid ID', recording_backup_index_invalid:'Recording backup index is invalid', recording_backup_chunk_invalid:'Backup chunk {1} is invalid for recording {0}', import_complete_files:'Import complete: {0} files restored', import_failed:'Import failed: ',
             indexeddb_unavailable:'IndexedDB is unavailable', transaction_aborted:'Transaction aborted: {0}', unknown_reason:'Unknown reason', recording_transaction_failed:'Recording transaction failed', recording_transaction_aborted:'Recording transaction was aborted', class_file_transaction_failed:'Class file transaction failed', class_file_transaction_aborted:'Class file transaction was aborted', recording_storage_module_not_loaded:'Recording storage module is not loaded', class_lecture_content_empty:'Class lecture content is empty', data_structure_corrupt:'Corrupted data structure: books/papers must be arrays'
         });
@@ -7022,8 +7022,8 @@
             local_class_material_missing:'Support de cours local manquant : {0}', class_material_index_changed:"L’index des supports de cours a changé : {0}", class_note_content_missing:'Contenu du cours manquant : {0}', class_note_index_changed:"L’index des cours a changé : {0}", delete_cloud_class_material_failed:'Échec de suppression du support cloud : {0}', delete_cloud_class_note_failed:'Échec de suppression du cours cloud : {0}',
             notification_lecture_sync_title:'Synchronisation du cours terminée', notification_lecture_sync_body:'Le cours a été synchronisé dans le cloud', notification_abstract_sync_title:'Synchronisation du résumé terminée', notification_abstract_sync_body:'Le résumé a été synchronisé dans le cloud', network_endpoint_cors_error:'Erreur de réseau, d’endpoint ou de configuration CORS', permission_key_error:'Erreur d’autorisation ou d’identifiants', bucket_not_found:'Bucket introuvable',
             local_recording_chunk_corrupt:"Le segment local d’enregistrement {0} est corrompu", recording_source_size_failed:"Impossible de vérifier la taille de l’enregistrement source", cloud_recording_manifest_invalid:"Le manifeste cloud de l’enregistrement est invalide", cloud_recording_chunk_invalid:'Le segment cloud {0} est invalide', cloud_recording_chunk_hash_failed:'Échec de vérification du segment cloud {0}', delete_cloud_recording_manifest_failed:'Échec de suppression du manifeste cloud : {0}', delete_cloud_recording_chunk_failed:'Échec de suppression du segment cloud : {0}', delete_legacy_cloud_recording_failed:"Échec de suppression de l’ancien enregistrement cloud : {0}",
-            confirm_empty_local_overwrite_cloud:'Les données locales sont vides. Remplacer les données cloud non vides ?', upload_cancelled:'Envoi annulé', recording_not_fully_saved:"L’enregistrement n’est pas entièrement sauvegardé : {0}", sync_skipped_class_items:' ; {0} supports de cours absents localement ont été ignorés ; les copies cloud existantes ont été conservées', cloud_index_repaired:'Index cloud réparé', count_lectures:'{0} cours', count_abstracts:'{0} résumés', count_class_materials:'{0} supports de cours', count_exercise_files:'{0} fichiers d’exercices', count_note_pages:'{0} pages de notes', count_note_media:'{0} médias de notes', confirm_empty_cloud_overwrite_local:'Les données cloud sont vides. Remplacer les données locales ?', restore_cancelled:'Restauration annulée', restore_notebook_detail:', plus {0} pages de notes et {1} médias',
-            backup_file_too_large:'Le fichier de sauvegarde est trop volumineux', compressed_zip_unsupported:'Les entrées ZIP compressées ne sont pas prises en charge', zip_descriptor_unsupported:'Les descripteurs de données ZIP ne sont pas pris en charge', recording_backup_source_size_invalid:'Taille de source de sauvegarde invalide : {0}', recording_backup_manifest_invalid:'Manifeste de sauvegarde invalide : {0}', recording_backup_chunk_missing:"Le segment {1} de l’enregistrement {0} manque dans la sauvegarde", recording_backup_length_failed:'Échec de vérification de la longueur de la sauvegarde : {0}', unknown_recording_backup_source:'Source de sauvegarde inconnue : {0}', legacy_recording_missing:'Ancien enregistrement manquant : {0}', recording_backup_chunk_length_failed:'Échec de vérification de la longueur du segment : {0}', recording_backup_chunk_missing_simple:'Segment de sauvegarde manquant : {0}', recording_has_no_backup_data:"L’enregistrement ne contient aucune donnée à sauvegarder : {0}", stop_recording_before_backup:"Arrêtez l’enregistrement avant de créer une sauvegarde", packing_zip_backup:'Création de la sauvegarde ZIP…', recording_added_during_export:'Enregistrement ajouté pendant l’exportation',
+            confirm_empty_local_overwrite_cloud:'Les données locales sont vides. Remplacer les données cloud non vides ?', upload_cancelled:'Envoi annulé', recording_not_fully_saved:"L’enregistrement n’est pas entièrement sauvegardé : {0}", sync_skipped_class_items:' ; {0} supports de cours absents localement ont été ignorés ; les copies cloud existantes ont été conservées', sync_progress_materials:'Envoi des supports de cours {0}/{1}…', sync_progress_lectures:'Envoi des cours et des pages de notes…', sync_progress_pages:'Envoi des pages de notes {0}/{1}…', sync_progress_metadata:'Publication de l’index cloud…', sync_progress_files:'Envoi des fichiers {0}/{1}…', upload_timeout:'Délai d’envoi dépassé : {0}', restore_progress_files:'Restauration des fichiers {0}/{1}…', restore_progress_pages:'Restauration des pages de notes {0}/{1}…', restore_notebook_failed_detail:', {0} pages de notes n’ont pas pu être récupérées du cloud', cloud_index_repaired:'Index cloud réparé', count_lectures:'{0} cours', count_abstracts:'{0} résumés', count_class_materials:'{0} supports de cours', count_exercise_files:'{0} fichiers d’exercices', count_note_pages:'{0} pages de notes', count_note_media:'{0} médias de notes', confirm_empty_cloud_overwrite_local:'Les données cloud sont vides. Remplacer les données locales ?', restore_cancelled:'Restauration annulée', restore_notebook_detail:', plus {0} pages de notes et {1} médias',
+            backup_file_too_large:'Le fichier de sauvegarde est trop volumineux', compressed_zip_unsupported:'Les entrées ZIP compressées ne sont pas prises en charge', zip_descriptor_unsupported:'Les descripteurs de données ZIP ne sont pas pris en charge', recording_backup_source_size_invalid:'Taille de source de sauvegarde invalide : {0}', recording_backup_manifest_invalid:'Manifeste de sauvegarde invalide : {0}', recording_backup_chunk_missing:"Le segment {1} de l’enregistrement {0} manque dans la sauvegarde", recording_backup_length_failed:'Échec de vérification de la longueur de la sauvegarde : {0}', unknown_recording_backup_source:'Source de sauvegarde inconnue : {0}', legacy_recording_missing:'Ancien enregistrement manquant : {0}', recording_backup_chunk_length_failed:'Échec de vérification de la longueur du segment : {0}', recording_backup_chunk_missing_simple:'Segment de sauvegarde manquant : {0}', recording_has_no_backup_data:"L’enregistrement ne contient aucune donnée à sauvegarder : {0}", stop_recording_before_backup:"Arrêtez l’enregistrement avant de créer une sauvegarde", packing_zip_backup:'Création de la sauvegarde ZIP…', export_progress:'Création de la sauvegarde ZIP… {0} fichiers écrits', export_native_open_failed:'Impossible de créer le fichier ZIP dans Téléchargements', export_native_write_failed:'Échec de l’écriture du fichier ZIP', recording_added_during_export:'Enregistrement ajouté pendant l’exportation',
             export_local_files_detail:' ({0} fichiers locaux inclus)', export_missing_recordings_detail:' ({0} enregistrements supplémentaires inclus)', export_failed:"Échec de l’exportation : ", confirm_import_zip_overwrite:'Importer cette sauvegarde ZIP remplacera les données actuelles. Continuer ?', parsing_zip_backup:'Analyse de la sauvegarde ZIP…', backup_missing_metadata:'metadata.json manque dans la sauvegarde', missing_recordings_manifest_invalid:'Le manifeste des enregistrements supplémentaires est invalide', missing_recordings_manifest_invalid_id:'Le manifeste contient un identifiant invalide', recording_backup_index_invalid:"L’index de sauvegarde des enregistrements est invalide", recording_backup_chunk_invalid:'Le segment {1} de l’enregistrement {0} est invalide', import_complete_files:'Importation terminée : {0} fichiers restaurés', import_failed:"Échec de l’importation : ",
             indexeddb_unavailable:'IndexedDB est indisponible', transaction_aborted:'Transaction interrompue : {0}', unknown_reason:'Raison inconnue', recording_transaction_failed:"Échec de la transaction d’enregistrement", recording_transaction_aborted:"La transaction d’enregistrement a été interrompue", class_file_transaction_failed:'Échec de la transaction du fichier de cours', class_file_transaction_aborted:'La transaction du fichier de cours a été interrompue', recording_storage_module_not_loaded:"Le module de stockage des enregistrements n’est pas chargé", class_lecture_content_empty:'Le contenu du cours est vide', data_structure_corrupt:'Structure de données corrompue : books/papers doivent être des tableaux'
         });
@@ -9303,11 +9303,12 @@
         }
 
         // ==================== Toast ====================
-        function showToast(msg) {
+        function showToast(msg, durationMs = 2000) {
             const t = document.getElementById('toast');
             t.textContent = msg;
             t.classList.add('show');
-            setTimeout(() => t.classList.remove('show'), 2000);
+            clearTimeout(showToast._timer);
+            showToast._timer = setTimeout(() => t.classList.remove('show'), durationMs);
         }
 
         // ==================== Modal Helpers (from original) ====================
@@ -14433,6 +14434,19 @@
                 const mergedIntent = remoteClassroomCount === 0 && localClassroomCount > 0
                     ? localClassroom
                     : mergeClassroomData(remoteClassroom, localClassroom, remoteBaseline);
+                let candidate;
+                if (options.fullOverwrite) {
+                    // 手动「同步到云端」是全量推送：云端索引以本机快照为准，不与云端旧索引合并
+                    // （合并会把本机已删除的笔记本/讲义/课堂条目从云端加回来）。仍保留：
+                    // 课堂删除墓碑取并集、pending 正文不进入索引、ETag CAS 防止与并发写入互相覆盖。
+                    candidate = {
+                        ...localMetadata,
+                        notebooks: localMetadata.notebooks || { items: [], reviews: [] },
+                        classroom: stripClassroomData(localClassroom, true),
+                        classroomTombstones: tombstones,
+                        syncedAt: new Date().toISOString()
+                    };
+                } else {
                 let candidateBase = options.classroomOnly && remoteMetadata
                     ? remoteMetadata
                     : localMetadata;
@@ -14462,7 +14476,7 @@
                     mergedNotebooks.reviews = (mergedNotebooks.reviews || [])
                         .filter(review => review?.notebookId !== options.notebookDeletedId);
                 }
-                const candidate = {
+                candidate = {
                     ...candidateBase,
                     lectures: mergeLecturesData(
                         remoteMetadata?.lectures,
@@ -14474,6 +14488,7 @@
                     classroomTombstones: tombstones,
                     syncedAt: new Date().toISOString()
                 };
+                }
 
                 if (!options.allowEmpty &&
                     !await r2ProtectMetadataOverwrite(candidate, remoteResult?.data || null, remoteMetadata)) {
@@ -14490,6 +14505,15 @@
                         : {};
                 try {
                     await r2PutObject('metadata.json', JSON.stringify(candidate), 'application/json', conditions);
+
+                    if (options.fullOverwrite) {
+                        // 全量覆盖：云端已等于本机快照，只需记录墓碑并清除课堂 pending 标记
+                        appData.classroomTombstones = mergeClassroomTombstones(
+                            appData.classroomTombstones, candidate.classroomTombstones);
+                        await markClassroomMetadataCloudCommitted(candidate.classroom);
+                        saveData();
+                        return { metadata: candidate, casCommitted: true };
+                    }
 
                     // 把本轮 CAS 读取到的其它设备课堂新增项合并回当前活对象；等待网络
                     // 期间刚创建的本地 pending 项仍由 merge 规则保留。
@@ -14807,9 +14831,25 @@
                 .flatMap(nb => nb.pages || [])
                 .find(pg => pg && pg.id === pageId);
             const mediaIds = new Set();
-            let pgData = await getFileData('nbpage_' + pageId).catch(() => null);
+            let pgData;
+            try {
+                pgData = await getFileData('nbpage_' + pageId);
+            } catch (e) {
+                // 本地读取失败（IndexedDB 连接异常等）绝不能当成空白页：旧实现会用空内容
+                // 覆盖本地正文并上传到云端，表现为恢复后「笔画不全」。这里直接跳过本页。
+                console.warn('[nb-sync] 读取笔记页失败，跳过上传:', pageId, e);
+                return;
+            }
             let pageContent = null;
-            try { pageContent = pgData ? JSON.parse(pgData) : null; } catch (e) {}
+            if (pgData) {
+                try {
+                    pageContent = JSON.parse(pgData);
+                } catch (e) {
+                    console.warn('[nb-sync] 笔记页内容损坏，跳过上传:', pageId, e);
+                    return;
+                }
+            }
+            // 从未书写过的页面本地没有记录，按空白页上传即可
             if (!pageContent && page) pageContent = { strokes: [], texts: [], media: [], recognized: null };
             if (pageContent) {
                 if (!pageContent.updatedAt) {
@@ -14820,9 +14860,8 @@
                     page.updatedAt = pageContent.updatedAt;
                     saveData();
                 }
-                pgData = JSON.stringify(pageContent);
-                await saveFileData('nbpage_' + pageId, pgData);
-                await r2PutObject('notebooks/pages/nbpage_' + pageId, pgData, 'application/json');
+                // 不再把规范化后的内容写回本地：写回会与编辑器的保存竞争并覆盖用户刚写的笔画
+                await r2PutObject('notebooks/pages/nbpage_' + pageId, JSON.stringify(pageContent), 'application/json');
                 (pageContent.media || []).forEach(m => { if (m.mediaId) mediaIds.add(m.mediaId); });
             }
             if (page && page.bgImage) mediaIds.add(page.bgImage);
@@ -14832,12 +14871,21 @@
             }
         }
 
-        async function r2SyncAllNotebookPages() {
-            for (const nb of (appData.notebooks?.items || [])) {
-                for (const pg of (nb.pages || [])) {
-                    if (pg && pg.id) await r2SyncNotebookPageBundle(pg.id);
+        // options.concurrency：手动全量推送时并发上传若干页以缩短耗时（默认逐页，行为同旧版）
+        async function r2SyncAllNotebookPages(onProgress, options = {}) {
+            const pages = (appData.notebooks?.items || [])
+                .flatMap(nb => (nb.pages || []).filter(pg => pg && pg.id));
+            const concurrency = Math.max(1, Math.min(8, Number(options.concurrency) || 1));
+            let done = 0, next = 0;
+            const worker = async () => {
+                while (next < pages.length) {
+                    const pg = pages[next++];
+                    await r2SyncNotebookPageBundle(pg.id);
+                    done++;
+                    if (onProgress) onProgress(done, pages.length);
                 }
-            }
+            };
+            await Promise.all(Array.from({ length: Math.min(concurrency, pages.length) }, worker));
         }
 
         function r2NotebookMediaIdsFromPage(page, pageJson) {
@@ -14854,10 +14902,18 @@
 
         async function r2PullNotebookAssetsFromCloud(options = {}) {
             const missingOnly = options.missingOnly !== false;
-            let pages = 0, media = 0;
+            // 手动恢复给单个对象一个下载上限，避免网络停滞让整次恢复无声挂起；启动拉取保持原样
+            const getObject = key => options.timeoutMs
+                ? r2GetObjectWithTimeout(key, options.timeoutMs)
+                : r2GetObject(key);
+            const total = (appData.notebooks?.items || [])
+                .reduce((sum, nb) => sum + (nb.pages || []).filter(page => page && page.id).length, 0);
+            let pages = 0, media = 0, failed = 0, visited = 0;
             for (const nb of (appData.notebooks?.items || [])) {
                 for (const page of (nb.pages || [])) {
                     if (!page || !page.id) continue;
+                    visited++;
+                    if (options.onProgress) options.onProgress(visited, total);
                     let pageJson = await getFileData('nbpage_' + page.id).catch(() => null);
                     let localPageUpdatedAt = 0;
                     try {
@@ -14868,20 +14924,26 @@
                         (cloudPageUpdatedAt > 0 && cloudPageUpdatedAt > localPageUpdatedAt);
                     if (shouldPullPage) {
                         try {
-                            const cloudPage = await r2GetObject('notebooks/pages/nbpage_' + page.id);
+                            const cloudPage = await getObject('notebooks/pages/nbpage_' + page.id);
                             if (cloudPage) {
                                 pageJson = cloudPage;
                                 await saveFileData('nbpage_' + page.id, cloudPage);
                                 pages++;
+                            } else if (!pageJson) {
+                                failed++;
+                                console.warn('[sync] 云端没有该笔记页正文:', page.id);
                             }
-                        } catch (e) { console.warn('[startup-sync] 拉取笔记页失败:', page.id, e); }
+                        } catch (e) {
+                            failed++;
+                            console.warn('[startup-sync] 拉取笔记页失败:', page.id, e);
+                        }
                     }
                     const mediaIds = r2NotebookMediaIdsFromPage(page, pageJson);
                     for (const mediaId of mediaIds) {
                         const localMedia = await getFileData('nbmedia_' + mediaId).catch(() => null);
                         if (missingOnly && localMedia) continue;
                         try {
-                            const cloudMedia = await r2GetObject('notebooks/media/nbmedia_' + mediaId);
+                            const cloudMedia = await getObject('notebooks/media/nbmedia_' + mediaId);
                             if (cloudMedia) {
                                 await saveFileData('nbmedia_' + mediaId, cloudMedia);
                                 media++;
@@ -14890,7 +14952,7 @@
                     }
                 }
             }
-            return { pages, media };
+            return { pages, media, failed };
         }
 
         function r2NotebookPositionKey(notebookId) {
@@ -15352,6 +15414,7 @@
             return await hmac(kService, 'aws4_request');
         }
 
+        const R2_UNSIGNED_PAYLOAD_BYTES = 4 * 1024 * 1024;
         async function r2PutObject(key, data, contentType = 'application/octet-stream', options = {}) {
             const config = appData.settings.r2Config;
             // 移除endpoint末尾的斜杠
@@ -15360,7 +15423,15 @@
             const url = endpoint + '/' + path;
             
             const isBinary = data instanceof Blob || data instanceof ArrayBuffer || ArrayBuffer.isView(data);
-            const payload = typeof data === 'string' || isBinary ? data : JSON.stringify(data);
+            let payload = typeof data === 'string' || isBinary ? data : JSON.stringify(data);
+            const payloadBytes = payload instanceof Blob ? payload.size
+                : (payload instanceof ArrayBuffer || ArrayBuffer.isView(payload)) ? payload.byteLength
+                : payload.length;
+            // 大对象（书籍 PDF、课堂照片等在 IndexedDB 中多为 base64 字符串）：整段 SHA-256 需要再
+            // 复制一份字节，fetch 发送字符串时又复制一份，低内存 WebView（Boox）会被系统杀掉。
+            // 改用 R2 支持的 UNSIGNED-PAYLOAD 跳过正文哈希，并把正文转成 Blob 交给 blob 存储流式上传。
+            const largePayload = payloadBytes >= R2_UNSIGNED_PAYLOAD_BYTES;
+            if (largePayload && !(payload instanceof Blob)) payload = new Blob([payload], { type: contentType });
             
             // 构建请求头 - 不包含浏览器禁止的头
             const headers = new Headers();
@@ -15375,7 +15446,7 @@
             const now = new Date();
             const amzDate = now.toISOString().replace(/[:-]|\.\d{3}/g, '');
             const dateStamp = amzDate.slice(0, 8);
-            const contentSha256 = await sha256Hex(payload);
+            const contentSha256 = largePayload ? 'UNSIGNED-PAYLOAD' : await sha256Hex(payload);
             
             // 签名用的头（包含host用于计算，但不发送）
             const headersToSign = {
@@ -15421,12 +15492,26 @@
             if (options.ifMatch) headers.set('If-Match', String(options.ifMatch));
             if (options.ifNoneMatch) headers.set('If-None-Match', String(options.ifNoneMatch));
             
-            const response = await fetch(url, {
-                method: 'PUT',
-                headers: headers,
-                body: payload,
-                mode: 'cors'
-            });
+            // 上传没有内建超时：网络停滞会让手动同步永远停在「正在同步」而无任何提示。
+            // 按大小给一个宽松上限（基础 5 分钟 + 每 10 MB 1 分钟），只用于兜底。
+            const controller = typeof AbortController === 'function' ? new AbortController() : null;
+            const timeoutMs = 5 * 60 * 1000 + Math.ceil(payloadBytes / (10 * 1024 * 1024)) * 60 * 1000;
+            const timer = controller ? setTimeout(() => controller.abort(), timeoutMs) : null;
+            let response;
+            try {
+                response = await fetch(url, {
+                    method: 'PUT',
+                    headers: headers,
+                    body: payload,
+                    mode: 'cors',
+                    signal: controller ? controller.signal : undefined
+                });
+            } catch (e) {
+                if (controller && controller.signal.aborted) throw new Error(i18n('upload_timeout', key));
+                throw e;
+            } finally {
+                if (timer) clearTimeout(timer);
+            }
             
             if (!response.ok) {
                 const errText = await response.text().catch(() => '');
@@ -15911,6 +15996,15 @@
 
             r2SyncInProgress = true;
             showToast(i18n('toast_syncing'));
+            // 全量推送在 Boox 等设备上可能持续数分钟：按阶段给出节流的进度提示，
+            // 结束时的成功/失败提示停留更久，避免被误认为「没有提示」。
+            let lastSyncProgressAt = 0;
+            const syncProgress = (key, done, total) => {
+                const now = Date.now();
+                if (done < total && now - lastSyncProgressAt < 2500) return;
+                lastSyncProgressAt = now;
+                showToast(i18n(key, done, total), 4000);
+            };
             
             try {
                 // 1. 上传元数据 (不包含PDF数据，但保留annotations)
@@ -15953,10 +16047,20 @@
                     skippedClassroomItems.push({ id: item?.id, name: item?.name || item?.title || '', reason });
                     console.warn('[sync] 课堂素材已跳过，云端已有内容保持不变:', item?.id, reason);
                 };
+                let classroomTotal = 0, classroomDone = 0;
+                for (const listKey of ['courses', 'seminars']) {
+                    for (const folder of (appData.classroom?.[listKey] || [])) {
+                        for (const session of (folder.sessions || [])) {
+                            classroomTotal += (session.sourceFolder || []).length +
+                                (session.notes || []).filter(note => note.contentKey).length;
+                        }
+                    }
+                }
                 for (const listKey of ['courses', 'seminars']) {
                     for (const folder of (appData.classroom?.[listKey] || [])) {
                         for (const session of (folder.sessions || [])) {
                             for (const mat of (session.sourceFolder || [])) {
+                                syncProgress('sync_progress_materials', ++classroomDone, classroomTotal);
                                 try {
                                     if (mat.type === 'recording') {
                                         if (!await r2SyncRecording(mat)) {
@@ -15972,6 +16076,7 @@
                             }
                             for (const note of (session.notes || [])) {
                                 if (!note.contentKey) continue;
+                                syncProgress('sync_progress_materials', ++classroomDone, classroomTotal);
                                 try {
                                     await r2SyncClassroomNote(note);
                                     uploadedClassroomNotes++;
@@ -15983,14 +16088,21 @@
                     }
                 }
                 // 手动"同步到云端"是全量推送，同时充当云端正文丢失后的修复入口。
+                showToast(i18n('sync_progress_lectures'), 4000);
                 const uploadedLectures = await r2SyncChangedLectureContents({ force: true });
-                await r2SyncAllNotebookPages();
+                // 笔记页全量上传（本机内容覆盖云端），并发 3 路以缩短耗时
+                if (nbState.dirty) await nbSavePageNow();
+                await r2SyncAllNotebookPages((done, total) => syncProgress('sync_progress_pages', done, total),
+                    { concurrency: 3 });
                 metadata.lectures = stripLectureContent(appData.lectures);
                 metadata.notebooks = appData.notebooks || { items: [], reviews: [] };
                 metadata.classroom = stripClassroomData(appData.classroom, true);
                 metadata.syncedAt = new Date().toISOString();
+                // 全量覆盖云端索引（见 r2PublishMetadataWithCas 的 fullOverwrite 说明）
+                showToast(i18n('sync_progress_metadata'), 4000);
                 const metadataPublishResult = await r2PublishMetadataWithCas(metadata,
                     stripClassroomData(appData.classroom, false), {
+                        fullOverwrite: true,
                         allowEmpty: allowEmptyMetadataOverwrite ||
                             (appData.classroomSyncOutbox || []).length > 0
                     });
@@ -16002,7 +16114,10 @@
                 let uploadedFiles = 0;
                 const allDocs = [...appData.books, ...appData.papers];
                 
-                for (const doc of allDocs) {
+                for (let docIndex = 0; docIndex < allDocs.length; docIndex++) {
+                    const doc = allDocs[docIndex];
+                    syncProgress('sync_progress_files', docIndex + 1, allDocs.length);
+                    // 每份 PDF 只在本轮迭代中驻留内存
                     const fileData = await getFileData(doc.id);
                     if (fileData) {
                         const fileKey = 'files/' + doc.id + '.pdf';
@@ -16093,10 +16208,10 @@
                 showToast(i18n('sync_done_detail', uploadedFiles, uploadedLectures, uploadedAbstracts) +
                     (skippedClassroomItems.length
                         ? i18n('sync_skipped_class_items', skippedClassroomItems.length)
-                        : ''));
+                        : ''), 6000);
             } catch (err) {
                 console.error('Sync to R2 failed:', err);
-                showToast(i18n('toast_sync_failed') + err.message);
+                showToast(i18n('toast_sync_failed') + err.message, 6000);
             } finally {
                 r2SyncInProgress = false;
                 if (r2PendingSyncQueue.length > 0) {
@@ -16906,6 +17021,7 @@
             }
         }
 
+        const R2_RESTORE_OBJECT_TIMEOUT_MS = 20 * 60 * 1000;
         async function syncFromR2() {
             const config = appData.settings.r2Config;
             if (!config || !config.accessKeyId) {
@@ -16925,6 +17041,13 @@
             
             r2SyncInProgress = true;
             showToast(i18n('toast_restoring'));
+            let lastRestoreProgressAt = 0;
+            const restoreProgress = (key, done, total) => {
+                const now = Date.now();
+                if (done < total && now - lastRestoreProgressAt < 2500) return;
+                lastRestoreProgressAt = now;
+                showToast(i18n(key, done, total), 4000);
+            };
             
             try {
                 // 1. 下载元数据
@@ -16953,7 +17076,6 @@
                 // syncFromR2 自己的作用域内，供后面的课堂合并使用。
                 const localClassroomBeforeRestore = appData.classroom || { courses: [], seminars: [] };
                 const localLecturesBeforeRestore = appData.lectures || {};
-                const localNotebooksBeforeRestore = appData.notebooks || { items: [], reviews: [] };
                 const cloudRestoreSyncedAtMs = syncTimestamp(metadata.syncedAt);
                 appData.classroomTombstones = mergeClassroomTombstones(
                     metadata.classroomTombstones, appData.classroomTombstones);
@@ -16997,11 +17119,13 @@
                 appData.classroom = mergedClassroom;
                 appData.exercises = metadata.exercises || { folders: [], wrongByFolder: {}, archivedWrong: {} };
                 if (!appData.exercises.archivedWrong) appData.exercises.archivedWrong = {};
-                appData.notebooks = mergeNotebooksData(
-                    metadata.notebooks,
-                    localNotebooksBeforeRestore,
-                    cloudRestoreSyncedAtMs
-                );
+                // 手动「从云端恢复」是全量恢复：笔记本索引（含页面列表、复习记录与墓碑）直接采用
+                // 云端快照，不与本机合并——合并会让本机较新的条目留下、云端的页面列表被改写，
+                // 随后逐页拉取时只能取回部分页面的笔画。页面正文在第 7 步按云端副本逐页覆盖。
+                appData.notebooks = {
+                    items: Array.isArray(metadata.notebooks?.items) ? metadata.notebooks.items : [],
+                    reviews: Array.isArray(metadata.notebooks?.reviews) ? metadata.notebooks.reviews : []
+                };
                 appData.settings = { ...metadata.settings, ...localApiSettings, r2Config: localR2Config };
                 // 用户主动从云端完整恢复，数据可信，允许后续上传
                 appDataLoaded = true;
@@ -17012,10 +17136,12 @@
                 let downloadedFiles = 0;
                 const allDocs = [...appData.books, ...appData.papers];
                 
-                for (const doc of allDocs) {
+                for (let docIndex = 0; docIndex < allDocs.length; docIndex++) {
+                    const doc = allDocs[docIndex];
+                    restoreProgress('restore_progress_files', docIndex + 1, allDocs.length);
                     const fileKey = 'files/' + doc.id + '.pdf';
                     try {
-                        const fileData = await r2GetObject(fileKey);
+                        const fileData = await r2GetObjectWithTimeout(fileKey, R2_RESTORE_OBJECT_TIMEOUT_MS);
                         if (fileData) {
                             await saveFileData(doc.id, fileData);
                             downloadedFiles++;
@@ -17191,8 +17317,25 @@
                     }
                 }
 
-                // 7. 下载笔记本页面与媒体
-                const downloadedNotebooks = await r2PullNotebookAssetsFromCloud({ missingOnly: false });
+                // 7. 下载笔记本页面与媒体（全部按云端副本覆盖本地正文）
+                const downloadedNotebooks = await r2PullNotebookAssetsFromCloud({
+                    missingOnly: false,
+                    timeoutMs: R2_RESTORE_OBJECT_TIMEOUT_MS,
+                    onProgress: (done, total) => restoreProgress('restore_progress_pages', done, total)
+                });
+                // 缩略图/摘要缓存按页缓存，恢复后必须作废，否则大纲与导出面板仍显示恢复前的内容；
+                // 若笔记本编辑器正打开着，按恢复后的正文重新载入当前页。
+                Object.keys(nbThumbCache).forEach(key => { delete nbThumbCache[key]; });
+                Object.keys(nbSnippetCache).forEach(key => { delete nbSnippetCache[key]; });
+                if (document.getElementById('nbEditor')?.classList.contains('show') && nbState.notebookId) {
+                    nbState.dirty = false;
+                    if (nbGetNotebook(nbState.notebookId)) {
+                        await nbLoadPage(nbState.pageIndex, false);
+                        nbRefreshOutline();
+                    } else {
+                        await nbCloseEditor();
+                    }
+                }
 
                 renderLibrary();
                 renderNotesPage();
@@ -17203,10 +17346,12 @@
                 // immediately reflect the restored data without needing a refresh.
                 try { applySettings(); } catch (e) { console.warn('applySettings failed', e); }
                 try { initR2AutoSync(); } catch (e) { console.warn('initR2AutoSync failed', e); }
-                showToast(i18n('restore_done_detail', downloadedFiles, downloadedLectures, downloadedAbstracts) + (downloadedNotebooks.pages || downloadedNotebooks.media ? i18n('restore_notebook_detail', downloadedNotebooks.pages, downloadedNotebooks.media) : ''));
+                showToast(i18n('restore_done_detail', downloadedFiles, downloadedLectures, downloadedAbstracts) +
+                    (downloadedNotebooks.pages || downloadedNotebooks.media ? i18n('restore_notebook_detail', downloadedNotebooks.pages, downloadedNotebooks.media) : '') +
+                    (downloadedNotebooks.failed ? i18n('restore_notebook_failed_detail', downloadedNotebooks.failed) : ''), 6000);
             } catch (err) {
                 console.error('Sync from R2 failed:', err);
-                showToast(i18n('toast_restore_failed') + err.message);
+                showToast(i18n('toast_restore_failed') + err.message, 6000);
             } finally {
                 r2SyncInProgress = false;
                 if (r2PendingSyncQueue.length > 0) {
@@ -17229,50 +17374,167 @@
             for (let i = 0; i < bytes.length; i++) crc = (crc >>> 8) ^ dataZipCrc32.table[(crc ^ bytes[i]) & 0xff];
             return (crc ^ -1) >>> 0;
         }
-        async function dataZipCrc32Blob(blob) {
-            if (!dataZipCrc32.table) dataZipCrc32(new Uint8Array(0));
-            let crc = 0 ^ -1;
-            const step = 4 * 1024 * 1024;
-            for (let offset = 0; offset < blob.size; offset += step) {
-                const bytes = new Uint8Array(await blob.slice(offset, Math.min(blob.size, offset + step)).arrayBuffer());
-                for (let i = 0; i < bytes.length; i++) {
-                    crc = (crc >>> 8) ^ dataZipCrc32.table[(crc ^ bytes[i]) & 0xff];
-                }
-            }
-            return (crc ^ -1) >>> 0;
-        }
         function dataZipU16(n) { return [n & 255, (n >>> 8) & 255]; }
         function dataZipU32(n) { return [n & 255, (n >>> 8) & 255, (n >>> 16) & 255, (n >>> 24) & 255]; }
         function dataZipDosDate(d = new Date()) {
             return { time: (d.getHours() << 11) | (d.getMinutes() << 5) | Math.floor(d.getSeconds() / 2), date: ((d.getFullYear() - 1980) << 9) | ((d.getMonth() + 1) << 5) | d.getDate() };
         }
-        function dataZipEncode(value) {
-            if (value instanceof Uint8Array) return value;
-            if (value instanceof ArrayBuffer) return new Uint8Array(value);
-            return new TextEncoder().encode(String(value ?? ''));
+
+        // ---------- 流式 ZIP 写入 ----------
+        // 备份 ZIP 常达数百 MB，而书籍 PDF、课堂照片、笔记媒体在 IndexedDB 中多以 base64
+        // 字符串保存。旧实现把全部条目及其 UTF-8 编码同时驻留在 JS 堆里再合成一个 Blob，
+        // Boox 等低内存 WebView 会在此处被系统杀掉渲染进程（表现为「阅读器进程已恢复，
+        // 已返回书架」而得不到 ZIP）。现在逐条目处理：第一遍只累计 CRC/长度，第二遍按
+        // 2 MB 分片写入 sink，任何时刻堆内仅保留一个分片；条目仍为 stored（不压缩）且不带
+        // 数据描述符，与 dataZipRead 的读取方式完全一致。
+        const DATA_ZIP_CHUNK = 2 * 1024 * 1024;
+
+        // 字符串按不拆分代理对的边界切片编码为 UTF-8，避免整段编码再翻倍占用内存
+        function* dataZipStringChunks(str, chunkChars = DATA_ZIP_CHUNK) {
+            const encoder = new TextEncoder();
+            for (let start = 0; start < str.length;) {
+                let end = Math.min(str.length, start + chunkChars);
+                const code = str.charCodeAt(end - 1);
+                if (end < str.length && code >= 0xd800 && code <= 0xdbff) end++;
+                yield encoder.encode(str.slice(start, end));
+                start = end;
+            }
         }
-        async function dataZipCreate(files) {
-            const chunks = [], central = [];
+        // 逐分片遍历条目数据：Blob | ArrayBuffer | TypedArray | string
+        async function* dataZipDataChunks(data) {
+            if (data instanceof Blob) {
+                for (let offset = 0; offset < data.size; offset += DATA_ZIP_CHUNK) {
+                    yield new Uint8Array(await data.slice(offset, Math.min(data.size, offset + DATA_ZIP_CHUNK)).arrayBuffer());
+                }
+            } else if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
+                const bytes = data instanceof ArrayBuffer
+                    ? new Uint8Array(data)
+                    : new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+                for (let offset = 0; offset < bytes.length; offset += DATA_ZIP_CHUNK) {
+                    yield bytes.subarray(offset, Math.min(bytes.length, offset + DATA_ZIP_CHUNK));
+                }
+            } else {
+                yield* dataZipStringChunks(String(data ?? ''));
+            }
+        }
+        function dataZipCrc32Update(crc, bytes) {
+            if (!dataZipCrc32.table) dataZipCrc32(new Uint8Array(0));
+            const table = dataZipCrc32.table;
+            for (let i = 0; i < bytes.length; i++) crc = (crc >>> 8) ^ table[(crc ^ bytes[i]) & 0xff];
+            return crc;
+        }
+        // 第一遍：只统计 CRC 与字节数，不保留数据
+        async function dataZipMeasure(data) {
+            let crc = 0 ^ -1, size = 0;
+            for await (const bytes of dataZipDataChunks(data)) {
+                crc = dataZipCrc32Update(crc, bytes);
+                size += bytes.length;
+            }
+            return { crc: (crc ^ -1) >>> 0, size };
+        }
+        // entries：同步或异步可迭代的 { name, data }；sink：{ write(bytes), writeBlob?(blob), finish(), abort() }
+        async function dataZipStream(entries, sink, onEntry) {
+            const central = [];
             let offset = 0;
+            let count = 0;
             const dt = dataZipDosDate();
-            for (const f of files) {
+            for await (const f of entries) {
                 const name = new TextEncoder().encode(f.name);
-                const data = f.data instanceof Blob ? f.data : dataZipEncode(f.data);
-                const size = data instanceof Blob ? data.size : data.length;
-                if (size > 0xffffffff) throw new Error(i18n('backup_file_too_large'));
-                const crc = data instanceof Blob ? await dataZipCrc32Blob(data) : dataZipCrc32(data);
+                const { crc, size } = await dataZipMeasure(f.data);
+                if (size > 0xffffffff || offset + size > 0xffffffff) throw new Error(i18n('backup_file_too_large'));
                 const local = new Uint8Array([0x50,0x4b,3,4, ...dataZipU16(20), ...dataZipU16(0x0800), ...dataZipU16(0), ...dataZipU16(dt.time), ...dataZipU16(dt.date), ...dataZipU32(crc), ...dataZipU32(size), ...dataZipU32(size), ...dataZipU16(name.length), 0,0, ...name]);
-                chunks.push(local, data);
+                await sink.write(local);
+                if (f.data instanceof Blob && typeof sink.writeBlob === 'function') {
+                    await sink.writeBlob(f.data);
+                } else {
+                    for await (const bytes of dataZipDataChunks(f.data)) await sink.write(bytes);
+                }
                 central.push({ name, crc, size, offset });
                 offset += local.length + size;
+                count++;
+                if (onEntry) onEntry(count, f.name);
             }
             const centralStart = offset;
             for (const c of central) {
-                const hdr = new Uint8Array([0x50,0x4b,1,2, ...dataZipU16(20), ...dataZipU16(20), ...dataZipU16(0x0800), ...dataZipU16(0), ...dataZipU16(dt.time), ...dataZipU16(dt.date), ...dataZipU32(c.crc), ...dataZipU32(c.size), ...dataZipU32(c.size), ...dataZipU16(c.name.length), 0,0, 0,0, 0,0, 0,0,0,0, ...dataZipU32(c.offset), ...c.name]);
-                chunks.push(hdr); offset += hdr.length;
+                // 中央目录头固定部分为 46 字节：文件名长度之后依次是扩展区长度(2)、注释长度(2)、
+                // 起始磁盘号(2)、内部属性(2)、外部属性(4)、本地文件头偏移(4)。旧实现少写了 2 字节，
+                // 应用自身导入只读本地文件头所以不受影响，但外部解压工具会判定归档损坏。
+                const hdr = new Uint8Array([0x50,0x4b,1,2, ...dataZipU16(20), ...dataZipU16(20), ...dataZipU16(0x0800), ...dataZipU16(0), ...dataZipU16(dt.time), ...dataZipU16(dt.date), ...dataZipU32(c.crc), ...dataZipU32(c.size), ...dataZipU32(c.size), ...dataZipU16(c.name.length), 0,0, 0,0, 0,0, 0,0, 0,0,0,0, ...dataZipU32(c.offset), ...c.name]);
+                await sink.write(hdr); offset += hdr.length;
             }
-            chunks.push(new Uint8Array([0x50,0x4b,5,6, 0,0, 0,0, ...dataZipU16(central.length), ...dataZipU16(central.length), ...dataZipU32(offset - centralStart), ...dataZipU32(centralStart), 0,0]));
-            return new Blob(chunks, { type: 'application/zip' });
+            await sink.write(new Uint8Array([0x50,0x4b,5,6, 0,0, 0,0, ...dataZipU16(central.length), ...dataZipU16(central.length), ...dataZipU32(offset - centralStart), ...dataZipU32(centralStart), 0,0]));
+            return { count, bytes: offset };
+        }
+        // Blob sink：每积累 4 MB 就把已写字节封成 Blob 交给浏览器的 blob 存储（可落盘），
+        // JS 堆里不再同时保留整个 ZIP；来自 IndexedDB 的 Blob 直接引用，不复制。
+        function dataZipBlobSink() {
+            const parts = [];
+            let pending = [], pendingBytes = 0;
+            const flush = () => {
+                if (!pending.length) return;
+                parts.push(new Blob(pending));
+                pending = []; pendingBytes = 0;
+            };
+            return {
+                write(bytes) {
+                    pending.push(bytes);
+                    pendingBytes += bytes.length;
+                    if (pendingBytes >= 2 * DATA_ZIP_CHUNK) flush();
+                },
+                writeBlob(blob) { flush(); parts.push(blob); },
+                finish() { flush(); return new Blob(parts, { type: 'application/zip' }); },
+                abort() { pending = []; pendingBytes = 0; parts.length = 0; }
+            };
+        }
+        function dataZipBytesToBase64(bytes) {
+            let binary = '';
+            const step = 0x8000;
+            for (let i = 0; i < bytes.length; i += step) {
+                binary += String.fromCharCode.apply(null, bytes.subarray(i, Math.min(bytes.length, i + step)));
+            }
+            return btoa(binary);
+        }
+        // Boox 原生 sink：经 DownloadBridge 分片流式写入系统下载目录（与导出 PDF 相同位置），
+        // 全程不构造整块 Blob，也不再经过 blob URL → fetch → 整体 base64 的旧路径。
+        function dataZipNativeSink(fileName) {
+            const dl = window.BooxDownloadNative;
+            const token = dl.beginSave(fileName, 'application/zip');
+            if (!token) throw new Error(i18n('export_native_open_failed'));
+            let pending = [], pendingBytes = 0;
+            const flush = () => {
+                if (!pendingBytes) return;
+                let buf = pending[0];
+                if (pending.length > 1) {
+                    buf = new Uint8Array(pendingBytes);
+                    let at = 0;
+                    for (const part of pending) { buf.set(part, at); at += part.length; }
+                }
+                pending = []; pendingBytes = 0;
+                if (!dl.appendBase64(token, dataZipBytesToBase64(buf))) {
+                    throw new Error(i18n('export_native_write_failed'));
+                }
+            };
+            return {
+                write(bytes) {
+                    pending.push(bytes);
+                    pendingBytes += bytes.length;
+                    if (pendingBytes >= DATA_ZIP_CHUNK) flush();
+                },
+                finish() {
+                    flush();
+                    if (!dl.finishSave(token)) throw new Error(i18n('export_native_write_failed'));
+                    return null;
+                },
+                abort(reason) {
+                    pending = []; pendingBytes = 0;
+                    try { dl.abortSave(token, String(reason || '')); } catch (e) { /* 忽略 */ }
+                }
+            };
+        }
+        async function dataZipCreate(files) {
+            const sink = dataZipBlobSink();
+            await dataZipStream(files, sink);
+            return sink.finish();
         }
         function dataZipReadU16(v, p) { return v.getUint16(p, true); }
         function dataZipReadU32(v, p) { return v.getUint32(p, true); }
@@ -17604,7 +17866,6 @@
                         }))
                     };
                 }
-                const files = [{ name: 'metadata.json', data: JSON.stringify(metadata, null, 2) }];
                 const verifiedIdbData = new Map();
                 for (const prepared of exportedRecordings) {
                     for (const entry of (prepared.idbEntries || [])) {
@@ -17621,80 +17882,108 @@
                     .filter(key => verifiedIdbData.has(key) || typeof key !== 'string' ||
                         (!key.startsWith(recordingManifestPrefix) &&
                          !key.startsWith(recordingChunkPrefix)));
-                const idbIndex = [];
-                let fileIndex = 0;
-                for (const key of keys) {
-                    const data = verifiedIdbData.has(key)
-                        ? verifiedIdbData.get(key)
-                        : await getFileData(key).catch(() => null);
-                    if (data === null || data === undefined) continue;
-                    const base = 'idb/data/' + String(fileIndex++).padStart(8, '0');
-                    if (data instanceof Blob) {
-                        const path = base + '.bin';
-                        files.push({ name: path, data });
-                        idbIndex.push({ id: key, path, kind: 'blob', mime: data.type || 'application/octet-stream', size: data.size });
-                    } else if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
-                        const path = base + '.bin';
-                        const blob = new Blob([data], { type: 'application/octet-stream' });
-                        files.push({ name: path, data: blob });
-                        idbIndex.push({ id: key, path, kind: 'blob', mime: blob.type, size: blob.size });
-                    } else if (typeof data === 'string') {
-                        const path = base + '.txt';
-                        files.push({ name: path, data });
-                        idbIndex.push({ id: key, path, kind: 'string' });
-                    } else {
-                        const path = base + '.json';
-                        files.push({ name: path, data: JSON.stringify(data) });
-                        idbIndex.push({ id: key, path, kind: 'json' });
-                    }
-                }
-                files.push({ name: 'idb/index.json', data: JSON.stringify(idbIndex) });
 
-                // Native, legacy, and known-incomplete IDB sources use bounded,
-                // hashed portable entries. Only fully verified IDB journals stay in
-                // the generic IDB index.
-                const portableRecordings = [];
-                let portableIndex = 0;
-                for (const prepared of exportedRecordings) {
-                    if (!prepared.chunks) continue;
-                    const item = {
-                        id: prepared.material.id,
-                        mimeType: prepared.mimeType,
-                        duration: prepared.material.duration || 0,
-                        startedAt: prepared.material.uploadedAt,
-                        byteLength: prepared.byteLength,
-                        incomplete: prepared.incomplete,
-                        material: prepared.context,
-                        chunks: []
-                    };
-                    for (const chunk of prepared.chunks) {
-                        const path = 'recordings/data/' + String(portableIndex++).padStart(8, '0') + '.bin';
-                        files.push({ name: path, data: chunk.data });
-                        item.chunks.push({ path, size: chunk.size, sha256: chunk.sha256 });
+                // 条目按需生成并立即写入 ZIP（见 dataZipStream）：每个 IndexedDB 记录只在
+                // 本轮迭代中驻留内存，索引文件在其数据条目之后写出（dataZipRead 按名字取用，
+                // 不依赖顺序）。
+                async function* backupEntries() {
+                    yield { name: 'metadata.json', data: JSON.stringify(metadata, null, 2) };
+                    const idbIndex = [];
+                    let fileIndex = 0;
+                    for (const key of keys) {
+                        const data = verifiedIdbData.has(key)
+                            ? verifiedIdbData.get(key)
+                            : await getFileData(key).catch(() => null);
+                        if (data === null || data === undefined) continue;
+                        const base = 'idb/data/' + String(fileIndex++).padStart(8, '0');
+                        if (data instanceof Blob) {
+                            const path = base + '.bin';
+                            idbIndex.push({ id: key, path, kind: 'blob', mime: data.type || 'application/octet-stream', size: data.size });
+                            yield { name: path, data };
+                        } else if (data instanceof ArrayBuffer || ArrayBuffer.isView(data)) {
+                            const path = base + '.bin';
+                            idbIndex.push({ id: key, path, kind: 'blob', mime: 'application/octet-stream', size: data.byteLength });
+                            yield { name: path, data };
+                        } else if (typeof data === 'string') {
+                            const path = base + '.txt';
+                            idbIndex.push({ id: key, path, kind: 'string' });
+                            yield { name: path, data };
+                        } else {
+                            const path = base + '.json';
+                            idbIndex.push({ id: key, path, kind: 'json' });
+                            yield { name: path, data: JSON.stringify(data) };
+                        }
                     }
-                    portableRecordings.push(item);
+                    yield { name: 'idb/index.json', data: JSON.stringify(idbIndex) };
+
+                    // Native, legacy, and known-incomplete IDB sources use bounded,
+                    // hashed portable entries. Only fully verified IDB journals stay in
+                    // the generic IDB index.
+                    const portableRecordings = [];
+                    let portableIndex = 0;
+                    for (const prepared of exportedRecordings) {
+                        if (!prepared.chunks) continue;
+                        const item = {
+                            id: prepared.material.id,
+                            mimeType: prepared.mimeType,
+                            duration: prepared.material.duration || 0,
+                            startedAt: prepared.material.uploadedAt,
+                            byteLength: prepared.byteLength,
+                            incomplete: prepared.incomplete,
+                            material: prepared.context,
+                            chunks: []
+                        };
+                        for (const chunk of prepared.chunks) {
+                            const path = 'recordings/data/' + String(portableIndex++).padStart(8, '0') + '.bin';
+                            item.chunks.push({ path, size: chunk.size, sha256: chunk.sha256 });
+                            yield { name: path, data: chunk.data };
+                        }
+                        portableRecordings.push(item);
+                    }
+                    if (portableRecordings.length) {
+                        yield { name: 'recordings/index.json', data: JSON.stringify(portableRecordings) };
+                    }
+                    if (exportedMissingRecordings.length) {
+                        yield {
+                            name: 'recordings/missing.json',
+                            data: JSON.stringify({
+                                format: 'math-reader-missing-recordings-v1',
+                                exportedAt: metadata.exportedAt,
+                                items: exportedMissingRecordings
+                            }, null, 2)
+                        };
+                    }
                 }
-                if (portableRecordings.length) {
-                    files.push({ name: 'recordings/index.json', data: JSON.stringify(portableRecordings) });
-                }
-                if (exportedMissingRecordings.length) {
-                    files.push({
-                        name: 'recordings/missing.json',
-                        data: JSON.stringify({
-                            format: 'math-reader-missing-recordings-v1',
-                            exportedAt: metadata.exportedAt,
-                            items: exportedMissingRecordings
-                        }, null, 2)
+
+                // Boox APK：直接经原生桥流式写入系统下载目录（与导出 PDF 相同位置）；
+                // 其它平台：分块交给 blob 存储后按 a[download] 下载。
+                const zipName = 'math-reader-full-export-' + new Date().toISOString().slice(0,10) + '.zip';
+                const useNativeSink = typeof window.BooxDownloadNative?.beginSave === 'function';
+                const sink = useNativeSink ? dataZipNativeSink(zipName) : dataZipBlobSink();
+                let lastProgressAt = Date.now();
+                let written;
+                let zipBlob = null;
+                try {
+                    written = await dataZipStream(backupEntries(), sink, (count) => {
+                        const now = Date.now();
+                        if (now - lastProgressAt < 2500) return;
+                        lastProgressAt = now;
+                        showToast(i18n('export_progress', count));
                     });
+                    zipBlob = sink.finish();
+                } catch (err) {
+                    try { sink.abort(err?.message || String(err)); } catch (e) { /* 忽略 */ }
+                    throw err;
                 }
-                const blob = await dataZipCreate(files);
-                const url = URL.createObjectURL(blob);
-                const a = document.createElement('a');
-                a.href = url;
-                a.download = 'math-reader-full-export-' + new Date().toISOString().slice(0,10) + '.zip';
-                a.click();
-                setTimeout(() => URL.revokeObjectURL(url), 30000);
-                showToast(i18n('toast_export_success') + i18n('export_local_files_detail', files.length - 1) +
+                if (zipBlob) {
+                    const url = URL.createObjectURL(zipBlob);
+                    const a = document.createElement('a');
+                    a.href = url;
+                    a.download = zipName;
+                    a.click();
+                    setTimeout(() => URL.revokeObjectURL(url), 30000);
+                }
+                showToast(i18n('toast_export_success') + i18n('export_local_files_detail', written.count - 1) +
                     (exportedMissingRecordings.length
                         ? i18n('export_missing_recordings_detail', exportedMissingRecordings.length)
                         : ''));


### PR DESCRIPTION
本 PR 只涉及 **手动** 路径（设置页「导出数据」「同步到云端」「从云端恢复」）；自动云同步的逻辑未改动，下文单独列出被触及的共用底层函数及原因。

## 1. BOOX 导出数据得不到 ZIP
- 根因：备份内容（PDF、课堂照片、笔记媒体）在 IndexedDB 中多为 base64 字符串，旧实现把全部条目及其 UTF-8 编码同时驻留在 JS 堆中再合成一个 Blob，BOOX 等低内存 WebView 在此被系统整体杀掉（随后 BOOX 系统返回其书库并显示系统提示），ZIP 从未写出。
- 改为逐条目流式写入：先只统计 CRC 与长度，再按 2 MB 分片写入 sink，任何时刻堆内仅保留一个分片。BOOX APK 直接经 `DownloadBridge.beginSave/appendBase64/finishSave` 流式写入系统下载目录（与导出 PDF 相同位置）；其它平台分块交给 blob 存储后仍走 `a[download]`。
- 顺带修正中央目录头少写 2 字节的既有问题（应用自身导入不受影响，但外部解压工具会判定归档损坏）。`python -m zipfile -t` 与 `unzip -t` 均通过。

## 2. 手动「同步到云端」（`syncToR2`）
- 云端索引以本机快照全量覆盖（`r2PublishMetadataWithCas` 新增 `fullOverwrite` 选项，仅手动路径传入），不再与云端旧索引合并；保留课堂删除墓碑并集、pending 正文过滤与 ETag CAS。
- 按阶段给出节流进度提示（课堂素材 / 讲义与笔记页 / 发布索引 / 文件），成功与失败提示停留 6 秒。
- 笔记页全量上传并发 3 路；上传前先落盘编辑器中未保存的页面。

## 3. 手动「从云端恢复」（`syncFromR2`）
- 笔记本索引直接采用云端快照（不再与本机合并），随后逐页按云端副本覆盖本地正文；恢复后作废缩略图/摘要缓存，若编辑器正打开则按恢复后的正文重新载入当前页。
- 单个对象下载设 20 分钟上限，进度提示，并在结果中给出未能取回的页数。

## 被触及的共用底层函数（仅传输与数据安全，自动同步的判定逻辑不变）
- `r2PutObject`：≥ 4 MB 的正文改用 R2 支持的 `UNSIGNED-PAYLOAD` 并以 Blob 作为请求体（避免整段哈希与发送时的两次复制，也显著减少大文件上传的哈希耗时）；所有 PUT 增加按大小计算的超时兜底。
- `r2SyncNotebookPageBundle`：本地读取失败或内容损坏时跳过该页，不再把空白页上传并写回覆盖本地正文（这是恢复后「笔画不全」的一个直接来源）；不再把规范化后的内容写回 IndexedDB，避免与编辑器保存竞争。
- `r2SyncAllNotebookPages` / `r2PullNotebookAssetsFromCloud`：新增可选的进度 / 并发 / 超时参数，不传参时行为与之前一致。

## 验证
- `node --check`、`node --test tests/*.test.js` 通过。
- Chromium 内以假的原生桥验证流式导出：字符串（含跨 2 MB 分片边界的代理对）、Blob、ArrayBuffer、JSON 条目全部往返一致，逐条 CRC、标志位、中央目录与 EOCD 校验通过；Blob 路径输出与旧写入器逐字节一致（补齐 2 字节后）。
- Chromium 内以同源内存 R2 模拟验证：手动同步后云端索引等于本机快照（云端多出的笔记本被覆盖掉）、全部笔记页正文上传、metadata PUT 携带 If-Match；≥ 4 MB 正文使用 UNSIGNED-PAYLOAD；损坏的本地页面不会被上传；手动恢复后本机笔记本索引等于云端快照、所有页面（含本机原本没有的笔记本）笔画取回、打开中的编辑器重新载入、缩略图缓存已清空。
- 完整 APK 构建由 CI 执行（沙箱无法下载 Android SDK）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01693RQFYwD6ARqH2z3FG4z6

---
_Generated by [Claude Code](https://claude.ai/code/session_01693RQFYwD6ARqH2z3FG4z6)_