### PR TITLE
修复笔记本与讲义的手写输入、原生 SDK 和页面留白

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -15,6 +15,13 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
+      - name: Check handwriting input and shared page
+        run: |
+          node tests/notebook-input.test.js
+          node tests/native-selection.test.js
+          node tests/boox-pen.test.js
+          cmp app/src/main/assets/www/index.html docs/index.html
+
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin

--- a/app/src/main/assets/boox-pen.js
+++ b/app/src/main/assets/boox-pen.js
@@ -115,15 +115,21 @@
     // eraserToggle: 全局函数名，回放原生笔侧橡皮笔迹时临时切换
     // suspendFlag: 全局布尔变量名，为真时挂起原生直渲染（套索/文本/图形等非书写工具）
     // widthFlag: 全局变量名，数值为当前笔刷 CSS 像素宽度（原生直渲染层的笔迹粗细）
+    // clipId: 长画布的滚动容器，探测与原生区域都限制在可见内容内
     var CONFIGS = [
         { name: 'notebookQuiz', id: 'nbQuizFsCanvas',       cssWidth: 2,
           eraserBtn: 'qzEraserBtn',     eraserToggle: 'toggleQzEraser' },
         { name: 'notebook',     id: 'nbCanvas',             cssWidth: 2,
           eraserBtn: 'nbEraserBtn',     eraserToggle: 'toggleNbEraser',
-          suspendFlag: '__nbNativeSuspend', widthFlag: '__nbNativeWidth' },
+          suspendFlag: '__nbNativeSuspend', widthFlag: '__nbNativeWidth',
+          clipId: 'nbCanvasWrap' },
         { name: 'draft',        id: 'draftCanvas',          cssWidth: 2 },
-        { name: 'lectureDraft', id: 'lectureDraftCanvas',   cssWidth: 2 },
-        { name: 'lectureDraw',  id: 'lectureDrawCanvas',    cssWidth: 2 },
+        { name: 'lectureDraft', id: 'lectureDraftCanvas',   cssWidth: 4,
+          clipId: 'lectureDraftCanvasWrapper', eraserBtn: 'lectureDraftEraserToggle',
+          widthFlag: '__lectureDraftNativeWidth' },
+        { name: 'lectureDraw',  id: 'lectureDrawCanvas',    cssWidth: 2,
+          clipId: 'lectureViewerContent', eraserBtn: 'lecturePenEraser',
+          eraserToggle: 'toggleLecturePenEraser', widthFlag: '__lectureNativeWidth' },
         { name: 'exercise',     id: 'exerciseDoingCanvas',  cssWidth: 2,
           eraserBtn: 'exEraserBtn',     eraserToggle: 'toggleExEraser',
           suspendFlag: '__exNativeSuspend' },
@@ -135,19 +141,33 @@
     var activeEls = [];
     var lastKey = 'off';
 
-    function isDrawable(el) {
+    function drawableRect(el, cfg) {
+        var r = el.getBoundingClientRect();
+        var clip = cfg.clipId && document.getElementById(cfg.clipId);
+        if (clip) {
+            var c = clip.getBoundingClientRect();
+            return {
+                left: Math.max(r.left, c.left, 0), top: Math.max(r.top, c.top, 0),
+                right: Math.min(r.right, c.right, window.innerWidth),
+                bottom: Math.min(r.bottom, c.bottom, window.innerHeight)
+            };
+        }
+        return r;
+    }
+
+    function isDrawable(el, cfg) {
         if (!el || !el.isConnected) { return false; }
         var cs = getComputedStyle(el);
         if (cs.display === 'none' || cs.visibility === 'hidden' || cs.pointerEvents === 'none') {
             return false;
         }
-        var r = el.getBoundingClientRect();
-        if (r.width < 4 || r.height < 4) { return false; }
+        var r = drawableRect(el, cfg);
+        if (r.right - r.left < 4 || r.bottom - r.top < 4) { return false; }
         var vw = window.innerWidth, vh = window.innerHeight;
         if (r.right <= 0 || r.bottom <= 0 || r.left >= vw || r.top >= vh) { return false; }
         // 顶层采样：被弹窗/面板遮住时不能抢笔
         var samples = [
-            [r.left + r.width / 2, r.top + r.height / 2],
+            [(r.left + r.right) / 2, (r.top + r.bottom) / 2],
             [r.left + 8, r.top + 8], [r.right - 8, r.top + 8],
             [r.left + 8, r.bottom - 8], [r.right - 8, r.bottom - 8]
         ];
@@ -195,7 +215,7 @@
             var els = cfg.selector
                 ? Array.prototype.slice.call(document.querySelectorAll(cfg.selector))
                 : [document.getElementById(cfg.id)];
-            els = els.filter(isDrawable);
+            els = els.filter(function (el) { return isDrawable(el, cfg); });
             if (els.length) { found = { cfg: cfg, els: els }; }
         }
         if (!found || eraserActive(found.cfg)) {
@@ -210,7 +230,7 @@
         for (var g = 0; g < activeEls.length; g++) { installFingerGuard(activeEls[g]); }
         var vw = window.innerWidth, vh = window.innerHeight;
         var rects = found.els.map(function (el) {
-            var r = el.getBoundingClientRect();
+            var r = drawableRect(el, found.cfg);
             return [
                 Math.round(Math.max(r.left, 0) * DPR),
                 Math.round(Math.max(r.top, 0) * DPR),

--- a/app/src/main/assets/boox-pen.js
+++ b/app/src/main/assets/boox-pen.js
@@ -297,7 +297,7 @@
     }, true);
 
     /* -------- 原生笔迹回放 -------- */
-    function dispatchPointer(el, type, x, y, pressure, buttons) {
+    function dispatchPointer(el, type, x, y, pressure, buttons, button) {
         var ev = new PointerEvent(type, {
             bubbles: true,
             cancelable: true,
@@ -308,18 +308,20 @@
             clientX: x,
             clientY: y,
             pressure: pressure,
+            button: button,
             buttons: buttons
         });
         el.dispatchEvent(ev);
     }
 
-    function replay(el, pts) {
-        dispatchPointer(el, 'pointerdown', pts[0][0], pts[0][1], pts[0][2], 1);
+    function replay(el, pts, erase) {
+        var button = erase ? 5 : 0, buttons = erase ? 32 : 1;
+        dispatchPointer(el, 'pointerdown', pts[0][0], pts[0][1], pts[0][2], buttons, button);
         for (var i = 1; i < pts.length; i++) {
-            dispatchPointer(el, 'pointermove', pts[i][0], pts[i][1], pts[i][2], 1);
+            dispatchPointer(el, 'pointermove', pts[i][0], pts[i][1], pts[i][2], buttons, -1);
         }
         var last = pts[pts.length - 1];
-        dispatchPointer(el, 'pointerup', last[0], last[1], 0, 0);
+        dispatchPointer(el, 'pointerup', last[0], last[1], 0, 0, button);
     }
 
     // points: [[viewPxX, viewPxY, pressure], ...]，erase: 笔侧橡皮
@@ -346,7 +348,7 @@
             try { window[cfg.eraserToggle](); toggled = true; } catch (e) {}
         }
         try {
-            replay(target, pts);
+            replay(target, pts, erase);
         } finally {
             if (toggled) {
                 try { window[cfg.eraserToggle](); } catch (e) {}

--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -4754,6 +4754,7 @@
             border-radius: 8px; overflow: hidden; cursor: pointer; background: #fff;
             user-select: none; -webkit-user-select: none; touch-action: none;
         }
+        #nbExportThumbs .nb-thumb { touch-action: pan-y; }
         .nb-thumb img { width: 100%; display: block; pointer-events: none; }
         .nb-thumb.current { border-color: var(--accent); }
         .nb-thumb.dragging { opacity: 0.5; border-style: dashed; }
@@ -20905,6 +20906,7 @@ ${i18n('prompt_lecture_gen')}`;
         let lectureDraftDrawing = false;
         let lectureDraftPointerId = null;
         let lectureDraftPointerIsPen = false;
+        let lectureDraftPointerIsEraser = false;
         let lectureDraftLastX = 0;
         let lectureDraftLastY = 0;
         let lectureDraftHistory = [];
@@ -21265,12 +21267,16 @@ ${i18n('prompt_lecture_gen')}`;
         }
 
         function startLectureDraftDraw(e) {
-            if ((!lectureDraftPenEnabled && !lectureDraftEraserEnabled) || lectureDraftDrawing || lectureDraftPanActive) return;
-            if (applePencilMode && !booxReaderIsPen(e)) return;
+            const isPen = booxReaderIsPen(e);
+            if ((!lectureDraftPenEnabled && !lectureDraftEraserEnabled) || lectureDraftDrawing) return;
+            if (!isPen && (applePencilMode || lectureDraftPanActive)) return;
+            // 笔接管先落下的手指平移，原生整笔回放也没有额外 touchstart 可清除此状态。
+            lectureDraftPanActive = false;
             e.preventDefault();
             try { lectureDraftCanvas.setPointerCapture(e.pointerId); } catch (err) {}
             lectureDraftPointerId = e.pointerId;
-            lectureDraftPointerIsPen = booxReaderIsPen(e);
+            lectureDraftPointerIsPen = isPen;
+            lectureDraftPointerIsEraser = isPen && (e.button === 5 || !!(e.buttons & 32));
             lectureDraftDrawing = true;
             const rect = lectureDraftCanvas.getBoundingClientRect();
             lectureDraftLastX = e.clientX - rect.left;
@@ -21288,7 +21294,7 @@ ${i18n('prompt_lecture_gen')}`;
             lectureDraftCtx.moveTo(lectureDraftLastX, lectureDraftLastY);
             lectureDraftCtx.lineTo(x, y);
             
-            if (lectureDraftEraserEnabled) {
+            if (lectureDraftEraserEnabled || lectureDraftPointerIsEraser) {
                 lectureDraftCtx.globalCompositeOperation = 'destination-out';
                 lectureDraftCtx.strokeStyle = 'rgba(0,0,0,1)';
                 lectureDraftCtx.lineWidth = 20;
@@ -21309,6 +21315,7 @@ ${i18n('prompt_lecture_gen')}`;
             if (lectureDraftDrawing && e.pointerId === lectureDraftPointerId) {
                 lectureDraftDrawing = false;
                 lectureDraftPointerId = null;
+                lectureDraftPointerIsEraser = false;
                 lectureDraftCtx.globalCompositeOperation = 'source-over';
                 saveLectureDraftCanvasState();
                 debouncedSaveLectureDraft();
@@ -31661,6 +31668,8 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
         // ==================== 指针输入（书写/橡皮/套索/图形/文本） ====================
         let _nbActivePointerId = null;
+        let _nbActivePointerIsPen = false;
+        let _nbTouchGesture = null;
         function nbEventPoint(e) {
             const c = document.getElementById('nbCanvas');
             const r = c.getBoundingClientRect();
@@ -31705,16 +31714,18 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
             // 沿用阅读器的 touch-action:none + 手指手动滚动，避免 Safari 抢走 Pencil。
             const wrap = document.getElementById('nbCanvasWrap');
-            let gesture = null;
             const fingers = e => Array.from(e.touches).filter(t => t.touchType !== 'stylus');
             const beginGesture = e => {
-                gesture = null;
-                if (!applePencilMode || nbState.drawing
+                _nbTouchGesture = null;
+                if ((nbState.drawing && _nbActivePointerIsPen)
                     || e.target.closest('input, textarea, button')
                     || (document.activeElement?.isContentEditable && document.activeElement.contains(e.target))) return;
                 const ts = fingers(e);
-                if (!ts.length || ts.length > 2 || ts.length !== e.touches.length) return;
-                gesture = {
+                if (!ts.length || ts.length > 2 || ts.length !== e.touches.length
+                    || (!applePencilMode && ts.length !== 2)) return;
+                // 第二根手指接管导航前，撤回第一根手指尚未提交的编辑。
+                nbCancelDrawing();
+                _nbTouchGesture = {
                     count: ts.length,
                     x: ts.reduce((n, t) => n + t.clientX, 0) / ts.length,
                     y: ts.reduce((n, t) => n + t.clientY, 0) / ts.length,
@@ -31723,9 +31734,10 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             };
             wrap.addEventListener('touchstart', beginGesture, { passive: true });
             wrap.addEventListener('touchmove', e => {
-                if (!gesture || !applePencilMode || nbState.drawing) { gesture = null; return; }
+                const gesture = _nbTouchGesture;
+                if (!gesture || nbState.drawing) { _nbTouchGesture = null; return; }
                 const ts = fingers(e);
-                if (ts.length !== gesture.count || ts.length !== e.touches.length) { gesture = null; return; }
+                if (ts.length !== gesture.count || ts.length !== e.touches.length) { _nbTouchGesture = null; return; }
                 const x = ts.reduce((n, t) => n + t.clientX, 0) / ts.length;
                 const y = ts.reduce((n, t) => n + t.clientY, 0) / ts.length;
                 const rect = wrap.getBoundingClientRect();
@@ -31737,16 +31749,49 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 const ratio = nbState.zoom / oldZoom;
                 wrap.scrollLeft = scrollX * ratio - (x - rect.left);
                 wrap.scrollTop = scrollY * ratio - (y - rect.top);
-                gesture = { count: ts.length, x, y, distance };
+                _nbTouchGesture = { count: ts.length, x, y, distance };
                 e.preventDefault();
             }, { passive: false });
             wrap.addEventListener('touchend', beginGesture, { passive: true });
-            wrap.addEventListener('touchcancel', () => { gesture = null; }, { passive: true });
+            wrap.addEventListener('touchcancel', () => { _nbTouchGesture = null; }, { passive: true });
+        }
+
+        function nbCancelDrawing() {
+            const d = nbState.drawing;
+            if (!d) return;
+            nbState.drawing = null;
+            _nbActivePointerId = null;
+            let changed = false;
+            if (d.mode === 'erase') {
+                // i 是每次删除当时的索引；必须逆着删除顺序恢复。
+                changed = d.removed.length > 0;
+                d.removed.slice().reverse().forEach(({ s, i }) => nbState.content.strokes.splice(i, 0, s));
+            } else if (d.mode === 'move') {
+                changed = d.moved;
+                const before = new Map(d.before.map(s => [s.id, s]));
+                for (const s of nbState.content.strokes) {
+                    if (before.has(s.id)) { Object.assign(s, before.get(s.id)); delete s._bb; }
+                }
+                if (nbState.selection) nbState.selection.bbox = nbSelBBox(nbState.selection.ids);
+                nbPositionSelToolbar();
+            } else if (d.mode === 'boxdrag') {
+                changed = true; // 旧自动保存可能已写入拖动中途的位置，即使后来拖回起点也要重存。
+                Object.assign(d.obj, d.before);
+                const el = document.querySelector(`#nbTextLayer [data-id="${d.obj.id}"]`);
+                if (el) { el.style.left = d.obj.x + 'px'; el.style.top = d.obj.y + 'px'; }
+                if (d.kind === 'text') nbPositionTextToolbar(d.obj.id);
+            } else if (d.cancel) {
+                d.cancel();
+            }
+            nbRedraw();
+            if (changed) nbScheduleSave();
         }
 
         function nbPointerDown(e) {
             if (e.button === 2 || nbState.drawing) return;
+            if (e.pointerType === 'touch' && (e.isPrimary === false || _nbTouchGesture)) return;
             if (applePencilMode && !booxReaderIsPen(e)) return;
+            _nbTouchGesture = null;
             nbHidePanel();
             nbHideOutline();
             nbHideTextToolbar();
@@ -31755,6 +31800,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             e.preventDefault();
             try { e.target.setPointerCapture(e.pointerId); } catch (err) {}
             _nbActivePointerId = e.pointerId;
+            _nbActivePointerIsPen = booxReaderIsPen(e);
 
             if (tool === 'pen') {
                 // Boox 原生笔按矩形抢占整个画布，落在文本框/媒体上的笔迹会以回放事件
@@ -31767,7 +31813,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                         document.querySelectorAll('.nb-media-img.selected,.nb-media-audio.selected').forEach(x => x.classList.remove('selected'));
                         document.querySelector(`#nbTextLayer [data-id="${hit.obj.id}"]`)?.classList.add('selected');
                     }
-                    nbState.drawing = { mode: 'boxdrag', kind: hit.kind, obj: hit.obj, last: p, moved: false };
+                    nbState.drawing = { mode: 'boxdrag', kind: hit.kind, obj: hit.obj, before: { x: hit.obj.x, y: hit.obj.y }, last: p, moved: false };
                     nbNativeRefresh();   // 清掉原生层点按留下的墨点
                     return;
                 }
@@ -31791,8 +31837,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             } else if (tool === 'shape') {
                 nbState.drawing = { mode: 'shape', start: p, cur: p, freehand: [p], preview: null };
             } else if (tool === 'text') {
-                nbAddTextBox(p[0], p[1]);
-                nbState.drawing = null;
+                nbState.drawing = { mode: 'text', start: p };
             }
         }
 
@@ -31857,7 +31902,9 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             if (!d || e.pointerId !== _nbActivePointerId) return;
             _nbActivePointerId = null;
             nbState.drawing = null;
-            if (d.mode === 'stroke') {
+            if (d.mode === 'text') {
+                if (e.type !== 'pointercancel') nbAddTextBox(d.start[0], d.start[1]);
+            } else if (d.mode === 'stroke') {
                 const pts = d.stroke.paths[0];
                 if (pts.length >= 1) {
                     nbState.content.strokes.push(d.stroke);
@@ -32270,7 +32317,11 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 if (e.target.classList.contains('nb-tb-corner') || e.target.classList.contains('nb-media-del')) return;
                 const editing = document.activeElement === inner;
                 if (editing && e.target === inner) return;   // 编辑中不拦截光标操作
+                if (nbState.drawing || (e.pointerType === 'touch' && (e.isPrimary === false || _nbTouchGesture))) return;
                 if (applePencilMode && !booxReaderIsPen(e)) return;
+                _nbTouchGesture = null;
+                _nbActivePointerId = e.pointerId;
+                _nbActivePointerIsPen = booxReaderIsPen(e);
                 e.preventDefault();
                 e.stopPropagation();
                 nbSelectTextBox(box.id);
@@ -32291,6 +32342,16 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     if (ev.pointerId !== e.pointerId) return;
                     document.removeEventListener('pointermove', mv);
                     document.removeEventListener('pointerup', up);
+                    document.removeEventListener('pointercancel', up);
+                    nbState.drawing = null;
+                    _nbActivePointerId = null;
+                    if (ev.type === 'pointercancel') {
+                        box.x = ox; box.y = oy;
+                        el.style.left = ox + 'px'; el.style.top = oy + 'px';
+                        nbPositionTextToolbar(box.id);
+                        nbScheduleSave();
+                        return;
+                    }
                     if (moved) {
                         nbScheduleSave();
                     } else {
@@ -32306,8 +32367,10 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                         } catch (err) {}
                     }
                 };
+                nbState.drawing = { mode: 'object', cancel: () => up({ pointerId: e.pointerId, type: 'pointercancel' }) };
                 document.addEventListener('pointermove', mv);
                 document.addEventListener('pointerup', up);
+                document.addEventListener('pointercancel', up);
             });
 
             // 四角缩放：等比调整字号与宽度，对角固定
@@ -32316,9 +32379,15 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 h.className = 'nb-tb-corner';
                 h.dataset.c = c;
                 h.addEventListener('pointerdown', (e) => {
+                    if (nbState.drawing || (e.pointerType === 'touch' && (e.isPrimary === false || _nbTouchGesture))) return;
                     if (applePencilMode && !booxReaderIsPen(e)) return;
+                    _nbTouchGesture = null;
+                    _nbActivePointerId = e.pointerId;
+                    _nbActivePointerIsPen = booxReaderIsPen(e);
                     e.preventDefault();
                     e.stopPropagation();
+                    const before = { x: box.x, y: box.y, w: box.w, fontSize: box.fontSize };
+                    const styleBefore = el.style.cssText, fontBefore = inner.style.fontSize;
                     const s = nbDisplayScale();
                     const w0 = el.offsetWidth, h0 = el.offsetHeight, f0 = box.fontSize || 18;
                     const x0 = box.x, y0 = box.y;
@@ -32348,11 +32417,24 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                         if (ev.pointerId !== e.pointerId) return;
                         document.removeEventListener('pointermove', mv);
                         document.removeEventListener('pointerup', up);
+                        document.removeEventListener('pointercancel', up);
+                        nbState.drawing = null;
+                        _nbActivePointerId = null;
+                        if (ev.type === 'pointercancel') {
+                            Object.assign(box, before);
+                            el.style.cssText = styleBefore;
+                            inner.style.fontSize = fontBefore;
+                            nbPositionTextToolbar(box.id);
+                            nbScheduleSave();
+                            return;
+                        }
                         nbScheduleSave();
                         nbShowTextToolbar(box.id);   // 刷新工具条上的字号状态
                     };
+                    nbState.drawing = { mode: 'object', cancel: () => up({ pointerId: e.pointerId, type: 'pointercancel' }) };
                     document.addEventListener('pointermove', mv);
                     document.addEventListener('pointerup', up);
+                    document.addEventListener('pointercancel', up);
                 });
                 el.appendChild(h);
             });
@@ -32475,7 +32557,11 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             el.appendChild(del);
             el.addEventListener('pointerdown', (e) => {
                 if (e.target.tagName === 'BUTTON') return;
+                if (nbState.drawing || (e.pointerType === 'touch' && (e.isPrimary === false || _nbTouchGesture))) return;
                 if (applePencilMode && !booxReaderIsPen(e)) return;
+                _nbTouchGesture = null;
+                _nbActivePointerId = e.pointerId;
+                _nbActivePointerIsPen = booxReaderIsPen(e);
                 e.preventDefault();
                 e.stopPropagation();
                 document.querySelectorAll('.nb-media-img.selected,.nb-media-audio.selected,.nb-textbox.selected').forEach(x => x.classList.remove('selected'));
@@ -32496,10 +32582,21 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     if (ev.pointerId !== e.pointerId) return;
                     document.removeEventListener('pointermove', mv);
                     document.removeEventListener('pointerup', up);
+                    document.removeEventListener('pointercancel', up);
+                    nbState.drawing = null;
+                    _nbActivePointerId = null;
+                    if (ev.type === 'pointercancel') {
+                        m.x = ox; m.y = oy;
+                        el.style.left = ox + 'px'; el.style.top = oy + 'px';
+                        nbScheduleSave();
+                        return;
+                    }
                     if (moved) nbScheduleSave();
                 };
+                nbState.drawing = { mode: 'object', cancel: () => up({ pointerId: e.pointerId, type: 'pointercancel' }) };
                 document.addEventListener('pointermove', mv);
                 document.addEventListener('pointerup', up);
+                document.addEventListener('pointercancel', up);
             });
             return el;
         }

--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -1024,11 +1024,26 @@
         /* 手写模式必须压过透明套索层的 user-select:text，避免 iPad
            长按或 Pencil 抖动唤起浏览器原生选区/放大镜。 */
         body.reader-pen-mode #readerContainer,
-        body.reader-pen-mode #readerContainer * {
+        body.reader-pen-mode #readerContainer *,
+        body.lecture-pen-mode #lectureViewerContent,
+        body.lecture-pen-mode #lectureViewerContent *,
+        #lectureDraftCanvasWrapper.active,
+        #lectureDraftCanvasWrapper.active *,
+        body:not(.nb-text-mode) #nbCanvasWrap,
+        body:not(.nb-text-mode) #nbCanvasWrap * {
             -webkit-user-select: none !important;
             user-select: none !important;
             -webkit-touch-callout: none !important;
         }
