### PR TITLE
修复 iOS PWA 笔记原生选区

### DIFF
--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -4534,6 +4534,21 @@
             flex-direction: column;
         }
         .nb-editor.show { display: flex; }
+        /* iPadOS 笔记编辑器禁用原生选区；聚焦的编辑控件在下方恢复 */
+        #nbEditor.show,
+        #nbEditor.show * {
+            -webkit-user-select: none;
+            user-select: none;
+            -webkit-touch-callout: none;
+        }
+        #nbEditor.show input:focus,
+        #nbEditor.show select:focus,
+        #nbEditor.show .nb-textbox-inner:focus,
+        #nbEditor.show .nb-textbox-inner:focus * {
+            -webkit-user-select: text;
+            user-select: text;
+            -webkit-touch-callout: default;
+        }
         .nb-topbar {
             height: 52px; flex-shrink: 0;
             background: var(--bg-primary);


### PR DESCRIPTION
## 修改

- 仅在打开的笔记编辑器内禁用原生选区和长按菜单
- 聚焦输入框、下拉框和笔记文字框时恢复原生编辑
- 不拦截 touch/pointer 事件，不修改保存和 R2 同步逻辑

这是相对 #32 更窄的 CSS-only 尝试，避免改变笔画保存所依赖的事件流。

## 验证

- Chromium：编辑器文字不可拖选，聚焦文字框和页码输入框仍可编辑
- 完成一笔后等待 1.5 秒，IndexedDB 笔画数恰好增加 1，`dirty=false`
- 编辑器外文字仍可选择
- `node --test tests/*.test.js`
- `./gradlew assembleDebug`
- `git diff --check`

当前没有 iPad 和 Apple Pencil 环境，烦请维护者在 iPadOS PWA 上确认原生选区是否消失，并确认现有云同步配置下笔画仍可正常同步。

Closes #81