+        /* 文本编辑继续使用原有光标/选区；手写保护与阅读器共用。 */
+        body.lecture-pen-mode #lectureViewerContent :is(input, textarea, [contenteditable="true"], [contenteditable="true"] *),
+        #lectureDraftCanvasWrapper.active :is(input, textarea, [contenteditable="true"], [contenteditable="true"] *),
+        body:not(.nb-text-mode) #nbCanvasWrap :is(input, textarea, [contenteditable="true"], [contenteditable="true"] *) {
+            -webkit-user-select: text !important;
+            user-select: text !important;
+            -webkit-touch-callout: default !important;
+        }
+        body.lecture-pen-mode .eink-lecture-tap-zone { pointer-events: none; }
         /* AI 评论的计数圆点：沿用笔记 marker，换蓝色以区分手写笔记 */
         .annotation-marker.ai-marker {
             background: rgba(59, 130, 246, 0.7);
@@ -4486,12 +4501,13 @@
         }
 
         /* ==================== 笔记模块（page7 + 笔记本编辑器） ==================== */
+        #page7 { padding: 0; }
         .nbhome-grid {
             display: grid;
             grid-template-columns: 1fr 1fr;
             gap: 12px;
             height: 100%;
-            padding: 16px 16px 80px;
+            padding: 0;
             box-sizing: border-box;
         }
         .nbhome-column {
@@ -4635,6 +4651,7 @@
         .nb-page-box canvas { position: absolute; left: 0; top: 0; }
         #nbBgCanvas { z-index: 1; }
         #nbCanvas { z-index: 2; touch-action: none; }
+        body.apple-pencil-mode #nbCanvasWrap { touch-action: none; }
         #nbOverlayCanvas { z-index: 3; pointer-events: none; }
         #nbTextLayer { position: absolute; left: 0; top: 0; z-index: 4; pointer-events: none; transform-origin: 0 0; }
         #nbTextLayer > * { pointer-events: auto; }
@@ -13342,8 +13359,11 @@
 
         function readerPenModeOwnsEventTarget(target) {
             const container = document.getElementById('readerContainer');
-            return !!(penMode && container && target
-                && (target === container || container.contains(target)));
+            if (penMode && container && target
+                && (target === container || container.contains(target))) return true;
+            const element = target && (target.nodeType === 1 ? target : target.parentElement);
+            if (!element || !element.closest || element.closest('input, textarea, [contenteditable="true"]')) return false;
+            return !!element.closest('body.lecture-pen-mode #lectureViewerContent, #lectureDraftCanvasWrapper.active, body:not(.nb-text-mode) #nbCanvasWrap');
         }
 
         function blockReaderNativeSelectionInPenMode(e) {
@@ -13353,13 +13373,11 @@
         }
 
         function clearNativeReaderSelectionInPenMode() {
-            if (!penMode) return;
-            const container = document.getElementById('readerContainer');
             const selection = typeof window.getSelection === 'function' ? window.getSelection() : null;
-            if (!container || !selection || !selection.rangeCount) return;
+            if (!selection || !selection.rangeCount) return;
             const anchor = selection.anchorNode;
             const focus = selection.focusNode;
-            if ((anchor && container.contains(anchor)) || (focus && container.contains(focus))) {
+            if (readerPenModeOwnsEventTarget(anchor) || readerPenModeOwnsEventTarget(focus)) {
                 selection.removeAllRanges();
             }
         }
@@ -20372,24 +20390,20 @@ ${i18n('prompt_lecture_gen')}`;
 
         function toggleLecturePenMode() {
             lecturePenMode = !lecturePenMode;
-            const btn = document.getElementById('lecturePenBtn');
-            const toolbar = document.getElementById('lecturePenToolbar');
+            applyLectureInputMode();
+            if (!lecturePenMode) saveLectureDrawing();
+        }
+
+        function applyLectureInputMode() {
+            document.body.classList.toggle('lecture-pen-mode', lecturePenMode);
+            document.getElementById('lecturePenBtn').classList.toggle('active', lecturePenMode);
+            document.getElementById('lecturePenToolbar').classList.toggle('show', lecturePenMode);
             const canvas = document.getElementById('lectureDrawCanvas');
-            
-            btn.classList.toggle('active', lecturePenMode);
-            
-            if (lecturePenMode) {
-                toolbar.classList.add('show');
-                if (canvas) {
-                    canvas.classList.add('active');
-                }
-            } else {
-                toolbar.classList.remove('show');
-                if (canvas) {
-                    canvas.classList.remove('active');
-                }
-                saveLectureDrawing();
-            }
+            if (canvas) canvas.classList.toggle('active', lecturePenMode);
+            window.__lectureNativeWidth = lecturePenSize;
+            if (lecturePenMode) hideLectureSelectionMenu();
+            clearNativeReaderSelectionInPenMode();
+            if (window.__booxPen && window.__booxPen.syncRegions) window.__booxPen.syncRegions();
         }
 
         function setLecturePenColor(el) {
@@ -20400,6 +20414,7 @@ ${i18n('prompt_lecture_gen')}`;
             document.getElementById('lecturePenEraser').classList.remove('active');
             // 仅本地记忆，不云同步
             try { localStorage.setItem('lecturePenColor', lecturePenColor); } catch(e) {}
+            applyLectureInputMode();
         }
 
         function setLecturePenSize(el) {
@@ -20408,6 +20423,7 @@ ${i18n('prompt_lecture_gen')}`;
             lecturePenSize = parseInt(el.dataset.size);
             // 仅本地记忆，不云同步
             try { localStorage.setItem('lecturePenSize', String(lecturePenSize)); } catch(e) {}
+            applyLectureInputMode();
         }
 
         // 恢复本地记忆的画笔偏好
@@ -20436,6 +20452,7 @@ ${i18n('prompt_lecture_gen')}`;
             if (lecturePenEraser) {
                 document.querySelectorAll('.lecture-pen-color').forEach(c => c.classList.remove('active'));
             }
+            applyLectureInputMode();
         }
 
         function initLectureDrawCanvas() {
@@ -20489,6 +20506,7 @@ ${i18n('prompt_lecture_gen')}`;
                 ro.observe(lectureBody);
                 canvas._resizeObserver = ro;
             }
+            applyLectureInputMode();
         }
 
         // 讲义画布：检查是否应忽略此指针（Apple Pencil 模式下忽略手指）
@@ -20885,6 +20903,8 @@ ${i18n('prompt_lecture_gen')}`;
         let lectureDraftPenColor = '#000000';
         let lectureDraftPenSize = 2;
         let lectureDraftDrawing = false;
+        let lectureDraftPointerId = null;
+        let lectureDraftPointerIsPen = false;
         let lectureDraftLastX = 0;
         let lectureDraftLastY = 0;
         let lectureDraftHistory = [];
@@ -20920,6 +20940,8 @@ ${i18n('prompt_lecture_gen')}`;
                 document.getElementById('lectureDraftMiniBar').style.display = 'block';
             }
             saveLectureDraft();
+            clearNativeReaderSelectionInPenMode();
+            if (window.__booxPen && window.__booxPen.syncRegions) window.__booxPen.syncRegions();
         }
 
         function getLectureDraftKey() {
@@ -21038,10 +21060,11 @@ ${i18n('prompt_lecture_gen')}`;
             lectureDraftCanvas.addEventListener('touchstart', handleLectureDraftTouchStart, { passive: false });
             lectureDraftCanvas.addEventListener('touchmove', handleLectureDraftTouchMove, { passive: false });
             lectureDraftCanvas.addEventListener('touchend', handleLectureDraftTouchEnd);
-            lectureDraftCanvas.addEventListener('mousedown', startLectureDraftDraw);
-            lectureDraftCanvas.addEventListener('mousemove', doLectureDraftDraw);
-            lectureDraftCanvas.addEventListener('mouseup', endLectureDraftDraw);
-            lectureDraftCanvas.addEventListener('mouseleave', endLectureDraftDraw);
+            lectureDraftCanvas.addEventListener('touchcancel', handleLectureDraftTouchEnd);
+            lectureDraftCanvas.addEventListener('pointerdown', startLectureDraftDraw);
+            lectureDraftCanvas.addEventListener('pointermove', doLectureDraftDraw);
+            lectureDraftCanvas.addEventListener('pointerup', endLectureDraftDraw);
+            lectureDraftCanvas.addEventListener('pointercancel', endLectureDraftDraw);
             
             lectureDraftCanvas.bindedEvents = true;
         }
@@ -21101,6 +21124,8 @@ ${i18n('prompt_lecture_gen')}`;
                     }
                 }, 50);
             }
+            clearNativeReaderSelectionInPenMode();
+            if (window.__booxPen && window.__booxPen.syncRegions) window.__booxPen.syncRegions();
         }
 
         function toggleLectureDraftEraser() {
@@ -21129,6 +21154,8 @@ ${i18n('prompt_lecture_gen')}`;
                     }
                 }, 50);
             }
+            clearNativeReaderSelectionInPenMode();
+            if (window.__booxPen && window.__booxPen.syncRegions) window.__booxPen.syncRegions();
         }
 
         function restoreLectureDraftPenSettings() {
@@ -21140,6 +21167,7 @@ ${i18n('prompt_lecture_gen')}`;
             });
             
             lectureDraftPenSize = s.lectureDraftPenSize || 2;
+            window.__lectureDraftNativeWidth = lectureDraftPenSize * 2;
             document.querySelectorAll('#lectureDraftPenTools .pen-size').forEach(sz => {
                 sz.classList.toggle('active', parseInt(sz.dataset.size) === lectureDraftPenSize);
             });
@@ -21160,6 +21188,8 @@ ${i18n('prompt_lecture_gen')}`;
                     }
                 }, 100);
             }
+            clearNativeReaderSelectionInPenMode();
+            if (window.__booxPen && window.__booxPen.syncRegions) window.__booxPen.syncRegions();
         }
 
         function setLectureDraftPenColor(el) {
@@ -21172,10 +21202,13 @@ ${i18n('prompt_lecture_gen')}`;
 
         function setLectureDraftPenSize(el) {
             lectureDraftPenSize = parseInt(el.dataset.size);
+            window.__lectureDraftNativeWidth = lectureDraftPenSize * 2;
             document.querySelectorAll('#lectureDraftPenTools .pen-size').forEach(s => s.classList.remove('active'));
             el.classList.add('active');
             appData.settings.lectureDraftPenSize = lectureDraftPenSize;
             saveData();
+            clearNativeReaderSelectionInPenMode();
+            if (window.__booxPen && window.__booxPen.syncRegions) window.__booxPen.syncRegions();
         }
 
         function formatLectureDraftText(type) {
@@ -21197,85 +21230,47 @@ ${i18n('prompt_lecture_gen')}`;
         let lectureDraftPanLastY = 0;
 
         function handleLectureDraftTouchStart(e) {
+            lectureDraftPanActive = false;
             if (!lectureDraftPenEnabled && !lectureDraftEraserEnabled) return;
-            if (e.touches.length === 2) {
-                e.preventDefault();
-                lectureDraftDrawing = false;
-                lectureDraftPanActive = true;
-                const cx = (e.touches[0].clientX + e.touches[1].clientX) / 2;
-                const cy = (e.touches[0].clientY + e.touches[1].clientY) / 2;
-                lectureDraftPanLastX = cx;
-                lectureDraftPanLastY = cy;
-                return;
-            }
-            if (e.touches.length !== 1) return;
-            e.preventDefault();
-            lectureDraftDrawing = true;
-            const touch = e.touches[0];
-            const rect = lectureDraftCanvas.getBoundingClientRect();
-            lectureDraftLastX = touch.clientX - rect.left;
-            lectureDraftLastY = touch.clientY - rect.top;
+            if (lectureDraftDrawing && lectureDraftPointerIsPen) return;
+            const touches = Array.from(e.touches);
+            if (touches.some(t => t.touchType === 'stylus')) return;
+            if (touches.length !== 2 && !(applePencilMode && touches.length === 1)) return;
+            endLectureDraftDraw({ pointerId: lectureDraftPointerId });
+            lectureDraftPanActive = true;
+            lectureDraftPanLastX = touches.reduce((n, t) => n + t.clientX, 0) / touches.length;
+            lectureDraftPanLastY = touches.reduce((n, t) => n + t.clientY, 0) / touches.length;
         }
 
         function handleLectureDraftTouchMove(e) {
-            if (e.touches.length === 2 && lectureDraftPanActive) {
-                e.preventDefault();
-                const cx = (e.touches[0].clientX + e.touches[1].clientX) / 2;
-                const cy = (e.touches[0].clientY + e.touches[1].clientY) / 2;
-                const dx = cx - lectureDraftPanLastX;
-                const dy = cy - lectureDraftPanLastY;
-                const wrapper = document.getElementById('lectureDraftCanvasWrapper');
-                if (wrapper) {
-                    wrapper.scrollLeft -= dx;
-                    wrapper.scrollTop -= dy;
-                }
-                lectureDraftPanLastX = cx;
-                lectureDraftPanLastY = cy;
-                return;
+            if (!lectureDraftPanActive) return;
+            const touches = Array.from(e.touches);
+            if (touches.some(t => t.touchType === 'stylus')) return;
+            if (touches.length !== 2 && !(applePencilMode && touches.length === 1)) return;
+            const cx = touches.reduce((n, t) => n + t.clientX, 0) / touches.length;
+            const cy = touches.reduce((n, t) => n + t.clientY, 0) / touches.length;
+            const wrapper = document.getElementById('lectureDraftCanvasWrapper');
+            if (wrapper) {
+                wrapper.scrollLeft -= cx - lectureDraftPanLastX;
+                wrapper.scrollTop -= cy - lectureDraftPanLastY;
             }
-            if (!lectureDraftDrawing || (!lectureDraftPenEnabled && !lectureDraftEraserEnabled)) return;
-            if (e.touches.length !== 1) return;
+            lectureDraftPanLastX = cx;
+            lectureDraftPanLastY = cy;
             e.preventDefault();
-            const touch = e.touches[0];
-            const rect = lectureDraftCanvas.getBoundingClientRect();
-            const x = touch.clientX - rect.left;
-            const y = touch.clientY - rect.top;
-            
-            lectureDraftCtx.beginPath();
-            lectureDraftCtx.moveTo(lectureDraftLastX, lectureDraftLastY);
-            lectureDraftCtx.lineTo(x, y);
-            
-            if (lectureDraftEraserEnabled) {
-                lectureDraftCtx.globalCompositeOperation = 'destination-out';
-                lectureDraftCtx.strokeStyle = 'rgba(0,0,0,1)';
-                lectureDraftCtx.lineWidth = 20;
-            } else {
-                lectureDraftCtx.globalCompositeOperation = 'source-over';
-                lectureDraftCtx.strokeStyle = lectureDraftPenColor;
-                lectureDraftCtx.lineWidth = lectureDraftPenSize * 2;
-            }
-            lectureDraftCtx.lineCap = 'round';
-            lectureDraftCtx.lineJoin = 'round';
-            lectureDraftCtx.stroke();
-            
-            lectureDraftLastX = x;
-            lectureDraftLastY = y;
         }
 
         function handleLectureDraftTouchEnd(e) {
-            if (e.touches.length < 2) {
-                lectureDraftPanActive = false;
-            }
-            if (lectureDraftDrawing) {
-                lectureDraftDrawing = false;
-                lectureDraftCtx.globalCompositeOperation = 'source-over';
-                saveLectureDraftCanvasState();
-                debouncedSaveLectureDraft();
-            }
+            lectureDraftPanActive = false;
+            if (e.touches.length) handleLectureDraftTouchStart(e);
         }
 
         function startLectureDraftDraw(e) {
-            if (!lectureDraftPenEnabled && !lectureDraftEraserEnabled) return;
+            if ((!lectureDraftPenEnabled && !lectureDraftEraserEnabled) || lectureDraftDrawing || lectureDraftPanActive) return;
+            if (applePencilMode && !booxReaderIsPen(e)) return;
+            e.preventDefault();
+            try { lectureDraftCanvas.setPointerCapture(e.pointerId); } catch (err) {}
+            lectureDraftPointerId = e.pointerId;
+            lectureDraftPointerIsPen = booxReaderIsPen(e);
             lectureDraftDrawing = true;
             const rect = lectureDraftCanvas.getBoundingClientRect();
             lectureDraftLastX = e.clientX - rect.left;
@@ -21283,7 +21278,8 @@ ${i18n('prompt_lecture_gen')}`;
         }
 
         function doLectureDraftDraw(e) {
-            if (!lectureDraftDrawing || (!lectureDraftPenEnabled && !lectureDraftEraserEnabled)) return;
+            if (!lectureDraftDrawing || e.pointerId !== lectureDraftPointerId || (!lectureDraftPenEnabled && !lectureDraftEraserEnabled)) return;
+            e.preventDefault();
             const rect = lectureDraftCanvas.getBoundingClientRect();
             const x = e.clientX - rect.left;
             const y = e.clientY - rect.top;
@@ -21309,9 +21305,10 @@ ${i18n('prompt_lecture_gen')}`;
             lectureDraftLastY = y;
         }
 
-        function endLectureDraftDraw() {
-            if (lectureDraftDrawing) {
+        function endLectureDraftDraw(e) {
+            if (lectureDraftDrawing && e.pointerId === lectureDraftPointerId) {
                 lectureDraftDrawing = false;
+                lectureDraftPointerId = null;
                 lectureDraftCtx.globalCompositeOperation = 'source-over';
                 saveLectureDraftCanvasState();
                 debouncedSaveLectureDraft();
@@ -21430,6 +21427,7 @@ ${i18n('prompt_lecture_gen')}`;
         function handleLectureSelection(e) {
             // 延时足够让iPad完成选区，但在弹出原生菜单前拦截
             setTimeout(() => {
+                if (lecturePenMode) return;
                 const selection = window.getSelection();
                 const text = selection.toString().trim();
 
@@ -31309,7 +31307,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             if (!wrap || !document.getElementById('nbEditor').classList.contains('show')) return;
             const availW = wrap.clientWidth, availH = wrap.clientHeight;
             if (availW <= 0 || availH <= 0) return;
-            nbState.fitScale = Math.min(availW / NB_PAGE_W, availH / NB_PAGE_H);
+            nbState.fitScale = availW / NB_PAGE_W;
             const s = nbDisplayScale();
             const cssW = Math.round(NB_PAGE_W * s), cssH = Math.round(NB_PAGE_H * s);
             const box = document.getElementById('nbPageBox');
@@ -31586,6 +31584,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             document.querySelectorAll('.nb-brush-btn').forEach((b, i) =>
                 b.classList.toggle('active', tool === 'pen' && i === nbState.brushIndex));
             document.body.classList.toggle('nb-text-mode', tool === 'text');
+            clearNativeReaderSelectionInPenMode();
         }
         function toggleNbEraser() {
             nbSetTool(nbState.tool === 'eraser' ? (nbState.prevTool || 'pen') : 'eraser');
@@ -31661,6 +31660,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         }
 
         // ==================== 指针输入（书写/橡皮/套索/图形/文本） ====================
+        let _nbActivePointerId = null;
         function nbEventPoint(e) {
             const c = document.getElementById('nbCanvas');
             const r = c.getBoundingClientRect();
@@ -31702,10 +31702,51 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             c.addEventListener('pointerup', nbPointerUp);
             c.addEventListener('pointercancel', nbPointerUp);
             c.addEventListener('contextmenu', e => e.preventDefault());
+
+            // 沿用阅读器的 touch-action:none + 手指手动滚动，避免 Safari 抢走 Pencil。
+            const wrap = document.getElementById('nbCanvasWrap');
+            let gesture = null;
+            const fingers = e => Array.from(e.touches).filter(t => t.touchType !== 'stylus');
+            const beginGesture = e => {
+                gesture = null;
+                if (!applePencilMode || nbState.drawing
+                    || e.target.closest('input, textarea, button')
+                    || (document.activeElement?.isContentEditable && document.activeElement.contains(e.target))) return;
+                const ts = fingers(e);
+                if (!ts.length || ts.length > 2 || ts.length !== e.touches.length) return;
+                gesture = {
+                    count: ts.length,
+                    x: ts.reduce((n, t) => n + t.clientX, 0) / ts.length,
+                    y: ts.reduce((n, t) => n + t.clientY, 0) / ts.length,
+                    distance: ts.length === 2 ? Math.hypot(ts[1].clientX - ts[0].clientX, ts[1].clientY - ts[0].clientY) : 0
+                };
+            };
+            wrap.addEventListener('touchstart', beginGesture, { passive: true });
+            wrap.addEventListener('touchmove', e => {
+                if (!gesture || !applePencilMode || nbState.drawing) { gesture = null; return; }
+                const ts = fingers(e);
+                if (ts.length !== gesture.count || ts.length !== e.touches.length) { gesture = null; return; }
+                const x = ts.reduce((n, t) => n + t.clientX, 0) / ts.length;
+                const y = ts.reduce((n, t) => n + t.clientY, 0) / ts.length;
+                const rect = wrap.getBoundingClientRect();
+                const oldZoom = nbState.zoom;
+                const distance = ts.length === 2 ? Math.hypot(ts[1].clientX - ts[0].clientX, ts[1].clientY - ts[0].clientY) : 0;
+                const scrollX = wrap.scrollLeft + gesture.x - rect.left;
+                const scrollY = wrap.scrollTop + gesture.y - rect.top;
+                if (distance > 0 && gesture.distance > 0 && distance !== gesture.distance) nbZoomSet(oldZoom * distance / gesture.distance * 100);
+                const ratio = nbState.zoom / oldZoom;
+                wrap.scrollLeft = scrollX * ratio - (x - rect.left);
+                wrap.scrollTop = scrollY * ratio - (y - rect.top);
+                gesture = { count: ts.length, x, y, distance };
+                e.preventDefault();
+            }, { passive: false });
+            wrap.addEventListener('touchend', beginGesture, { passive: true });
+            wrap.addEventListener('touchcancel', () => { gesture = null; }, { passive: true });
         }
 
         function nbPointerDown(e) {
-            if (e.button === 2) return;
+            if (e.button === 2 || nbState.drawing) return;
+            if (applePencilMode && !booxReaderIsPen(e)) return;
             nbHidePanel();
             nbHideOutline();
             nbHideTextToolbar();
@@ -31713,6 +31754,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             const tool = nbState.tool;
             e.preventDefault();
             try { e.target.setPointerCapture(e.pointerId); } catch (err) {}
+            _nbActivePointerId = e.pointerId;
 
             if (tool === 'pen') {
                 // Boox 原生笔按矩形抢占整个画布，落在文本框/媒体上的笔迹会以回放事件
@@ -31756,7 +31798,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
         function nbPointerMove(e) {
             const d = nbState.drawing;
-            if (!d) return;
+            if (!d || e.pointerId !== _nbActivePointerId) return;
             e.preventDefault();
             const events = (typeof e.getCoalescedEvents === 'function' && e.getCoalescedEvents().length) ? e.getCoalescedEvents() : [e];
             for (const ev of events) {
@@ -31812,7 +31854,8 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
         function nbPointerUp(e) {
             const d = nbState.drawing;
-            if (!d) return;
+            if (!d || e.pointerId !== _nbActivePointerId) return;
+            _nbActivePointerId = null;
             nbState.drawing = null;
             if (d.mode === 'stroke') {
                 const pts = d.stroke.paths[0];
@@ -32227,6 +32270,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 if (e.target.classList.contains('nb-tb-corner') || e.target.classList.contains('nb-media-del')) return;
                 const editing = document.activeElement === inner;
                 if (editing && e.target === inner) return;   // 编辑中不拦截光标操作
+                if (applePencilMode && !booxReaderIsPen(e)) return;
                 e.preventDefault();
                 e.stopPropagation();
                 nbSelectTextBox(box.id);
@@ -32234,6 +32278,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 const sx = e.clientX, sy = e.clientY, ox = box.x, oy = box.y;
                 let moved = false;
                 const mv = (ev) => {
+                    if (ev.pointerId !== e.pointerId) return;
                     const dx = (ev.clientX - sx) / s, dy = (ev.clientY - sy) / s;
                     if (Math.abs(dx) > 2 || Math.abs(dy) > 2) moved = true;
                     box.x = Math.round(ox + dx);
@@ -32242,7 +32287,8 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     el.style.top = box.y + 'px';
                     nbPositionTextToolbar(box.id);
                 };
-                const up = () => {
+                const up = (ev) => {
+                    if (ev.pointerId !== e.pointerId) return;
                     document.removeEventListener('pointermove', mv);
                     document.removeEventListener('pointerup', up);
                     if (moved) {
@@ -32270,6 +32316,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 h.className = 'nb-tb-corner';
                 h.dataset.c = c;
                 h.addEventListener('pointerdown', (e) => {
+                    if (applePencilMode && !booxReaderIsPen(e)) return;
                     e.preventDefault();
                     e.stopPropagation();
                     const s = nbDisplayScale();
@@ -32283,6 +32330,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     const d0 = Math.max(10, Math.hypot(cx0 - ax, cy0 - ay));
                     const sx = e.clientX, sy = e.clientY;
                     const mv = (ev) => {
+                        if (ev.pointerId !== e.pointerId) return;
                         const px = (ev.clientX - sx) / s + (c.includes('l') ? x0 : x0 + w0);
                         const py = (ev.clientY - sy) / s + (c.includes('t') ? y0 : y0 + h0);
                         const k = Math.max(0.2, Math.min(6, Math.hypot(px - ax, py - ay) / d0));
@@ -32296,7 +32344,8 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                         inner.style.fontSize = box.fontSize + 'px';
                         nbPositionTextToolbar(box.id);
                     };
-                    const up = () => {
+                    const up = (ev) => {
+                        if (ev.pointerId !== e.pointerId) return;
                         document.removeEventListener('pointermove', mv);
                         document.removeEventListener('pointerup', up);
                         nbScheduleSave();
@@ -32426,6 +32475,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             el.appendChild(del);
             el.addEventListener('pointerdown', (e) => {
                 if (e.target.tagName === 'BUTTON') return;
+                if (applePencilMode && !booxReaderIsPen(e)) return;
                 e.preventDefault();
                 e.stopPropagation();
                 document.querySelectorAll('.nb-media-img.selected,.nb-media-audio.selected,.nb-textbox.selected').forEach(x => x.classList.remove('selected'));
@@ -32434,6 +32484,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 const sx = e.clientX, sy = e.clientY, ox = m.x, oy = m.y;
                 let moved = false;
                 const mv = (ev) => {
+                    if (ev.pointerId !== e.pointerId) return;
                     const dx = (ev.clientX - sx) / s, dy = (ev.clientY - sy) / s;
                     if (Math.abs(dx) > 2 || Math.abs(dy) > 2) moved = true;
                     m.x = Math.round(ox + dx);
@@ -32441,7 +32492,8 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     el.style.left = m.x + 'px';
                     el.style.top = m.y + 'px';
                 };
-                const up = () => {
+                const up = (ev) => {
+                    if (ev.pointerId !== e.pointerId) return;
                     document.removeEventListener('pointermove', mv);
                     document.removeEventListener('pointerup', up);
                     if (moved) nbScheduleSave();
@@ -32596,7 +32648,6 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             const l = document.getElementById('nbZoomLabel');
             if (l) l.textContent = Math.round(nbState.zoom * 100) + '%';
             nbLayout();
-            nbRenderTexts();
         }
 
         function nbShowExportModal() {

--- a/docs/index.html
+++ b/docs/index.html
@@ -4754,6 +4754,7 @@
             border-radius: 8px; overflow: hidden; cursor: pointer; background: #fff;
             user-select: none; -webkit-user-select: none; touch-action: none;
         }
+        #nbExportThumbs .nb-thumb { touch-action: pan-y; }
         .nb-thumb img { width: 100%; display: block; pointer-events: none; }
         .nb-thumb.current { border-color: var(--accent); }
         .nb-thumb.dragging { opacity: 0.5; border-style: dashed; }
@@ -20905,6 +20906,7 @@ ${i18n('prompt_lecture_gen')}`;
         let lectureDraftDrawing = false;
         let lectureDraftPointerId = null;
         let lectureDraftPointerIsPen = false;
+        let lectureDraftPointerIsEraser = false;
         let lectureDraftLastX = 0;
         let lectureDraftLastY = 0;
         let lectureDraftHistory = [];
@@ -21265,12 +21267,16 @@ ${i18n('prompt_lecture_gen')}`;
         }
 
         function startLectureDraftDraw(e) {
-            if ((!lectureDraftPenEnabled && !lectureDraftEraserEnabled) || lectureDraftDrawing || lectureDraftPanActive) return;
-            if (applePencilMode && !booxReaderIsPen(e)) return;
+            const isPen = booxReaderIsPen(e);
+            if ((!lectureDraftPenEnabled && !lectureDraftEraserEnabled) || lectureDraftDrawing) return;
+            if (!isPen && (applePencilMode || lectureDraftPanActive)) return;
+            // 笔接管先落下的手指平移，原生整笔回放也没有额外 touchstart 可清除此状态。
+            lectureDraftPanActive = false;
             e.preventDefault();
             try { lectureDraftCanvas.setPointerCapture(e.pointerId); } catch (err) {}
             lectureDraftPointerId = e.pointerId;
-            lectureDraftPointerIsPen = booxReaderIsPen(e);
+            lectureDraftPointerIsPen = isPen;
+            lectureDraftPointerIsEraser = isPen && (e.button === 5 || !!(e.buttons & 32));
             lectureDraftDrawing = true;
             const rect = lectureDraftCanvas.getBoundingClientRect();
             lectureDraftLastX = e.clientX - rect.left;
@@ -21288,7 +21294,7 @@ ${i18n('prompt_lecture_gen')}`;
             lectureDraftCtx.moveTo(lectureDraftLastX, lectureDraftLastY);
             lectureDraftCtx.lineTo(x, y);
             
-            if (lectureDraftEraserEnabled) {
+            if (lectureDraftEraserEnabled || lectureDraftPointerIsEraser) {
                 lectureDraftCtx.globalCompositeOperation = 'destination-out';
                 lectureDraftCtx.strokeStyle = 'rgba(0,0,0,1)';
                 lectureDraftCtx.lineWidth = 20;
@@ -21309,6 +21315,7 @@ ${i18n('prompt_lecture_gen')}`;
             if (lectureDraftDrawing && e.pointerId === lectureDraftPointerId) {
                 lectureDraftDrawing = false;
                 lectureDraftPointerId = null;
+                lectureDraftPointerIsEraser = false;
                 lectureDraftCtx.globalCompositeOperation = 'source-over';
                 saveLectureDraftCanvasState();
                 debouncedSaveLectureDraft();
@@ -31661,6 +31668,8 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
         // ==================== 指针输入（书写/橡皮/套索/图形/文本） ====================
         let _nbActivePointerId = null;
+        let _nbActivePointerIsPen = false;
+        let _nbTouchGesture = null;
         function nbEventPoint(e) {
             const c = document.getElementById('nbCanvas');
             const r = c.getBoundingClientRect();
@@ -31705,16 +31714,18 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
             // 沿用阅读器的 touch-action:none + 手指手动滚动，避免 Safari 抢走 Pencil。
             const wrap = document.getElementById('nbCanvasWrap');
-            let gesture = null;
             const fingers = e => Array.from(e.touches).filter(t => t.touchType !== 'stylus');
             const beginGesture = e => {
-                gesture = null;
-                if (!applePencilMode || nbState.drawing
+                _nbTouchGesture = null;
+                if ((nbState.drawing && _nbActivePointerIsPen)
                     || e.target.closest('input, textarea, button')
                     || (document.activeElement?.isContentEditable && document.activeElement.contains(e.target))) return;
                 const ts = fingers(e);
-                if (!ts.length || ts.length > 2 || ts.length !== e.touches.length) return;
-                gesture = {
+                if (!ts.length || ts.length > 2 || ts.length !== e.touches.length
+                    || (!applePencilMode && ts.length !== 2)) return;
+                // 第二根手指接管导航前，撤回第一根手指尚未提交的编辑。
+                nbCancelDrawing();
+                _nbTouchGesture = {
                     count: ts.length,
                     x: ts.reduce((n, t) => n + t.clientX, 0) / ts.length,
                     y: ts.reduce((n, t) => n + t.clientY, 0) / ts.length,
@@ -31723,9 +31734,10 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             };
             wrap.addEventListener('touchstart', beginGesture, { passive: true });
             wrap.addEventListener('touchmove', e => {
-                if (!gesture || !applePencilMode || nbState.drawing) { gesture = null; return; }
+                const gesture = _nbTouchGesture;
+                if (!gesture || nbState.drawing) { _nbTouchGesture = null; return; }
                 const ts = fingers(e);
-                if (ts.length !== gesture.count || ts.length !== e.touches.length) { gesture = null; return; }
+                if (ts.length !== gesture.count || ts.length !== e.touches.length) { _nbTouchGesture = null; return; }
                 const x = ts.reduce((n, t) => n + t.clientX, 0) / ts.length;
                 const y = ts.reduce((n, t) => n + t.clientY, 0) / ts.length;
                 const rect = wrap.getBoundingClientRect();
@@ -31737,16 +31749,49 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 const ratio = nbState.zoom / oldZoom;
                 wrap.scrollLeft = scrollX * ratio - (x - rect.left);
                 wrap.scrollTop = scrollY * ratio - (y - rect.top);
-                gesture = { count: ts.length, x, y, distance };
+                _nbTouchGesture = { count: ts.length, x, y, distance };
                 e.preventDefault();
             }, { passive: false });
             wrap.addEventListener('touchend', beginGesture, { passive: true });
-            wrap.addEventListener('touchcancel', () => { gesture = null; }, { passive: true });
+            wrap.addEventListener('touchcancel', () => { _nbTouchGesture = null; }, { passive: true });
+        }
+
+        function nbCancelDrawing() {
+            const d = nbState.drawing;
+            if (!d) return;
+            nbState.drawing = null;
+            _nbActivePointerId = null;
+            let changed = false;
+            if (d.mode === 'erase') {
+                // i 是每次删除当时的索引；必须逆着删除顺序恢复。
+                changed = d.removed.length > 0;
+                d.removed.slice().reverse().forEach(({ s, i }) => nbState.content.strokes.splice(i, 0, s));
+            } else if (d.mode === 'move') {
+                changed = d.moved;
+                const before = new Map(d.before.map(s => [s.id, s]));
+                for (const s of nbState.content.strokes) {
+                    if (before.has(s.id)) { Object.assign(s, before.get(s.id)); delete s._bb; }
+                }
+                if (nbState.selection) nbState.selection.bbox = nbSelBBox(nbState.selection.ids);
+                nbPositionSelToolbar();
+            } else if (d.mode === 'boxdrag') {
+                changed = true; // 旧自动保存可能已写入拖动中途的位置，即使后来拖回起点也要重存。
+                Object.assign(d.obj, d.before);
+                const el = document.querySelector(`#nbTextLayer [data-id="${d.obj.id}"]`);
+                if (el) { el.style.left = d.obj.x + 'px'; el.style.top = d.obj.y + 'px'; }
+                if (d.kind === 'text') nbPositionTextToolbar(d.obj.id);
+            } else if (d.cancel) {
+                d.cancel();
+            }
+            nbRedraw();
+            if (changed) nbScheduleSave();
         }
 
         function nbPointerDown(e) {
             if (e.button === 2 || nbState.drawing) return;
+            if (e.pointerType === 'touch' && (e.isPrimary === false || _nbTouchGesture)) return;
             if (applePencilMode && !booxReaderIsPen(e)) return;
+            _nbTouchGesture = null;
             nbHidePanel();
             nbHideOutline();
             nbHideTextToolbar();
@@ -31755,6 +31800,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             e.preventDefault();
             try { e.target.setPointerCapture(e.pointerId); } catch (err) {}
             _nbActivePointerId = e.pointerId;
+            _nbActivePointerIsPen = booxReaderIsPen(e);
 
             if (tool === 'pen') {
                 // Boox 原生笔按矩形抢占整个画布，落在文本框/媒体上的笔迹会以回放事件
@@ -31767,7 +31813,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                         document.querySelectorAll('.nb-media-img.selected,.nb-media-audio.selected').forEach(x => x.classList.remove('selected'));
                         document.querySelector(`#nbTextLayer [data-id="${hit.obj.id}"]`)?.classList.add('selected');
                     }
-                    nbState.drawing = { mode: 'boxdrag', kind: hit.kind, obj: hit.obj, last: p, moved: false };
+                    nbState.drawing = { mode: 'boxdrag', kind: hit.kind, obj: hit.obj, before: { x: hit.obj.x, y: hit.obj.y }, last: p, moved: false };
                     nbNativeRefresh();   // 清掉原生层点按留下的墨点
                     return;
                 }
@@ -31791,8 +31837,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             } else if (tool === 'shape') {
                 nbState.drawing = { mode: 'shape', start: p, cur: p, freehand: [p], preview: null };
             } else if (tool === 'text') {
-                nbAddTextBox(p[0], p[1]);
-                nbState.drawing = null;
+                nbState.drawing = { mode: 'text', start: p };
             }
         }
 
@@ -31857,7 +31902,9 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             if (!d || e.pointerId !== _nbActivePointerId) return;
             _nbActivePointerId = null;
             nbState.drawing = null;
-            if (d.mode === 'stroke') {
+            if (d.mode === 'text') {
+                if (e.type !== 'pointercancel') nbAddTextBox(d.start[0], d.start[1]);
+            } else if (d.mode === 'stroke') {
                 const pts = d.stroke.paths[0];
                 if (pts.length >= 1) {
                     nbState.content.strokes.push(d.stroke);
@@ -32270,7 +32317,11 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 if (e.target.classList.contains('nb-tb-corner') || e.target.classList.contains('nb-media-del')) return;
                 const editing = document.activeElement === inner;
                 if (editing && e.target === inner) return;   // 编辑中不拦截光标操作
+                if (nbState.drawing || (e.pointerType === 'touch' && (e.isPrimary === false || _nbTouchGesture))) return;
                 if (applePencilMode && !booxReaderIsPen(e)) return;
+                _nbTouchGesture = null;
+                _nbActivePointerId = e.pointerId;
+                _nbActivePointerIsPen = booxReaderIsPen(e);
                 e.preventDefault();
                 e.stopPropagation();
                 nbSelectTextBox(box.id);
@@ -32291,6 +32342,16 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     if (ev.pointerId !== e.pointerId) return;
                     document.removeEventListener('pointermove', mv);
                     document.removeEventListener('pointerup', up);
+                    document.removeEventListener('pointercancel', up);
+                    nbState.drawing = null;
+                    _nbActivePointerId = null;
+                    if (ev.type === 'pointercancel') {
+                        box.x = ox; box.y = oy;
+                        el.style.left = ox + 'px'; el.style.top = oy + 'px';
+                        nbPositionTextToolbar(box.id);
+                        nbScheduleSave();
+                        return;
+                    }
                     if (moved) {
                         nbScheduleSave();
                     } else {
@@ -32306,8 +32367,10 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                         } catch (err) {}
                     }
                 };
+                nbState.drawing = { mode: 'object', cancel: () => up({ pointerId: e.pointerId, type: 'pointercancel' }) };
                 document.addEventListener('pointermove', mv);
                 document.addEventListener('pointerup', up);
+                document.addEventListener('pointercancel', up);
             });
 
             // 四角缩放：等比调整字号与宽度，对角固定
@@ -32316,9 +32379,15 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 h.className = 'nb-tb-corner';
                 h.dataset.c = c;
                 h.addEventListener('pointerdown', (e) => {
+                    if (nbState.drawing || (e.pointerType === 'touch' && (e.isPrimary === false || _nbTouchGesture))) return;
                     if (applePencilMode && !booxReaderIsPen(e)) return;
+                    _nbTouchGesture = null;
+                    _nbActivePointerId = e.pointerId;
+                    _nbActivePointerIsPen = booxReaderIsPen(e);
                     e.preventDefault();
                     e.stopPropagation();
+                    const before = { x: box.x, y: box.y, w: box.w, fontSize: box.fontSize };
+                    const styleBefore = el.style.cssText, fontBefore = inner.style.fontSize;
                     const s = nbDisplayScale();
                     const w0 = el.offsetWidth, h0 = el.offsetHeight, f0 = box.fontSize || 18;
                     const x0 = box.x, y0 = box.y;
@@ -32348,11 +32417,24 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                         if (ev.pointerId !== e.pointerId) return;
                         document.removeEventListener('pointermove', mv);
                         document.removeEventListener('pointerup', up);
+                        document.removeEventListener('pointercancel', up);
+                        nbState.drawing = null;
+                        _nbActivePointerId = null;
+                        if (ev.type === 'pointercancel') {
+                            Object.assign(box, before);
+                            el.style.cssText = styleBefore;
+                            inner.style.fontSize = fontBefore;
+                            nbPositionTextToolbar(box.id);
+                            nbScheduleSave();
+                            return;
+                        }
                         nbScheduleSave();
                         nbShowTextToolbar(box.id);   // 刷新工具条上的字号状态
                     };
+                    nbState.drawing = { mode: 'object', cancel: () => up({ pointerId: e.pointerId, type: 'pointercancel' }) };
                     document.addEventListener('pointermove', mv);
                     document.addEventListener('pointerup', up);
+                    document.addEventListener('pointercancel', up);
                 });
                 el.appendChild(h);
             });
@@ -32475,7 +32557,11 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             el.appendChild(del);
             el.addEventListener('pointerdown', (e) => {
                 if (e.target.tagName === 'BUTTON') return;
+                if (nbState.drawing || (e.pointerType === 'touch' && (e.isPrimary === false || _nbTouchGesture))) return;
                 if (applePencilMode && !booxReaderIsPen(e)) return;
+                _nbTouchGesture = null;
+                _nbActivePointerId = e.pointerId;
+                _nbActivePointerIsPen = booxReaderIsPen(e);
                 e.preventDefault();
                 e.stopPropagation();
                 document.querySelectorAll('.nb-media-img.selected,.nb-media-audio.selected,.nb-textbox.selected').forEach(x => x.classList.remove('selected'));
@@ -32496,10 +32582,21 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     if (ev.pointerId !== e.pointerId) return;
                     document.removeEventListener('pointermove', mv);
                     document.removeEventListener('pointerup', up);
+                    document.removeEventListener('pointercancel', up);
+                    nbState.drawing = null;
+                    _nbActivePointerId = null;
+                    if (ev.type === 'pointercancel') {
+                        m.x = ox; m.y = oy;
+                        el.style.left = ox + 'px'; el.style.top = oy + 'px';
+                        nbScheduleSave();
+                        return;
+                    }
                     if (moved) nbScheduleSave();
                 };
+                nbState.drawing = { mode: 'object', cancel: () => up({ pointerId: e.pointerId, type: 'pointercancel' }) };
                 document.addEventListener('pointermove', mv);
                 document.addEventListener('pointerup', up);
+                document.addEventListener('pointercancel', up);
             });
             return el;
         }

--- a/docs/index.html
+++ b/docs/index.html
@@ -1024,11 +1024,26 @@
         /* 手写模式必须压过透明套索层的 user-select:text，避免 iPad
            长按或 Pencil 抖动唤起浏览器原生选区/放大镜。 */
         body.reader-pen-mode #readerContainer,
-        body.reader-pen-mode #readerContainer * {
+        body.reader-pen-mode #readerContainer *,
+        body.lecture-pen-mode #lectureViewerContent,
+        body.lecture-pen-mode #lectureViewerContent *,
+        #lectureDraftCanvasWrapper.active,
+        #lectureDraftCanvasWrapper.active *,
+        body:not(.nb-text-mode) #nbCanvasWrap,
+        body:not(.nb-text-mode) #nbCanvasWrap * {
             -webkit-user-select: none !important;
             user-select: none !important;
             -webkit-touch-callout: none !important;
         }
+        /* 文本编辑继续使用原有光标/选区；手写保护与阅读器共用。 */
+        body.lecture-pen-mode #lectureViewerContent :is(input, textarea, [contenteditable="true"], [contenteditable="true"] *),
+        #lectureDraftCanvasWrapper.active :is(input, textarea, [contenteditable="true"], [contenteditable="true"] *),
+        body:not(.nb-text-mode) #nbCanvasWrap :is(input, textarea, [contenteditable="true"], [contenteditable="true"] *) {
+            -webkit-user-select: text !important;
+            user-select: text !important;
+            -webkit-touch-callout: default !important;
+        }
+        body.lecture-pen-mode .eink-lecture-tap-zone { pointer-events: none; }
         /* AI 评论的计数圆点：沿用笔记 marker，换蓝色以区分手写笔记 */
         .annotation-marker.ai-marker {
             background: rgba(59, 130, 246, 0.7);
@@ -4486,12 +4501,13 @@
         }
 
         /* ==================== 笔记模块（page7 + 笔记本编辑器） ==================== */
+        #page7 { padding: 0; }
         .nbhome-grid {
             display: grid;
             grid-template-columns: 1fr 1fr;
             gap: 12px;
             height: 100%;
-            padding: 16px 16px 80px;
+            padding: 0;
             box-sizing: border-box;
         }
         .nbhome-column {
@@ -4635,6 +4651,7 @@
         .nb-page-box canvas { position: absolute; left: 0; top: 0; }
         #nbBgCanvas { z-index: 1; }
         #nbCanvas { z-index: 2; touch-action: none; }
+        body.apple-pencil-mode #nbCanvasWrap { touch-action: none; }
         #nbOverlayCanvas { z-index: 3; pointer-events: none; }
         #nbTextLayer { position: absolute; left: 0; top: 0; z-index: 4; pointer-events: none; transform-origin: 0 0; }
         #nbTextLayer > * { pointer-events: auto; }
@@ -13342,8 +13359,11 @@
 
         function readerPenModeOwnsEventTarget(target) {
             const container = document.getElementById('readerContainer');
-            return !!(penMode && container && target
-                && (target === container || container.contains(target)));
+            if (penMode && container && target
+                && (target === container || container.contains(target))) return true;
+            const element = target && (target.nodeType === 1 ? target : target.parentElement);
+            if (!element || !element.closest || element.closest('input, textarea, [contenteditable="true"]')) return false;
+            return !!element.closest('body.lecture-pen-mode #lectureViewerContent, #lectureDraftCanvasWrapper.active, body:not(.nb-text-mode) #nbCanvasWrap');
         }
 
         function blockReaderNativeSelectionInPenMode(e) {
@@ -13353,13 +13373,11 @@
         }
 
         function clearNativeReaderSelectionInPenMode() {
-            if (!penMode) return;
-            const container = document.getElementById('readerContainer');
             const selection = typeof window.getSelection === 'function' ? window.getSelection() : null;
-            if (!container || !selection || !selection.rangeCount) return;
+            if (!selection || !selection.rangeCount) return;
             const anchor = selection.anchorNode;
             const focus = selection.focusNode;
-            if ((anchor && container.contains(anchor)) || (focus && container.contains(focus))) {
+            if (readerPenModeOwnsEventTarget(anchor) || readerPenModeOwnsEventTarget(focus)) {
                 selection.removeAllRanges();
             }
         }
@@ -20372,24 +20390,20 @@ ${i18n('prompt_lecture_gen')}`;
 
         function toggleLecturePenMode() {
             lecturePenMode = !lecturePenMode;
-            const btn = document.getElementById('lecturePenBtn');
-            const toolbar = document.getElementById('lecturePenToolbar');
+            applyLectureInputMode();
+            if (!lecturePenMode) saveLectureDrawing();
+        }
+
+        function applyLectureInputMode() {
+            document.body.classList.toggle('lecture-pen-mode', lecturePenMode);
+            document.getElementById('lecturePenBtn').classList.toggle('active', lecturePenMode);
+            document.getElementById('lecturePenToolbar').classList.toggle('show', lecturePenMode);
             const canvas = document.getElementById('lectureDrawCanvas');
-            
-            btn.classList.toggle('active', lecturePenMode);
-            
-            if (lecturePenMode) {
-                toolbar.classList.add('show');
-                if (canvas) {
-                    canvas.classList.add('active');
-                }
-            } else {
-                toolbar.classList.remove('show');
-                if (canvas) {
-                    canvas.classList.remove('active');
-                }
-                saveLectureDrawing();
-            }
+            if (canvas) canvas.classList.toggle('active', lecturePenMode);
+            window.__lectureNativeWidth = lecturePenSize;
+            if (lecturePenMode) hideLectureSelectionMenu();
+            clearNativeReaderSelectionInPenMode();
+            if (window.__booxPen && window.__booxPen.syncRegions) window.__booxPen.syncRegions();
         }
 
         function setLecturePenColor(el) {
@@ -20400,6 +20414,7 @@ ${i18n('prompt_lecture_gen')}`;
             document.getElementById('lecturePenEraser').classList.remove('active');
             // 仅本地记忆，不云同步
             try { localStorage.setItem('lecturePenColor', lecturePenColor); } catch(e) {}
+            applyLectureInputMode();
         }
 
         function setLecturePenSize(el) {
@@ -20408,6 +20423,7 @@ ${i18n('prompt_lecture_gen')}`;
             lecturePenSize = parseInt(el.dataset.size);
             // 仅本地记忆，不云同步
             try { localStorage.setItem('lecturePenSize', String(lecturePenSize)); } catch(e) {}
+            applyLectureInputMode();
         }
 
         // 恢复本地记忆的画笔偏好
@@ -20436,6 +20452,7 @@ ${i18n('prompt_lecture_gen')}`;
             if (lecturePenEraser) {
                 document.querySelectorAll('.lecture-pen-color').forEach(c => c.classList.remove('active'));
             }
+            applyLectureInputMode();
         }
 
         function initLectureDrawCanvas() {
@@ -20489,6 +20506,7 @@ ${i18n('prompt_lecture_gen')}`;
                 ro.observe(lectureBody);
                 canvas._resizeObserver = ro;
             }
+            applyLectureInputMode();
         }
 
         // 讲义画布：检查是否应忽略此指针（Apple Pencil 模式下忽略手指）
@@ -20885,6 +20903,8 @@ ${i18n('prompt_lecture_gen')}`;
         let lectureDraftPenColor = '#000000';
         let lectureDraftPenSize = 2;
         let lectureDraftDrawing = false;
+        let lectureDraftPointerId = null;
+        let lectureDraftPointerIsPen = false;
         let lectureDraftLastX = 0;
         let lectureDraftLastY = 0;
         let lectureDraftHistory = [];
@@ -20920,6 +20940,8 @@ ${i18n('prompt_lecture_gen')}`;
                 document.getElementById('lectureDraftMiniBar').style.display = 'block';
             }
             saveLectureDraft();
+            clearNativeReaderSelectionInPenMode();
+            if (window.__booxPen && window.__booxPen.syncRegions) window.__booxPen.syncRegions();
         }
 
         function getLectureDraftKey() {
@@ -21038,10 +21060,11 @@ ${i18n('prompt_lecture_gen')}`;
             lectureDraftCanvas.addEventListener('touchstart', handleLectureDraftTouchStart, { passive: false });
             lectureDraftCanvas.addEventListener('touchmove', handleLectureDraftTouchMove, { passive: false });
             lectureDraftCanvas.addEventListener('touchend', handleLectureDraftTouchEnd);
-            lectureDraftCanvas.addEventListener('mousedown', startLectureDraftDraw);
-            lectureDraftCanvas.addEventListener('mousemove', doLectureDraftDraw);
-            lectureDraftCanvas.addEventListener('mouseup', endLectureDraftDraw);
-            lectureDraftCanvas.addEventListener('mouseleave', endLectureDraftDraw);
+            lectureDraftCanvas.addEventListener('touchcancel', handleLectureDraftTouchEnd);
+            lectureDraftCanvas.addEventListener('pointerdown', startLectureDraftDraw);
+            lectureDraftCanvas.addEventListener('pointermove', doLectureDraftDraw);
+            lectureDraftCanvas.addEventListener('pointerup', endLectureDraftDraw);
+            lectureDraftCanvas.addEventListener('pointercancel', endLectureDraftDraw);
             
             lectureDraftCanvas.bindedEvents = true;
         }
@@ -21101,6 +21124,8 @@ ${i18n('prompt_lecture_gen')}`;
                     }
                 }, 50);
             }
+            clearNativeReaderSelectionInPenMode();
+            if (window.__booxPen && window.__booxPen.syncRegions) window.__booxPen.syncRegions();
         }
 
         function toggleLectureDraftEraser() {
@@ -21129,6 +21154,8 @@ ${i18n('prompt_lecture_gen')}`;
                     }
                 }, 50);
             }
+            clearNativeReaderSelectionInPenMode();
+            if (window.__booxPen && window.__booxPen.syncRegions) window.__booxPen.syncRegions();
         }
 
         function restoreLectureDraftPenSettings() {
@@ -21140,6 +21167,7 @@ ${i18n('prompt_lecture_gen')}`;
             });
             
             lectureDraftPenSize = s.lectureDraftPenSize || 2;
+            window.__lectureDraftNativeWidth = lectureDraftPenSize * 2;
             document.querySelectorAll('#lectureDraftPenTools .pen-size').forEach(sz => {
                 sz.classList.toggle('active', parseInt(sz.dataset.size) === lectureDraftPenSize);
             });
@@ -21160,6 +21188,8 @@ ${i18n('prompt_lecture_gen')}`;
                     }
                 }, 100);
             }
+            clearNativeReaderSelectionInPenMode();
+            if (window.__booxPen && window.__booxPen.syncRegions) window.__booxPen.syncRegions();
         }
 
         function setLectureDraftPenColor(el) {
@@ -21172,10 +21202,13 @@ ${i18n('prompt_lecture_gen')}`;
 
         function setLectureDraftPenSize(el) {
             lectureDraftPenSize = parseInt(el.dataset.size);
+            window.__lectureDraftNativeWidth = lectureDraftPenSize * 2;
             document.querySelectorAll('#lectureDraftPenTools .pen-size').forEach(s => s.classList.remove('active'));
             el.classList.add('active');
             appData.settings.lectureDraftPenSize = lectureDraftPenSize;
             saveData();
+            clearNativeReaderSelectionInPenMode();
+            if (window.__booxPen && window.__booxPen.syncRegions) window.__booxPen.syncRegions();
         }
 
         function formatLectureDraftText(type) {
@@ -21197,85 +21230,47 @@ ${i18n('prompt_lecture_gen')}`;
         let lectureDraftPanLastY = 0;
 
         function handleLectureDraftTouchStart(e) {
+            lectureDraftPanActive = false;
             if (!lectureDraftPenEnabled && !lectureDraftEraserEnabled) return;
-            if (e.touches.length === 2) {
-                e.preventDefault();
-                lectureDraftDrawing = false;
-                lectureDraftPanActive = true;
-                const cx = (e.touches[0].clientX + e.touches[1].clientX) / 2;
-                const cy = (e.touches[0].clientY + e.touches[1].clientY) / 2;
-                lectureDraftPanLastX = cx;
-                lectureDraftPanLastY = cy;
-                return;
-            }
-            if (e.touches.length !== 1) return;
-            e.preventDefault();
-            lectureDraftDrawing = true;
-            const touch = e.touches[0];
-            const rect = lectureDraftCanvas.getBoundingClientRect();
-            lectureDraftLastX = touch.clientX - rect.left;
-            lectureDraftLastY = touch.clientY - rect.top;
+            if (lectureDraftDrawing && lectureDraftPointerIsPen) return;
+            const touches = Array.from(e.touches);
+            if (touches.some(t => t.touchType === 'stylus')) return;
+            if (touches.length !== 2 && !(applePencilMode && touches.length === 1)) return;
+            endLectureDraftDraw({ pointerId: lectureDraftPointerId });
+            lectureDraftPanActive = true;
+            lectureDraftPanLastX = touches.reduce((n, t) => n + t.clientX, 0) / touches.length;
+            lectureDraftPanLastY = touches.reduce((n, t) => n + t.clientY, 0) / touches.length;
         }
 
         function handleLectureDraftTouchMove(e) {
-            if (e.touches.length === 2 && lectureDraftPanActive) {
-                e.preventDefault();
-                const cx = (e.touches[0].clientX + e.touches[1].clientX) / 2;
-                const cy = (e.touches[0].clientY + e.touches[1].clientY) / 2;
-                const dx = cx - lectureDraftPanLastX;
-                const dy = cy - lectureDraftPanLastY;
-                const wrapper = document.getElementById('lectureDraftCanvasWrapper');
-                if (wrapper) {
-                    wrapper.scrollLeft -= dx;
-                    wrapper.scrollTop -= dy;
-                }
-                lectureDraftPanLastX = cx;
-                lectureDraftPanLastY = cy;
-                return;
+            if (!lectureDraftPanActive) return;
+            const touches = Array.from(e.touches);
+            if (touches.some(t => t.touchType === 'stylus')) return;
+            if (touches.length !== 2 && !(applePencilMode && touches.length === 1)) return;
+            const cx = touches.reduce((n, t) => n + t.clientX, 0) / touches.length;
+            const cy = touches.reduce((n, t) => n + t.clientY, 0) / touches.length;
+            const wrapper = document.getElementById('lectureDraftCanvasWrapper');
+            if (wrapper) {
+                wrapper.scrollLeft -= cx - lectureDraftPanLastX;
+                wrapper.scrollTop -= cy - lectureDraftPanLastY;
             }
-            if (!lectureDraftDrawing || (!lectureDraftPenEnabled && !lectureDraftEraserEnabled)) return;
-            if (e.touches.length !== 1) return;
+            lectureDraftPanLastX = cx;
+            lectureDraftPanLastY = cy;
             e.preventDefault();
-            const touch = e.touches[0];
-            const rect = lectureDraftCanvas.getBoundingClientRect();
-            const x = touch.clientX - rect.left;
-            const y = touch.clientY - rect.top;
-            
-            lectureDraftCtx.beginPath();
-            lectureDraftCtx.moveTo(lectureDraftLastX, lectureDraftLastY);
-            lectureDraftCtx.lineTo(x, y);
-            
-            if (lectureDraftEraserEnabled) {
-                lectureDraftCtx.globalCompositeOperation = 'destination-out';
-                lectureDraftCtx.strokeStyle = 'rgba(0,0,0,1)';
-                lectureDraftCtx.lineWidth = 20;
-            } else {
-                lectureDraftCtx.globalCompositeOperation = 'source-over';
-                lectureDraftCtx.strokeStyle = lectureDraftPenColor;
-                lectureDraftCtx.lineWidth = lectureDraftPenSize * 2;
-            }
-            lectureDraftCtx.lineCap = 'round';
-            lectureDraftCtx.lineJoin = 'round';
-            lectureDraftCtx.stroke();
-            
-            lectureDraftLastX = x;
-            lectureDraftLastY = y;
         }
 
         function handleLectureDraftTouchEnd(e) {
-            if (e.touches.length < 2) {
-                lectureDraftPanActive = false;
-            }
-            if (lectureDraftDrawing) {
-                lectureDraftDrawing = false;
-                lectureDraftCtx.globalCompositeOperation = 'source-over';
-                saveLectureDraftCanvasState();
-                debouncedSaveLectureDraft();
-            }
+            lectureDraftPanActive = false;
+            if (e.touches.length) handleLectureDraftTouchStart(e);
         }
 
         function startLectureDraftDraw(e) {
-            if (!lectureDraftPenEnabled && !lectureDraftEraserEnabled) return;
+            if ((!lectureDraftPenEnabled && !lectureDraftEraserEnabled) || lectureDraftDrawing || lectureDraftPanActive) return;
+            if (applePencilMode && !booxReaderIsPen(e)) return;
+            e.preventDefault();
+            try { lectureDraftCanvas.setPointerCapture(e.pointerId); } catch (err) {}
+            lectureDraftPointerId = e.pointerId;
+            lectureDraftPointerIsPen = booxReaderIsPen(e);
             lectureDraftDrawing = true;
             const rect = lectureDraftCanvas.getBoundingClientRect();
             lectureDraftLastX = e.clientX - rect.left;
@@ -21283,7 +21278,8 @@ ${i18n('prompt_lecture_gen')}`;
         }
 
         function doLectureDraftDraw(e) {
-            if (!lectureDraftDrawing || (!lectureDraftPenEnabled && !lectureDraftEraserEnabled)) return;
+            if (!lectureDraftDrawing || e.pointerId !== lectureDraftPointerId || (!lectureDraftPenEnabled && !lectureDraftEraserEnabled)) return;
+            e.preventDefault();
             const rect = lectureDraftCanvas.getBoundingClientRect();
             const x = e.clientX - rect.left;
             const y = e.clientY - rect.top;
@@ -21309,9 +21305,10 @@ ${i18n('prompt_lecture_gen')}`;
             lectureDraftLastY = y;
         }
 
-        function endLectureDraftDraw() {
-            if (lectureDraftDrawing) {
+        function endLectureDraftDraw(e) {
+            if (lectureDraftDrawing && e.pointerId === lectureDraftPointerId) {
                 lectureDraftDrawing = false;
+                lectureDraftPointerId = null;
                 lectureDraftCtx.globalCompositeOperation = 'source-over';
                 saveLectureDraftCanvasState();
                 debouncedSaveLectureDraft();
@@ -21430,6 +21427,7 @@ ${i18n('prompt_lecture_gen')}`;
         function handleLectureSelection(e) {
             // 延时足够让iPad完成选区，但在弹出原生菜单前拦截
             setTimeout(() => {
+                if (lecturePenMode) return;
                 const selection = window.getSelection();
                 const text = selection.toString().trim();
 
@@ -31309,7 +31307,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             if (!wrap || !document.getElementById('nbEditor').classList.contains('show')) return;
             const availW = wrap.clientWidth, availH = wrap.clientHeight;
             if (availW <= 0 || availH <= 0) return;
-            nbState.fitScale = Math.min(availW / NB_PAGE_W, availH / NB_PAGE_H);
+            nbState.fitScale = availW / NB_PAGE_W;
             const s = nbDisplayScale();
             const cssW = Math.round(NB_PAGE_W * s), cssH = Math.round(NB_PAGE_H * s);
             const box = document.getElementById('nbPageBox');
@@ -31586,6 +31584,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             document.querySelectorAll('.nb-brush-btn').forEach((b, i) =>
                 b.classList.toggle('active', tool === 'pen' && i === nbState.brushIndex));
             document.body.classList.toggle('nb-text-mode', tool === 'text');
+            clearNativeReaderSelectionInPenMode();
         }
         function toggleNbEraser() {
             nbSetTool(nbState.tool === 'eraser' ? (nbState.prevTool || 'pen') : 'eraser');
@@ -31661,6 +31660,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         }
 
         // ==================== 指针输入（书写/橡皮/套索/图形/文本） ====================
+        let _nbActivePointerId = null;
         function nbEventPoint(e) {
             const c = document.getElementById('nbCanvas');
             const r = c.getBoundingClientRect();
@@ -31702,10 +31702,51 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             c.addEventListener('pointerup', nbPointerUp);
             c.addEventListener('pointercancel', nbPointerUp);
             c.addEventListener('contextmenu', e => e.preventDefault());
+
+            // 沿用阅读器的 touch-action:none + 手指手动滚动，避免 Safari 抢走 Pencil。
+            const wrap = document.getElementById('nbCanvasWrap');
+            let gesture = null;
+            const fingers = e => Array.from(e.touches).filter(t => t.touchType !== 'stylus');
+            const beginGesture = e => {
+                gesture = null;
+                if (!applePencilMode || nbState.drawing
+                    || e.target.closest('input, textarea, button')
+                    || (document.activeElement?.isContentEditable && document.activeElement.contains(e.target))) return;
+                const ts = fingers(e);
+                if (!ts.length || ts.length > 2 || ts.length !== e.touches.length) return;
+                gesture = {
+                    count: ts.length,
+                    x: ts.reduce((n, t) => n + t.clientX, 0) / ts.length,
+                    y: ts.reduce((n, t) => n + t.clientY, 0) / ts.length,
+                    distance: ts.length === 2 ? Math.hypot(ts[1].clientX - ts[0].clientX, ts[1].clientY - ts[0].clientY) : 0
+                };
+            };
+            wrap.addEventListener('touchstart', beginGesture, { passive: true });
+            wrap.addEventListener('touchmove', e => {
+                if (!gesture || !applePencilMode || nbState.drawing) { gesture = null; return; }
+                const ts = fingers(e);
+                if (ts.length !== gesture.count || ts.length !== e.touches.length) { gesture = null; return; }
+                const x = ts.reduce((n, t) => n + t.clientX, 0) / ts.length;
+                const y = ts.reduce((n, t) => n + t.clientY, 0) / ts.length;
+                const rect = wrap.getBoundingClientRect();
+                const oldZoom = nbState.zoom;
+                const distance = ts.length === 2 ? Math.hypot(ts[1].clientX - ts[0].clientX, ts[1].clientY - ts[0].clientY) : 0;
+                const scrollX = wrap.scrollLeft + gesture.x - rect.left;
+                const scrollY = wrap.scrollTop + gesture.y - rect.top;
+                if (distance > 0 && gesture.distance > 0 && distance !== gesture.distance) nbZoomSet(oldZoom * distance / gesture.distance * 100);
+                const ratio = nbState.zoom / oldZoom;
+                wrap.scrollLeft = scrollX * ratio - (x - rect.left);
+                wrap.scrollTop = scrollY * ratio - (y - rect.top);
+                gesture = { count: ts.length, x, y, distance };
+                e.preventDefault();
+            }, { passive: false });
+            wrap.addEventListener('touchend', beginGesture, { passive: true });
+            wrap.addEventListener('touchcancel', () => { gesture = null; }, { passive: true });
         }
 
         function nbPointerDown(e) {
-            if (e.button === 2) return;
+            if (e.button === 2 || nbState.drawing) return;
+            if (applePencilMode && !booxReaderIsPen(e)) return;
             nbHidePanel();
             nbHideOutline();
             nbHideTextToolbar();
@@ -31713,6 +31754,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             const tool = nbState.tool;
             e.preventDefault();
             try { e.target.setPointerCapture(e.pointerId); } catch (err) {}
+            _nbActivePointerId = e.pointerId;
 
             if (tool === 'pen') {
                 // Boox 原生笔按矩形抢占整个画布，落在文本框/媒体上的笔迹会以回放事件
@@ -31756,7 +31798,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
         function nbPointerMove(e) {
             const d = nbState.drawing;
-            if (!d) return;
+            if (!d || e.pointerId !== _nbActivePointerId) return;
             e.preventDefault();
             const events = (typeof e.getCoalescedEvents === 'function' && e.getCoalescedEvents().length) ? e.getCoalescedEvents() : [e];
             for (const ev of events) {
@@ -31812,7 +31854,8 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
         function nbPointerUp(e) {
             const d = nbState.drawing;
-            if (!d) return;
+            if (!d || e.pointerId !== _nbActivePointerId) return;
+            _nbActivePointerId = null;
             nbState.drawing = null;
             if (d.mode === 'stroke') {
                 const pts = d.stroke.paths[0];
@@ -32227,6 +32270,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 if (e.target.classList.contains('nb-tb-corner') || e.target.classList.contains('nb-media-del')) return;
                 const editing = document.activeElement === inner;
                 if (editing && e.target === inner) return;   // 编辑中不拦截光标操作
+                if (applePencilMode && !booxReaderIsPen(e)) return;
                 e.preventDefault();
                 e.stopPropagation();
                 nbSelectTextBox(box.id);
@@ -32234,6 +32278,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 const sx = e.clientX, sy = e.clientY, ox = box.x, oy = box.y;
                 let moved = false;
                 const mv = (ev) => {
+                    if (ev.pointerId !== e.pointerId) return;
                     const dx = (ev.clientX - sx) / s, dy = (ev.clientY - sy) / s;
                     if (Math.abs(dx) > 2 || Math.abs(dy) > 2) moved = true;
                     box.x = Math.round(ox + dx);
@@ -32242,7 +32287,8 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     el.style.top = box.y + 'px';
                     nbPositionTextToolbar(box.id);
                 };
-                const up = () => {
+                const up = (ev) => {
+                    if (ev.pointerId !== e.pointerId) return;
                     document.removeEventListener('pointermove', mv);
                     document.removeEventListener('pointerup', up);
                     if (moved) {
@@ -32270,6 +32316,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 h.className = 'nb-tb-corner';
                 h.dataset.c = c;
                 h.addEventListener('pointerdown', (e) => {
+                    if (applePencilMode && !booxReaderIsPen(e)) return;
                     e.preventDefault();
                     e.stopPropagation();
                     const s = nbDisplayScale();
@@ -32283,6 +32330,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     const d0 = Math.max(10, Math.hypot(cx0 - ax, cy0 - ay));
                     const sx = e.clientX, sy = e.clientY;
                     const mv = (ev) => {
+                        if (ev.pointerId !== e.pointerId) return;
                         const px = (ev.clientX - sx) / s + (c.includes('l') ? x0 : x0 + w0);
                         const py = (ev.clientY - sy) / s + (c.includes('t') ? y0 : y0 + h0);
                         const k = Math.max(0.2, Math.min(6, Math.hypot(px - ax, py - ay) / d0));
@@ -32296,7 +32344,8 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                         inner.style.fontSize = box.fontSize + 'px';
                         nbPositionTextToolbar(box.id);
                     };
-                    const up = () => {
+                    const up = (ev) => {
+                        if (ev.pointerId !== e.pointerId) return;
                         document.removeEventListener('pointermove', mv);
                         document.removeEventListener('pointerup', up);
                         nbScheduleSave();
@@ -32426,6 +32475,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             el.appendChild(del);
             el.addEventListener('pointerdown', (e) => {
                 if (e.target.tagName === 'BUTTON') return;
+                if (applePencilMode && !booxReaderIsPen(e)) return;
                 e.preventDefault();
                 e.stopPropagation();
                 document.querySelectorAll('.nb-media-img.selected,.nb-media-audio.selected,.nb-textbox.selected').forEach(x => x.classList.remove('selected'));
@@ -32434,6 +32484,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 const sx = e.clientX, sy = e.clientY, ox = m.x, oy = m.y;
                 let moved = false;
                 const mv = (ev) => {
+                    if (ev.pointerId !== e.pointerId) return;
                     const dx = (ev.clientX - sx) / s, dy = (ev.clientY - sy) / s;
                     if (Math.abs(dx) > 2 || Math.abs(dy) > 2) moved = true;
                     m.x = Math.round(ox + dx);
@@ -32441,7 +32492,8 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     el.style.left = m.x + 'px';
                     el.style.top = m.y + 'px';
                 };
-                const up = () => {
+                const up = (ev) => {
+                    if (ev.pointerId !== e.pointerId) return;
                     document.removeEventListener('pointermove', mv);
                     document.removeEventListener('pointerup', up);
                     if (moved) nbScheduleSave();
@@ -32596,7 +32648,6 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             const l = document.getElementById('nbZoomLabel');
             if (l) l.textContent = Math.round(nbState.zoom * 100) + '%';
             nbLayout();
-            nbRenderTexts();
         }
 
         function nbShowExportModal() {

--- a/tests/boox-pen.test.js
+++ b/tests/boox-pen.test.js
@@ -66,16 +66,18 @@ for (const [canvasId, clipId, eraserId, widthFlag] of [
             eraserToggles++;
             if (classes.has('active')) classes.delete('active');
             else classes.add('active');
-        }
+        },
+        toggleLectureDraftEraser() { eraserToggles++; }
     };
     context.window = context;
     vm.runInNewContext(source, context);
     const pen = context.__booxPen;
-    const lines = [], saves = [], timers = [];
+    const lines = [], composites = [], saves = [], timers = [];
     if (canvasId === 'lectureDraftCanvas') {
         canvas.getContext = () => ({
             beginPath() {}, moveTo: (x, y) => lines.push(['from', x, y]),
-            lineTo: (x, y) => lines.push(['to', x, y]), stroke() {},
+            lineTo: (x, y) => lines.push(['to', x, y]),
+            stroke() { composites.push(this.globalCompositeOperation); },
             getImageData: () => ({ lines: lines.slice() })
         });
         context.saveLectureDraft = () => saves.push('saved');
@@ -96,10 +98,10 @@ for (const [canvasId, clipId, eraserId, widthFlag] of [
     assert.equal(calls.length, 1, 'unchanged regions must not restart native drawing');
 
     pen.onStroke([[200, 300, 0.4], [240, 360, 0.8]], false);
-    assert.deepEqual(events.map(e => [e.type, e.clientX, e.clientY, e.pointerType, e.buttons]), [
-        ['pointerdown', 100, 150, 'pen', 1],
-        ['pointermove', 120, 180, 'pen', 1],
-        ['pointerup', 120, 180, 'pen', 0]
+    assert.deepEqual(events.map(e => [e.type, e.clientX, e.clientY, e.pointerType, e.button, e.buttons]), [
+        ['pointerdown', 100, 150, 'pen', 0, 1],
+        ['pointermove', 120, 180, 'pen', -1, 1],
+        ['pointerup', 120, 180, 'pen', 0, 0]
     ], 'native strokes must reach the existing pointer drawing/save handlers');
     if (canvasId === 'lectureDraftCanvas') {
         assert.deepEqual(lines, [['from', 120, 1150], ['to', 140, 1180]]);
@@ -125,6 +127,56 @@ for (const [canvasId, clipId, eraserId, widthFlag] of [
         assert.deepEqual([elements[clipId].scrollLeft, elements[clipId].scrollTop], [-30, -50]);
         context.handleLectureDraftTouchEnd(touchEvent([]));
         assert.equal(vm.runInNewContext('lectureDraftHistory.length', context), 1, 'scrolling must not create handwriting');
+
+        const state = expression => vm.runInNewContext(expression, context);
+        const stroke = [[200, 300, 0.4], [240, 360, 0.8]];
+        vm.runInNewContext('applePencilMode = true', context);
+        pen.onStroke(stroke, true);
+        assert.equal(composites.at(-1), 'destination-out', 'native side eraser must remove ink');
+        assert.deepEqual(events.slice(-3).map(e => [e.type, e.button, e.buttons]), [
+            ['pointerdown', 5, 32], ['pointermove', -1, 32], ['pointerup', 5, 0]
+        ], 'replay must preserve standard pen eraser buttons');
+        assert.equal(state('lectureDraftHistory.length'), 2, 'erasing must remain undoable');
+        assert.equal(state('lectureDraftPenEnabled && !lectureDraftEraserEnabled'), true);
+        assert.equal(classes.has('active'), false, 'side eraser must not select the toolbar eraser');
+        assert.equal(eraserToggles, 0, 'side eraser must not toggle persistent draft tools');
+        assert.equal(state('lectureDraftPointerIsEraser'), false, 'eraser state must end with the pointer');
+        pen.onStroke(stroke, false);
+        assert.equal(composites.at(-1), 'source-over', 'the next ordinary stroke must write normally');
+
+        // A reported finger/palm may already be panning when the native pen
+        // delivers its complete stroke. Pen input must take over and save it.
+        context.handleLectureDraftTouchStart(touchEvent([touch(100, 150)]));
+        assert.equal(state('lectureDraftPanActive'), true);
+        pen.onStroke(stroke, false);
+        assert.equal(state('lectureDraftPanActive'), false);
+        assert.equal(state('lectureDraftHistory.length'), 4, 'finger-first native replay must save an undo snapshot');
+        assert.equal(composites.length, 4, 'finger-first native replay must draw the complete stroke');
+        assert.equal(timers.at(-1).delay, 1000);
+        timers.at(-1).fn();
+        assert.deepEqual(saves, ['saved', 'saved'], 'finger-first native replay must persist');
+
+        const pointer = (type, pointerId, values = {}) => canvas.dispatchEvent(new context.PointerEvent(type, {
+            pointerType: 'pen', pointerId, clientX: 100, clientY: 150, button: 0, buttons: 1, ...values
+        }));
+        pointer('pointerdown', 12, { button: 5, buttons: 32 });
+        pointer('pointermove', 13, { pointerType: 'touch' });
+        pointer('pointerup', 13, { pointerType: 'touch', buttons: 0 });
+        assert.equal(state('lectureDraftDrawing && lectureDraftPointerId === 12 && lectureDraftPointerIsEraser'), true,
+            'another finger must not move or finish the active pen stroke');
+        assert.equal(composites.length, 4);
+        pointer('pointercancel', 12, { buttons: 0 });
+        assert.equal(state('!lectureDraftDrawing && lectureDraftPointerId === null && !lectureDraftPointerIsEraser'), true);
+        const historyAfterCancel = state('lectureDraftHistory.length');
+        context.handleLectureDraftTouchEnd(touchEvent([]));
+        context.handleLectureDraftTouchStart(touchEvent([touch(100, 150)]));
+        context.handleLectureDraftTouchMove(touchEvent([touch(110, 170)]));
+        assert.deepEqual([elements[clipId].scrollLeft, elements[clipId].scrollTop], [-40, -70],
+            'a new finger gesture must scroll after pointer cancellation');
+        context.handleLectureDraftTouchEnd(touchEvent([]));
+        pen.onStroke(stroke, false);
+        assert.equal(composites.at(-1), 'source-over', 'writing must recover after cancellation');
+        assert.equal(state('lectureDraftHistory.length'), historyAfterCancel + 1);
     }
     if (canvasId === 'lectureDrawCanvas') {
         pen.onStroke([[200, 300, 0.4]], true);

--- a/tests/boox-pen.test.js
+++ b/tests/boox-pen.test.js
@@ -1,0 +1,158 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const source = fs.readFileSync(path.join(__dirname, '../app/src/main/assets/boox-pen.js'), 'utf8');
+const page = fs.readFileSync(path.join(__dirname, '../docs/index.html'), 'utf8');
+function pageFunction(name) {
+    const match = page.match(new RegExp('        function ' + name + '\\([^)]*\\) \\{[\\s\\S]*?\\n        \\}'));
+    assert.ok(match, 'missing page function ' + name);
+    return match[0];
+}
+
+for (const [canvasId, clipId, eraserId, widthFlag] of [
+    ['lectureDrawCanvas', 'lectureViewerContent', 'lecturePenEraser', '__lectureNativeWidth'],
+    ['lectureDraftCanvas', 'lectureDraftCanvasWrapper', 'lectureDraftEraserToggle', '__lectureDraftNativeWidth'],
+    ['nbCanvas', 'nbCanvasWrap', 'nbEraserBtn', '__nbNativeWidth']
+]) {
+    const calls = [], events = [], classes = new Set(), listeners = {};
+    let covered = false, pointerEvents = 'auto', eraserToggles = 0;
+    // A long canvas scrolled into its middle: none of its original five sample
+    // points are visible. The SDK must sample and register only the viewport.
+    const rect = { left: -20, top: -1000, right: 920, bottom: 5000, width: 940, height: 6000 };
+    const clip = { left: 0, top: 60, right: 900, bottom: 750, width: 900, height: 690 };
+    const canvas = {
+        isConnected: true, classList: { contains: () => false },
+        getBoundingClientRect: () => rect,
+        setPointerCapture() {},
+        addEventListener(type, fn, capture) {
+            const handlers = listeners[type] || (listeners[type] = []);
+            capture === true ? handlers.unshift(fn) : handlers.push(fn);
+        },
+        dispatchEvent(e) {
+            events.push(e);
+            e.target = canvas;
+            for (const handler of listeners[e.type] || []) handler(e);
+        }
+    };
+    const elements = {
+        [canvasId]: canvas,
+        [clipId]: { getBoundingClientRect: () => clip, scrollLeft: 0, scrollTop: 0 },
+        [eraserId]: { classList: { contains: c => classes.has(c) } }
+    };
+    const context = {
+        navigator: {}, console: { log() {}, warn() {} },
+        devicePixelRatio: 2, innerWidth: 1000, innerHeight: 800,
+        [widthFlag]: 3,
+        addEventListener() {}, setInterval() {}, setTimeout() {}, clearTimeout() {},
+        getComputedStyle: () => ({ display: 'block', visibility: 'visible', pointerEvents }),
+        PointerEvent: class {
+            constructor(type, values) { Object.assign(this, values, { type }); }
+            preventDefault() {} stopPropagation() {}
+        },
+        document: {
+            getElementById: id => elements[id] || null,
+            querySelectorAll: () => [], addEventListener() {},
+            elementFromPoint: (x, y) => !covered && x >= clip.left && x <= clip.right
+                && y >= clip.top && y <= clip.bottom ? canvas : null
+        },
+        BooxPenNative: {
+            isAvailable: () => true,
+            setRects: json => calls.push(JSON.parse(json)),
+            disable: () => calls.push(null)
+        },
+        toggleLecturePenEraser() {
+            eraserToggles++;
+            if (classes.has('active')) classes.delete('active');
+            else classes.add('active');
+        }
+    };
+    context.window = context;
+    vm.runInNewContext(source, context);
+    const pen = context.__booxPen;
+    const lines = [], saves = [], timers = [];
+    if (canvasId === 'lectureDraftCanvas') {
+        canvas.getContext = () => ({
+            beginPath() {}, moveTo: (x, y) => lines.push(['from', x, y]),
+            lineTo: (x, y) => lines.push(['to', x, y]), stroke() {},
+            getImageData: () => ({ lines: lines.slice() })
+        });
+        context.saveLectureDraft = () => saves.push('saved');
+        context.setTimeout = (fn, delay) => { timers.push({ fn, delay }); return timers.length; };
+        vm.runInNewContext(
+            page.slice(page.indexOf('        let lectureDraftCanvas = null;'), page.indexOf('        function toggleLectureDraftPanel()'))
+            + page.slice(page.indexOf('        let lectureDraftPanActive = false;'), page.indexOf('        function handleLectureDraftTouchStart(e)'))
+            + '\nlet applePencilMode = true; let _lectureDraftSaveTimer = null;\n'
+            + ['booxReaderIsPen', 'initLectureDraftCanvas', 'startLectureDraftDraw', 'doLectureDraftDraw',
+                'endLectureDraftDraw', 'handleLectureDraftTouchStart', 'handleLectureDraftTouchMove',
+                'handleLectureDraftTouchEnd', 'saveLectureDraftCanvasState', 'debouncedSaveLectureDraft']
+                .map(pageFunction).join('\n')
+            + '\nlectureDraftPenEnabled = true; initLectureDraftCanvas();', context);
+    }
+    pen.syncRegions();
+    assert.deepEqual(calls.at(-1), { rects: [[0, 120, 1800, 1500]], width: 6 }, canvasId);
+    pen.syncRegions();
+    assert.equal(calls.length, 1, 'unchanged regions must not restart native drawing');
+
+    pen.onStroke([[200, 300, 0.4], [240, 360, 0.8]], false);
+    assert.deepEqual(events.map(e => [e.type, e.clientX, e.clientY, e.pointerType, e.buttons]), [
+        ['pointerdown', 100, 150, 'pen', 1],
+        ['pointermove', 120, 180, 'pen', 1],
+        ['pointerup', 120, 180, 'pen', 0]
+    ], 'native strokes must reach the existing pointer drawing/save handlers');
+    if (canvasId === 'lectureDraftCanvas') {
+        assert.deepEqual(lines, [['from', 120, 1150], ['to', 140, 1180]]);
+        assert.equal(vm.runInNewContext('lectureDraftHistory.length', context), 1, 'native replay must save an undo snapshot');
+        assert.equal(vm.runInNewContext('lectureDraftCanvasDirty', context), true);
+        assert.equal(timers.at(-1).delay, 1000, 'native replay must schedule the existing draft save');
+        timers.at(-1).fn();
+        assert.deepEqual(saves, ['saved']);
+
+        // Apple Pencil mode: direct finger pointers do not write; their touch
+        // events retain one-finger scroll. Normal mode retains two-finger pan.
+        const touch = (x, y) => ({ clientX: x, clientY: y, touchType: 'direct' });
+        const touchEvent = touches => ({ touches, preventDefault() {} });
+        context.startLectureDraftDraw(new context.PointerEvent('pointerdown', { pointerType: 'touch', pointerId: 9 }));
+        assert.equal(vm.runInNewContext('lectureDraftDrawing', context), false);
+        context.handleLectureDraftTouchStart(touchEvent([touch(100, 150)]));
+        context.handleLectureDraftTouchMove(touchEvent([touch(110, 170)]));
+        assert.deepEqual([elements[clipId].scrollLeft, elements[clipId].scrollTop], [-10, -20]);
+        context.handleLectureDraftTouchEnd(touchEvent([]));
+        vm.runInNewContext('applePencilMode = false', context);
+        context.handleLectureDraftTouchStart(touchEvent([touch(100, 150), touch(200, 150)]));
+        context.handleLectureDraftTouchMove(touchEvent([touch(120, 180), touch(220, 180)]));
+        assert.deepEqual([elements[clipId].scrollLeft, elements[clipId].scrollTop], [-30, -50]);
+        context.handleLectureDraftTouchEnd(touchEvent([]));
+        assert.equal(vm.runInNewContext('lectureDraftHistory.length', context), 1, 'scrolling must not create handwriting');
+    }
+    if (canvasId === 'lectureDrawCanvas') {
+        pen.onStroke([[200, 300, 0.4]], true);
+        assert.equal(eraserToggles, 2, 'side eraser toggles on for replay then restores pen');
+        assert.equal(classes.has('active'), false);
+    }
+
+    classes.add('active');
+    pen.syncRegions();
+    assert.equal(calls.at(-1), null, 'eraser must use the page erase handler');
+    classes.delete('active');
+    context[widthFlag] = 5;
+    pen.syncRegions();
+    assert.equal(calls.at(-1).width, 10, 'native width must follow the selected brush');
+
+    covered = true;
+    pen.syncRegions();
+    assert.equal(calls.at(-1), null, 'an obscured canvas must not capture native input');
+    covered = false;
+    pen.syncRegions();
+    pointerEvents = 'none';
+    pen.syncRegions();
+    assert.equal(calls.at(-1), null, 'leaving pen mode must disable the native region');
+    pointerEvents = 'auto';
+    pen.syncRegions();
+    rect.bottom = 50;
+    pen.syncRegions();
+    assert.equal(calls.at(-1), null, 'a canvas outside its scroll viewport must stay disabled');
+}
+
+console.log('BOOX handwriting regions and native stroke replay checks passed');

--- a/tests/native-selection.test.js
+++ b/tests/native-selection.test.js
@@ -1,0 +1,198 @@
+// Run: node tests/native-selection.test.js
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const html = fs.readFileSync(path.join(__dirname, '../docs/index.html'), 'utf8');
+const guardStart = html.indexOf('        function readerPenModeOwnsEventTarget(target)');
+const guardEnd = html.indexOf('        // 按当前画笔/套索模式调整页面分层', guardStart);
+const askStart = html.indexOf('        function handleLectureSelection(e)');
+const askEnd = html.indexOf('        // 用绝对定位的div覆盖高亮', askStart);
+const modeStart = html.indexOf('        function applyLectureInputMode()');
+const modeEnd = html.indexOf('        function setLecturePenColor(', modeStart);
+assert.ok(guardStart >= 0 && guardEnd > guardStart && askStart >= 0 && askEnd > askStart);
+assert.ok(modeStart >= 0 && modeEnd > modeStart);
+
+const elements = new Map();
+function element(id, parent = null, tag = 'DIV', editable = false) {
+    const classes = new Set();
+    const el = {
+        id, nodeType: 1, tagName: tag, parentElement: parent, parentNode: parent,
+        contentEditable: editable ? 'true' : 'inherit', isContentEditable: editable,
+        classList: {
+            contains: name => classes.has(name),
+            add: name => classes.add(name),
+            remove: name => classes.delete(name),
+            toggle(name, enabled) { enabled ? classes.add(name) : classes.delete(name); }
+        },
+        contains(node) {
+            for (; node; node = node.parentNode) if (node === this) return true;
+            return false;
+        },
+        matches(selector) {
+            return selector.split(',').some(part => {
+                part = part.trim();
+                const descendant = part.lastIndexOf(' ');
+                if (descendant >= 0) return this.matches(part.slice(descendant + 1))
+                    && !!this.parentElement?.closest(part.slice(0, descendant));
+                if (part === '[contenteditable="true"]' || part === '[contenteditable]') return editable;
+                const excluded = part.match(/:not\(([^)]+)\)/);
+                if (excluded && this.matches(excluded[1])) return false;
+                part = part.replace(/:not\([^)]+\)/, '');
+                const id = part.match(/#([\w-]+)/);
+                const className = part.match(/\.([\w-]+)/);
+                const tagName = part.match(/^[\w-]+/);
+                return (!id || this.id === id[1]) && (!className || classes.has(className[1]))
+                    && (!tagName || this.tagName.toLowerCase() === tagName[0]);
+            });
+        },
+        closest(selector) {
+            for (let node = this; node; node = node.parentElement) if (node.matches(selector)) return node;
+            return null;
+        }
+    };
+    elements.set(id, el);
+    return el;
+}
+const body = element('body', null, 'BODY');
+const reader = element('readerContainer', body);
+const readerInk = element('readerInk', reader);
+const lectureViewer = element('lectureViewer', body);
+const lecture = element('lectureViewerContent', lectureViewer);
+const lectureInk = element('lectureDrawCanvas', lecture, 'CANVAS');
+const lectureButton = element('lecturePenBtn', body, 'BUTTON');
+const lectureToolbar = element('lecturePenToolbar', body);
+const draft = element('lectureDraftCanvasWrapper', body);
+const draftInk = element('lectureDraftCanvas', draft, 'CANVAS');
+const notebookEditor = element('nbEditor', body);
+const notebook = element('nbCanvasWrap', notebookEditor);
+const notebookInk = element('nbCanvas', notebook, 'CANVAS');
+const outside = element('outside', body);
+const textNode = parent => ({ nodeType: 3, parentElement: parent, parentNode: parent });
+const registrations = new Map();
+const timeouts = [];
+let selection = null;
+let highlighted = null;
+let menuShown = 0;
+let regionsSynced = 0;
+const sandbox = {
+    penMode: false, lecturePenMode: false, lectureSelectedText: '', lectureSelectionRange: null,
+    lecturePenSize: 4,
+    nbState: { tool: 'pen' }, lectureDraftPenEnabled: false, lectureDraftEraserEnabled: false,
+    document: { body, activeElement: null,
+        getElementById: id => elements.get(id) || null,
+        addEventListener(type, handler, capture) { registrations.set(type, { handler, capture }); }
+    },
+    window: { getSelection: () => selection, __booxPen: { syncRegions: () => regionsSynced++ } },
+    setTimeout: callback => timeouts.push(callback), console,
+    highlightLectureSelection: range => { highlighted = range; },
+    showLectureSelectionMenu: () => menuShown++, hideLectureSelectionMenu() {}
+};
+vm.createContext(sandbox);
+vm.runInContext(html.slice(guardStart, guardEnd) + html.slice(askStart, askEnd)
+    + html.slice(modeStart, modeEnd), sandbox);
+
+function mode(readerOn, lectureOn, notebookOn, draftOn = false) {
+    sandbox.penMode = readerOn;
+    sandbox.lecturePenMode = lectureOn;
+    sandbox.nbState.tool = notebookOn ? 'pen' : 'text';
+    sandbox.lectureDraftPenEnabled = draftOn;
+    body.classList.toggle('reader-pen-mode', readerOn);
+    body.classList.toggle('lecture-pen-mode', lectureOn);
+    body.classList.toggle('nb-text-mode', !notebookOn);
+    lectureViewer.classList.add('show');
+    notebookEditor.classList.add('show');
+    draft.classList.toggle('active', draftOn);
+}
+function expectBlocked(target, blocked) {
+    for (const type of ['selectstart', 'dragstart', 'contextmenu']) {
+        const registration = registrations.get(type);
+        assert.equal(registration.capture, true, type + ' must use capture');
+        let prevented = false, stopped = false;
+        registration.handler({ target, preventDefault() { prevented = true; }, stopPropagation() { stopped = true; } });
+        assert.equal(prevented, blocked, type + ' target: ' + target.id);
+        assert.equal(stopped, blocked, type + ' propagation: ' + target.id);
+    }
+}
+function makeSelection(anchor, focus = anchor) {
+    selection = { anchorNode: anchor, focusNode: focus, rangeCount: 1,
+        removeAllRanges() { this.rangeCount = 0; }, toString: () => 'selected math',
+        getRangeAt: () => ({ cloneRange: () => ({ marker: 'saved range' }) })
+    };
+    return selection;
+}
+function expectCleared(anchor, focus, cleared) {
+    const selected = makeSelection(anchor, focus);
+    const registration = registrations.get('selectionchange');
+    assert.equal(registration.capture, true);
+    registration.handler();
+    assert.equal(selected.rangeCount, cleared ? 0 : 1, 'selection anchor/focus ownership');
+}
+
+mode(true, true, true, true);
+for (const ink of [readerInk, lectureInk, notebookInk, draftInk]) {
+    expectBlocked(ink, true);
+    expectCleared(textNode(ink), textNode(outside), true);
+    expectCleared(textNode(outside), textNode(ink), true);
+}
+expectBlocked(outside, false);
+expectCleared(textNode(outside), textNode(outside), false);
+
+// Existing reader behavior stays intact; newly protected surfaces allow editing.
+const readerInput = element('readerInput', reader, 'INPUT');
+expectBlocked(readerInput, true);
+for (const container of [lecture, notebook, draft]) {
+    for (const tag of ['INPUT', 'TEXTAREA', 'DIV']) {
+        const edit = element(container.id + tag, container, tag, tag === 'DIV');
+        const target = tag === 'DIV' ? element(edit.id + 'child', edit, 'SPAN') : edit;
+        expectBlocked(target, false);
+        expectCleared(textNode(target), textNode(target), false);
+    }
+}
+
+mode(false, false, false);
+for (const ink of [readerInk, lectureInk, notebookInk, draftInk]) {
+    expectBlocked(ink, false);
+    expectCleared(textNode(ink), textNode(ink), false);
+}
+
+// Non-writing lecture text keeps the existing custom Ask AI selection workflow.
+makeSelection(textNode(lecture));
+sandbox.handleLectureSelection({ target: lecture });
+timeouts.splice(0).forEach(callback => callback());
+assert.equal(sandbox.lectureSelectedText, 'selected math');
+assert.equal(highlighted, sandbox.lectureSelectionRange);
+assert.equal(menuShown, 1);
+assert.equal(selection.rangeCount, 0);
+
+// A queued touchend must not create an Ask AI menu after handwriting is enabled.
+makeSelection(textNode(lecture));
+sandbox.handleLectureSelection({ target: lectureInk });
+mode(false, true, false);
+timeouts.splice(0).forEach(callback => callback());
+assert.equal(menuShown, 1);
+
+// Mode application restores a replacement canvas and publishes its native region.
+makeSelection(textNode(lecture));
+sandbox.applyLectureInputMode();
+assert.ok(body.classList.contains('lecture-pen-mode'));
+assert.ok(lectureInk.classList.contains('active'));
+assert.ok(lectureButton.classList.contains('active'));
+assert.ok(lectureToolbar.classList.contains('show'));
+assert.equal(selection.rangeCount, 0);
+assert.equal(sandbox.window.__lectureNativeWidth, 4);
+const replacementCanvas = element('lectureDrawCanvas', lecture, 'CANVAS');
+sandbox.applyLectureInputMode();
+assert.ok(replacementCanvas.classList.contains('active'));
+assert.equal(regionsSynced, 2);
+sandbox.lecturePenMode = false;
+makeSelection(textNode(lecture));
+sandbox.applyLectureInputMode();
+assert.equal(body.classList.contains('lecture-pen-mode'), false);
+assert.equal(replacementCanvas.classList.contains('active'), false);
+assert.equal(lectureButton.classList.contains('active'), false);
+assert.equal(lectureToolbar.classList.contains('show'), false);
+assert.equal(selection.rangeCount, 1);
+assert.equal(regionsSynced, 3);
+console.log('native selection guards and lecture Ask AI: passed');

--- a/tests/native-selection.test.js
+++ b/tests/native-selection.test.js
@@ -195,4 +195,33 @@ assert.equal(lectureButton.classList.contains('active'), false);
 assert.equal(lectureToolbar.classList.contains('show'), false);
 assert.equal(selection.rangeCount, 1);
 assert.equal(regionsSynced, 3);
-console.log('native selection guards and lecture Ask AI: passed');
+
+// Export/print thumbnails scroll by finger; outline thumbnails keep drag sorting.
+const cssRule = selector => html.split(selector + ' {')[1]?.split('}')[0] || '';
+assert.match(cssRule('#nbExportThumbs .nb-thumb'), /touch-action:\s*pan-y\s*;/);
+assert.match(cssRule('.nb-thumb'), /touch-action:\s*none\s*;/);
+assert.match(cssRule('.nb-quiz-body'), /overflow-y:\s*auto\s*;/);
+assert.doesNotMatch(cssRule('.nb-thumb-placeholder'), /touch-action:\s*none/);
+for (const selector of ['.nb-thumb img', '.nb-thumb .chk']) {
+    assert.match(cssRule(selector), /pointer-events:\s*none\s*;/);
+}
+// Check the real markup, so moving the modal into the canvas would fail this check.
+const divStack = [];
+const markup = html.slice(html.indexOf('<body>'), html.indexOf('<script', html.indexOf('<body>')));
+for (const [tag] of markup.matchAll(/<\/?div\b[^>]*>/g)) {
+    if (tag.startsWith('</')) { divStack.pop(); continue; }
+    const id = tag.match(/\bid="([^"]+)"/)?.[1];
+    if (id === 'nbExportModal') assert.deepEqual(divStack, [], 'export modal must remain outside writing surfaces');
+    divStack.push(id);
+}
+const exportModal = element('nbExportModal', body);
+const exportGrid = element('nbExportThumbs', exportModal);
+const exportThumb = element('exportThumb', exportGrid);
+for (const pencilMode of [false, true]) {
+    mode(true, true, true, true);
+    body.classList.toggle('apple-pencil-mode', pencilMode);
+    for (const [id, tag] of [['placeholder', 'DIV'], ['image', 'IMG'], ['checkbox', 'INPUT']]) {
+        expectBlocked(element('export-' + id, exportThumb, tag), false);
+    }
+}
+console.log('native selection, lecture Ask AI and export touch scrolling: passed');

--- a/tests/notebook-input.test.js
+++ b/tests/notebook-input.test.js
@@ -15,6 +15,26 @@ function source(name) {
 }
 
 const elements = {};
+const nodes = [];
+const documentListeners = {};
+function node(tagName = 'DIV') {
+    const el = { tagName: tagName.toUpperCase(), style: {}, dataset: {}, children: [], listeners: {}, className: '',
+        addEventListener(type, callback) { (this.listeners[type] ||= []).push(callback); },
+        appendChild(child) { this.children.push(child); child.parentElement = this; },
+        closest: () => null, contains(target) { return target === this || this.children.some(c => c.contains(target)); },
+        offsetWidth: 220, offsetHeight: 40,
+        focus() { context.document.activeElement = this; },
+        querySelector(selector) { return this.children.find(c => c.className === selector.slice(1)); },
+    };
+    el.classList = {
+        contains: name => el.className.split(' ').includes(name),
+        add: name => { el.className += ' ' + name; },
+        remove: name => { el.className = el.className.split(' ').filter(c => c !== name).join(' '); },
+        toggle: noop,
+    };
+    nodes.push(el);
+    return el;
+}
 function element(id) {
     return elements[id] ||= {
         id, style: {}, listeners: {}, clientWidth: 1000, clientHeight: 700,
@@ -28,7 +48,12 @@ function element(id) {
 const noop = () => {};
 const context = vm.createContext({
     window: { devicePixelRatio: 1 },
-    document: { getElementById: element, querySelectorAll: () => [] },
+    i18n: key => key,
+    document: { getElementById: element, querySelectorAll: () => [], createElement: node,
+        querySelector: selector => nodes.find(n => n.dataset.id && selector.includes('"' + n.dataset.id + '"')),
+        addEventListener: (type, callback) => { (documentListeners[type] ||= []).push(callback); },
+        removeEventListener: (type, callback) => { documentListeners[type] = (documentListeners[type] || []).filter(f => f !== callback); },
+    },
     applePencilMode: true, NB_PAGE_W: 1000, NB_PAGE_H: 1414, NB_MM: 4,
     nbState: {
         tool: 'pen', shapeType: 'rect', fitScale: 1, zoom: 1, brushIndex: 0,
@@ -36,22 +61,27 @@ const context = vm.createContext({
         drawing: null, selection: null, content: { strokes: [], texts: [], media: [] },
     },
     nbHidePanel: noop, nbHideOutline: noop, nbHideTextToolbar: noop,
-    nbHitBoxAt: () => null, nbUid: () => 'stroke', nbPushOp: noop,
+    nbHitBoxAt: () => null, nbUid: () => 'stroke', nbPushOp: op => context.operations.push(op), operations: [],
     nbRedraw: noop, nbDrawOverlay: noop, nbDrawBg: noop, nbRenderTexts: noop,
-    nbScheduleSave: noop, nbNativeRefresh: noop, nbClearSelection: noop,
+    nbScheduleSave: () => { context.nbState.dirty = true; }, nbNativeRefresh: noop,
+    nbHideSelToolbar: noop, nbPositionSelToolbar: noop, nbPositionTextToolbar: noop,
+    nbSelectTextBox: noop, nbShowTextToolbar: noop, nbGetMediaData: async () => null,
     nbFinishLasso: noop, nbEraseAt: noop, nbShapePaths: () => [[0, 0], [10, 10]],
     nbAddTextBox: () => { context.textCreated++; }, textCreated: 0,
-    nbCtx: () => ({ save: noop, restore: noop, beginPath: noop, moveTo: noop, lineTo: noop, stroke: noop }),
+    nbCtx: () => ({ save: noop, restore: noop, beginPath: noop, moveTo: noop, lineTo: noop, stroke: noop, clearRect: noop, arc: noop }),
     setTimeout: callback => callback(), clearTimeout: noop,
     requestAnimationFrame: callback => callback(), cancelAnimationFrame: noop,
 });
 const functions = ['booxReaderIsPen', 'nbDisplayScale', 'nbEventPoint', 'nbLayout',
-    'nbZoomSet', 'nbInitCanvasEvents', 'nbPointerDown', 'nbPointerMove', 'nbPointerUp'];
-vm.runInContext('let _nbActivePointerId = null;\n' + functions.map(source).join('\n'), context);
+    'nbZoomSet', 'nbInitCanvasEvents', 'nbPointerDown', 'nbPointerMove', 'nbPointerUp', 'nbCancelDrawing',
+    'nbEraseAt', 'nbStrokeHits', 'nbSegDist', 'nbSelStrokes', 'nbCopySelStrokes', 'nbSelBBox',
+    'nbTranslateSelection', 'nbClearSelection', 'nbBuildTextEl', 'nbBuildMediaEl', 'nbApplyOp'];
+vm.runInContext('let _nbActivePointerId = null, _nbActivePointerIsPen = false, _nbTouchGesture = null;\n'
+    + functions.map(source).join('\n'), context);
 
 function pointer(type, id = 1, x = 10, y = 20) {
     return { pointerType: type, pointerId: id, button: 0, clientX: x, clientY: y,
-        target: element('nbCanvas'), preventDefault() { this.prevented = true; } };
+        target: element('nbCanvas'), preventDefault() { this.prevented = true; }, stopPropagation: noop };
 }
 
 // Every canvas tool obeys the same Pencil-only boundary, including mouse input.
@@ -107,8 +137,8 @@ const wrap = element('nbCanvasWrap');
 function touch(x, y, type = 'direct', identifier = 1) {
     return { clientX: x, clientY: y, touchType: type, identifier };
 }
-function dispatch(type, touches) {
-    const event = { type, touches, target: element('nbCanvas'),
+function dispatch(type, touches, target = element('nbCanvas')) {
+    const event = { type, touches, target,
         preventDefault() { this.prevented = true; }, stopPropagation: noop };
     for (const callback of wrap.listeners[type] || []) callback(event);
     return event;
@@ -146,4 +176,175 @@ dispatch('touchcancel', []);
 const scrollTop = wrap.scrollTop;
 dispatch('touchmove', [touch(100, 200)]);
 assert.equal(wrap.scrollTop, scrollTop, 'cancelled gesture cannot keep scrolling');
+
+function reset(tool = 'pen') {
+    context.nbCancelDrawing();
+    dispatch('touchend', []);
+    context.document.activeElement = null;
+    context.applePencilMode = false;
+    Object.assign(context.nbState, { tool, zoom: 1, fitScale: 1, drawing: null,
+        selection: null, dirty: false, content: { strokes: [], texts: [], media: [] } });
+    context.operations.length = 0;
+    context.nbHitBoxAt = () => null;
+    wrap.scrollLeft = 200; wrap.scrollTop = 200;
+}
+const twoFingers = [touch(100, 100), touch(200, 100, 'direct', 2)];
+function startFinger(x = 10, y = 20) {
+    context.nbPointerDown(pointer('touch', 11, x, y));
+    dispatch('touchstart', [touch(x, y)]);
+}
+function startPinch(target) {
+    context.nbPointerDown({ ...pointer('touch', 12), isPrimary: false });
+    dispatch('touchstart', twoFingers, target);
+}
+function docPointer(type, x, y, pointerType = 'touch') {
+    for (const callback of [...(documentListeners[type] || [])]) callback({ ...pointer(pointerType, 11, x, y), type });
+}
+
+// Default mode: the first finger's uncommitted preview disappears when a second
+// finger takes over. Navigation never adds undo entries or finishes a lasso/text tap.
+for (const tool of ['pen', 'shape', 'lasso', 'text']) {
+    reset(tool);
+    const saved = { id: 'saved', paths: [[[400, 400], [500, 500]]] };
+    context.nbState.content.strokes.push(saved);
+    const existingOp = { t: 'existing' };
+    context.operations.push(existingOp);
+    const textCount = context.textCreated;
+    startFinger();
+    context.nbPointerMove(pointer('touch', 11, 50, 60));
+    startPinch();
+    assert.equal(context.nbState.drawing, null, tool + ' preview cancelled');
+    context.nbPointerUp(pointer('touch', 11));
+    assert.deepEqual(context.nbState.content.strokes, [saved]);
+    assert.deepEqual(context.operations, [existingOp], 'navigation preserves undo history');
+    assert.equal(context.textCreated, textCount);
+    assert.equal(context.nbState.dirty, false, 'discarded preview needs no save');
+    dispatch('touchmove', [touch(100, 50), touch(200, 50, 'direct', 2)]);
+    assert.equal(wrap.scrollTop, 250, tool + ' allows two-finger pan');
+    dispatch('touchmove', [touch(50, 50), touch(250, 50, 'direct', 2)]);
+    assert.equal(context.nbState.zoom, 2, tool + ' allows two-finger zoom');
+    dispatch('touchend', [touch(50, 50)]);
+    const stoppedAt = wrap.scrollTop;
+    dispatch('touchmove', [touch(50, 100)]);
+    context.nbPointerMove(pointer('touch', 11, 80, 90));
+    assert.equal(wrap.scrollTop, stoppedAt, 'remaining finger cannot resume navigation or drawing');
+    assert.equal(context.nbState.drawing, null);
+    dispatch('touchend', []);
+}
+
+// Erasure mutates content immediately. Two separate removals use indices from
+// different array states, so undoing their chronological order is significant.
+reset('eraser');
+const original = [
+    { id: 'a', w: 1, paths: [[[10, 10]]] },
+    { id: 'b', w: 1, paths: [[[100, 100]]] },
+    { id: 'c', w: 1, paths: [[[60, 20]]] },
+];
+context.nbState.content.strokes.push(...original);
+startFinger(10, 10);
+context.nbPointerMove(pointer('touch', 11, 60, 20));
+assert.deepEqual(context.nbState.content.strokes.map(s => s.id), ['b']);
+context.nbState.dirty = false; // A previous autosave may have written the partial edit.
+startPinch();
+assert.deepEqual(context.nbState.content.strokes, original, 'restore exact pre-gesture stroke order');
+assert.equal(context.nbState.dirty, true, 'persist the restored content after an earlier autosave');
+assert.equal(context.operations.length, 0);
+
+reset('lasso');
+context.nbState.content.strokes.push({ id: 'selected', paths: [[[10, 20], [20, 30]]] });
+const addSelectionOp = { t: 'add', list: [context.nbState.content.strokes[0]] };
+context.nbState.selection = { ids: ['selected'], bbox: context.nbSelBBox(['selected']) };
+const beforeMove = JSON.stringify(context.nbState.content.strokes);
+const beforeBounds = JSON.stringify(context.nbState.selection.bbox);
+startFinger();
+context.nbPointerMove(pointer('touch', 11, 30, 40));
+assert.notEqual(JSON.stringify(context.nbState.content.strokes), beforeMove);
+startPinch();
+assert.equal(JSON.stringify(context.nbState.content.strokes), beforeMove);
+assert.equal(JSON.stringify(context.nbState.selection.bbox), beforeBounds);
+assert.equal(context.operations.length, 0);
+assert.equal(context.nbState.dirty, true);
+context.nbApplyOp(addSelectionOp, true);
+context.nbApplyOp(addSelectionOp, false);
+assert.equal(JSON.stringify(context.nbState.content.strokes), beforeMove, 'undo/redo keeps the restored stroke reference');
+
+reset();
+const hitBox = { id: 'hit', x: 10, y: 20 };
+context.nbHitBoxAt = () => ({ kind: 'text', obj: hitBox });
+startFinger();
+context.nbPointerMove(pointer('touch', 11, 30, 40));
+assert.equal(hitBox.x, 30);
+context.nbState.dirty = false; // Autosave ran while the box was away from its origin.
+context.nbPointerMove(pointer('touch', 11, 10, 20));
+startPinch();
+assert.deepEqual(hitBox, { id: 'hit', x: 10, y: 20 });
+assert.equal(context.nbState.dirty, true);
+
+// Text/media DOM drags and resize handles participate in the same cancellation,
+// including removing their document listeners so later pointer events cannot move them.
+for (const kind of ['text', 'image', 'audio', 'resize']) {
+    reset();
+    const obj = { id: kind, x: 10, y: 20, w: 220, fontSize: 18, type: kind };
+    const el = (kind === 'text' || kind === 'resize') ? context.nbBuildTextEl(obj) : context.nbBuildMediaEl(obj);
+    const target = kind === 'resize' ? el.children.find(c => c.dataset.c === 'br') : el;
+    const before = JSON.stringify(obj);
+    target.listeners.pointerdown[0]({ ...pointer('touch', 11), target });
+    dispatch('touchstart', [touch(10, 20)], target);
+    docPointer('pointermove', 50, 70);
+    assert.notEqual(JSON.stringify(obj), before, kind + ' actually moved');
+    context.nbState.dirty = false; // A prior save may contain the transient position/size.
+    docPointer('pointermove', 10, 20);
+    startPinch(target);
+    assert.equal(JSON.stringify(obj), before, kind + ' restored');
+    assert.equal(context.nbState.drawing, null);
+    assert.equal(context.nbState.dirty, true);
+    for (const type of ['pointermove', 'pointerup', 'pointercancel']) assert.equal(documentListeners[type].length, 0);
+    docPointer('pointermove', 90, 100);
+    assert.equal(JSON.stringify(obj), before);
+    dispatch('touchmove', [touch(100, 50), touch(200, 50, 'direct', 2)], target);
+    assert.equal(wrap.scrollTop, 250, kind + ' surface allows navigation');
+    assert.equal(context.operations.length, 0);
+}
+
+// A real pen stroke or object drag is never rolled back by two fingers, even
+// when the Pencil-only preference is disabled.
+for (const pencilOnly of [false, true]) {
+    reset();
+    context.applePencilMode = pencilOnly;
+    context.nbPointerDown(pointer('pen', 11));
+    const penDrawing = context.nbState.drawing;
+    startPinch();
+    dispatch('touchmove', [touch(100, 50), touch(200, 50, 'direct', 2)]);
+    assert.equal(context.nbState.drawing, penDrawing);
+    assert.equal(wrap.scrollTop, 200);
+    context.nbPointerUp(pointer('pen', 11));
+
+    reset();
+    context.applePencilMode = pencilOnly;
+    const obj = { id: 'pen-box', x: 10, y: 20 };
+    const el = context.nbBuildTextEl(obj);
+    el.listeners.pointerdown[0]({ ...pointer('pen', 11), target: el });
+    const penDrag = context.nbState.drawing;
+    startPinch(el);
+    assert.equal(context.nbState.drawing, penDrag);
+    docPointer('pointermove', 40, 50, 'pen');
+    docPointer('pointerup', 40, 50, 'pen');
+    assert.equal(obj.x, 40);
+}
+
+reset('text');
+const textCount = context.textCreated;
+startFinger();
+assert.equal(context.textCreated, textCount, 'text creation waits for tap release');
+context.nbPointerUp(pointer('touch', 11));
+assert.equal(context.textCreated, textCount + 1);
+reset('text');
+startFinger();
+context.nbPointerUp({ ...pointer('touch', 11), type: 'pointercancel' });
+assert.equal(context.textCreated, textCount + 1, 'a cancelled touch never creates text');
+reset();
+startFinger();
+context.nbPointerMove(pointer('touch', 11, 30, 40));
+context.nbPointerUp(pointer('touch', 11));
+assert.equal(context.nbState.content.strokes.length, 1, 'single-finger writing still commits');
 console.log('Notebook input checks passed');

--- a/tests/notebook-input.test.js
+++ b/tests/notebook-input.test.js
@@ -1,0 +1,149 @@
+// Run with: node tests/notebook-input.test.js
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const html = fs.readFileSync(path.join(__dirname, '../docs/index.html'), 'utf8');
+function source(name) {
+    const start = html.indexOf('        function ' + name + '(');
+    assert.notEqual(start, -1, name + ' exists');
+    const lineEnd = html.indexOf('\n', start);
+    const end = html.slice(start, lineEnd).trimEnd().endsWith('}')
+        ? lineEnd : html.indexOf('\n        }', lineEnd) + 10;
+    return html.slice(start, end);
+}
+
+const elements = {};
+function element(id) {
+    return elements[id] ||= {
+        id, style: {}, listeners: {}, clientWidth: 1000, clientHeight: 700,
+        scrollLeft: 200, scrollTop: 200,
+        classList: { contains: () => true },
+        addEventListener(type, callback) { (this.listeners[type] ||= []).push(callback); },
+        getBoundingClientRect: () => ({ left: 0, top: 0, width: 1000, height: 1414 }),
+        setPointerCapture() {}, closest: () => null,
+    };
+}
+const noop = () => {};
+const context = vm.createContext({
+    window: { devicePixelRatio: 1 },
+    document: { getElementById: element, querySelectorAll: () => [] },
+    applePencilMode: true, NB_PAGE_W: 1000, NB_PAGE_H: 1414, NB_MM: 4,
+    nbState: {
+        tool: 'pen', shapeType: 'rect', fitScale: 1, zoom: 1, brushIndex: 0,
+        brushes: [{ type: 'pen', color: '#111111', mm: 0.5 }],
+        drawing: null, selection: null, content: { strokes: [], texts: [], media: [] },
+    },
+    nbHidePanel: noop, nbHideOutline: noop, nbHideTextToolbar: noop,
+    nbHitBoxAt: () => null, nbUid: () => 'stroke', nbPushOp: noop,
+    nbRedraw: noop, nbDrawOverlay: noop, nbDrawBg: noop, nbRenderTexts: noop,
+    nbScheduleSave: noop, nbNativeRefresh: noop, nbClearSelection: noop,
+    nbFinishLasso: noop, nbEraseAt: noop, nbShapePaths: () => [[0, 0], [10, 10]],
+    nbAddTextBox: () => { context.textCreated++; }, textCreated: 0,
+    nbCtx: () => ({ save: noop, restore: noop, beginPath: noop, moveTo: noop, lineTo: noop, stroke: noop }),
+    setTimeout: callback => callback(), clearTimeout: noop,
+    requestAnimationFrame: callback => callback(), cancelAnimationFrame: noop,
+});
+const functions = ['booxReaderIsPen', 'nbDisplayScale', 'nbEventPoint', 'nbLayout',
+    'nbZoomSet', 'nbInitCanvasEvents', 'nbPointerDown', 'nbPointerMove', 'nbPointerUp'];
+vm.runInContext('let _nbActivePointerId = null;\n' + functions.map(source).join('\n'), context);
+
+function pointer(type, id = 1, x = 10, y = 20) {
+    return { pointerType: type, pointerId: id, button: 0, clientX: x, clientY: y,
+        target: element('nbCanvas'), preventDefault() { this.prevented = true; } };
+}
+
+// Every canvas tool obeys the same Pencil-only boundary, including mouse input.
+for (const tool of ['pen', 'eraser', 'lasso', 'shape', 'text']) {
+    for (const type of ['touch', 'mouse', '']) {
+        context.nbState.tool = tool;
+        context.nbPointerDown(pointer(type));
+        assert.equal(context.nbState.drawing, null, tool + ' rejects ' + type);
+        assert.equal(context.nbState.content.strokes.length, 0);
+        assert.equal(context.textCreated, 0);
+    }
+}
+
+// A palm cannot replace, move, or end a Pencil stroke.
+context.nbState.tool = 'pen';
+context.nbPointerDown(pointer('pen', 1));
+const drawing = context.nbState.drawing;
+assert.ok(drawing);
+context.nbPointerDown(pointer('touch', 2));
+context.nbPointerDown(pointer('pen', 4));
+context.nbPointerMove(pointer('touch', 2, 80, 90));
+context.nbPointerUp(pointer('touch', 2));
+assert.equal(context.nbState.drawing, drawing);
+assert.equal(drawing.stroke.paths[0].length, 1);
+context.nbPointerMove(pointer('pen', 1, 30, 40));
+assert.equal(drawing.stroke.paths[0].length, 2);
+context.nbPointerUp(pointer('pen', 1));
+assert.equal(context.nbState.drawing, null);
+assert.equal(context.nbState.content.strokes.length, 1);
+
+// Disabling the preference preserves finger writing.
+context.applePencilMode = false;
+context.nbPointerDown(pointer('touch', 3));
+context.nbPointerMove(pointer('touch', 3, 35, 45));
+context.nbPointerUp(pointer('touch', 3));
+assert.equal(context.nbState.content.strokes.length, 2);
+context.applePencilMode = true;
+
+// The shared native stylus detector also accepts BOOX pen replay events.
+context.window.__booxInput = { isPen: event => event.nativePen === true };
+context.nbPointerDown({ ...pointer('touch', 5), nativePen: true });
+assert.ok(context.nbState.drawing);
+context.nbPointerUp(pointer('touch', 5));
+delete context.window.__booxInput;
+
+// A wide/short viewport fills the writing area horizontally rather than shrinking to its height.
+context.nbLayout();
+assert.equal(element('nbPageBox').style.width, '1000px');
+assert.equal(element('nbPageBox').style.height, '1414px');
+
+context.nbInitCanvasEvents();
+const wrap = element('nbCanvasWrap');
+function touch(x, y, type = 'direct', identifier = 1) {
+    return { clientX: x, clientY: y, touchType: type, identifier };
+}
+function dispatch(type, touches) {
+    const event = { type, touches, target: element('nbCanvas'),
+        preventDefault() { this.prevented = true; }, stopPropagation: noop };
+    for (const callback of wrap.listeners[type] || []) callback(event);
+    return event;
+}
+assert.ok(wrap.listeners.touchstart, 'notebook wrapper handles touch navigation');
+dispatch('touchstart', [touch(100, 100)]);
+dispatch('touchmove', [touch(120, 130)]);
+assert.equal(wrap.scrollLeft, 180, 'one finger pans horizontally');
+assert.equal(wrap.scrollTop, 170, 'one finger pans vertically');
+dispatch('touchend', []);
+
+dispatch('touchstart', [touch(100, 100), touch(200, 100, 'direct', 2)]);
+dispatch('touchmove', [touch(50, 100), touch(250, 100, 'direct', 2)]);
+dispatch('touchend', []);
+assert.equal(context.nbState.zoom, 2, 'two fingers zoom using notebook zoom');
+assert.equal(wrap.scrollLeft, 510, 'pinch preserves the horizontal content anchor');
+assert.equal(wrap.scrollTop, 440, 'pinch preserves the vertical content anchor');
+
+const zoom = context.nbState.zoom;
+dispatch('touchstart', [touch(100, 100, 'stylus'), touch(200, 100, 'direct', 2)]);
+dispatch('touchmove', [touch(50, 100, 'stylus'), touch(250, 100, 'direct', 2)]);
+dispatch('touchend', []);
+assert.equal(context.nbState.zoom, zoom, 'Pencil plus finger never becomes a pinch');
+
+context.nbPointerDown(pointer('pen', 6));
+const inkScrollTop = wrap.scrollTop;
+dispatch('touchstart', [touch(100, 100)]);
+dispatch('touchmove', [touch(100, 200)]);
+assert.equal(wrap.scrollTop, inkScrollTop, 'a palm cannot scroll an active Pencil stroke');
+context.nbPointerUp(pointer('pen', 6));
+dispatch('touchend', []);
+
+dispatch('touchstart', [touch(100, 100)]);
+dispatch('touchcancel', []);
+const scrollTop = wrap.scrollTop;
+dispatch('touchmove', [touch(100, 200)]);
+assert.equal(wrap.scrollTop, scrollTop, 'cancelled gesture cannot keep scrolling');
+console.log('Notebook input checks passed');


### PR DESCRIPTION
修复笔记本、讲义和导出选页的触屏书写与滚动问题。

- 笔记列表去掉外层留白，纸张按可用宽度适配。普通模式保留单指绘制，支持双指平移和缩放；Apple Pencil 模式使用手指导航、笔书写。双指接管时撤回尚未完成的笔画、擦除或对象移动，避免杂点、误删和误建文本框。
- 讲义手写时翻页热区透传，BOOX 原生区域按可见滚动容器裁剪，并跟随笔宽与橡皮状态更新。
- 讲义草稿接收原生 PointerEvent 回放，笔可以接管先落下的手指平移；侧橡皮按当前笔画擦除，抬笔后保留原工具，沿用撤销和保存流程。
- 导出／打印选页的缩略图允许手指纵向滚动，保留大纲缩略图的拖动排序行为。
- 笔记本和讲义共用手写禁选保护，保留可编辑文本及非手写讲义选文问 AI。

验证：

- `node tests/notebook-input.test.js`
- `node tests/native-selection.test.js`
- `node tests/boox-pen.test.js`
- 内联 JavaScript 语法、`git diff --check`、Android HTML 与 `docs/index.html` 一致性检查。
- Chrome 实际触摸事件对照：导出选页在普通／Pencil 模式、占位图／已加载图片四种组合中，修复前从缩略图上滑动均不滚页，修复后均可滚动。
- Chrome 实际笔记本触摸事件：第一指开始绘制后第二指接管，双指平移及缩放不留下临时笔画或撤销记录，结束后单指绘制正常；Pencil 模式的单指导航正常。
- APK 构建流程加入上述三组回归检查和 HTML 一致性检查。

未连接真实 iPad／Apple Pencil 或 BOOX 设备；浏览器触摸模拟和函数回放已覆盖输入状态与滚动路径，硬件书写延迟和系统打印界面仍需设备验收。
