### PR TITLE
紧急抢救包：启动原生 ZIP 导出，不加载 WebView

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -35,6 +35,12 @@ jobs:
           cmp app/src/main/assets/www/classroom-storage.js docs/classroom-storage.js
           cmp app/src/main/assets/www/recording-ai.js docs/recording-ai.js
 
+      - name: Check bounded native data recovery
+        run: |
+          mkdir -p /tmp/raw-recovery-check
+          javac -d /tmp/raw-recovery-check app/src/main/java/com/mathreader/boox/RawDataBackup.java tests/RawDataBackupCheck.java
+          java -ea -Xmx32m -cp /tmp/raw-recovery-check RawDataBackupCheck
+
       - name: Calculate APK version
         id: version
         shell: bash

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
 
     <application
-        android:name=".MainApp"
+        android:name="android.app.Application"
         android:allowBackup="true"
         android:hardwareAccelerated="true"
         android:icon="@mipmap/ic_launcher"
@@ -18,7 +18,7 @@
         android:theme="@style/AppTheme">
 
         <activity
-            android:name=".MainActivity"
+            android:name=".RawRecoveryActivity"
             android:exported="true"
             android:launchMode="singleTask"
             android:configChanges="keyboard|keyboardHidden|orientation|screenSize|screenLayout|smallestScreenSize|uiMode|density"

--- a/app/src/main/java/com/mathreader/boox/RawDataBackup.java
+++ b/app/src/main/java/com/mathreader/boox/RawDataBackup.java
@@ -1,0 +1,105 @@
+package com.mathreader.boox;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+/** Cold-start copy: never opens a database or loads WebView. */
+public final class RawDataBackup {
+    private RawDataBackup() {}
+
+    public static long[] write(Path root, OutputStream output,
+                               BiConsumer<Long, Long> progress) throws IOException {
+        if (!Files.isDirectory(root.resolve("app_webview"))) {
+            throw new IOException("没有找到本机 WebView 数据，已停止导出");
+        }
+        long[] totals = {0, 0, 0};
+        List<String> errors = new ArrayList<>();
+        byte[] buffer = new byte[128 * 1024];
+        try (ZipOutputStream zip = new ZipOutputStream(output)) {
+            // Streaming level 0 supports unknown sizes and ZIP64 without rereading sources.
+            zip.setLevel(0);
+            Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                    return root.relativize(dir).toString().equals("lib")
+                            ? FileVisitResult.SKIP_SUBTREE : FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes before) throws IOException {
+                    String relative = root.relativize(file).toString();
+                    if (relative.equals("lib")) return FileVisitResult.CONTINUE;
+                    if (!before.isRegularFile()) {
+                        errors.add(relative + ": 非普通文件，未跟随链接");
+                        return FileVisitResult.CONTINUE;
+                    }
+                    InputStream input;
+                    try { input = Files.newInputStream(file); }
+                    catch (IOException e) {
+                        errors.add(relative + ": " + e);
+                        return FileVisitResult.CONTINUE;
+                    }
+                    long copied = 0;
+                    try {
+                        ZipEntry entry = new ZipEntry("private/" + relative.replace('\\', '/'));
+                        entry.setTime(before.lastModifiedTime().toMillis());
+                        zip.putNextEntry(entry);
+                        while (true) {
+                            int count;
+                            try { count = input.read(buffer); }
+                            catch (IOException e) { errors.add(relative + ": " + e); break; }
+                            if (count == -1) break;
+                            zip.write(buffer, 0, count);
+                            copied += count;
+                            totals[1] += count;
+                            progress.accept(totals[0], totals[1]);
+                        }
+                        zip.closeEntry();
+                    } finally {
+                        try { input.close(); }
+                        catch (IOException e) { errors.add(relative + ": " + e); }
+                    }
+                    try {
+                        BasicFileAttributes after = Files.readAttributes(file, BasicFileAttributes.class);
+                        if (copied != before.size() || copied != after.size() ||
+                                !before.lastModifiedTime().equals(after.lastModifiedTime())) {
+                            errors.add(relative + ": 复制期间文件变化或未读完整，已复制 " + copied + "/" + before.size());
+                        }
+                    } catch (IOException e) { errors.add(relative + ": " + e); }
+                    totals[0]++;
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFileFailed(Path file, IOException error) {
+                    errors.add(root.relativize(file) + ": " + error);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+            if (totals[0] == 0) throw new IOException("没有读到本机文件");
+            zip.putNextEntry(new ZipEntry("recovery-info.txt"));
+            String info = "format=math-reader-raw-local-v1\nfiles=" + totals[0] + "\nbytes=" + totals[1]
+                    + "\nerrors=" + errors.size()
+                    + "\nRaw private files for recovery; not a normal in-app import ZIP.\n"
+                    + "Excluded installed native library directory: lib.\n";
+            zip.write(info.getBytes(StandardCharsets.UTF_8));
+            zip.closeEntry();
+            if (!errors.isEmpty()) {
+                zip.putNextEntry(new ZipEntry("recovery-errors.txt"));
+                zip.write(String.join("\n", errors).getBytes(StandardCharsets.UTF_8));
+                zip.closeEntry();
+            }
+            totals[2] = errors.size();
+        }
+        return totals;
+    }
+}

--- a/app/src/main/java/com/mathreader/boox/RawRecoveryActivity.java
+++ b/app/src/main/java/com/mathreader/boox/RawRecoveryActivity.java
@@ -1,0 +1,130 @@
+package com.mathreader.boox;
+
+import android.app.Activity;
+import android.content.ContentValues;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Environment;
+import android.os.SystemClock;
+import android.provider.MediaStore;
+import android.view.WindowManager;
+import android.widget.Button;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Locale;
+import java.util.UUID;
+
+/** Emergency-only launcher. The manifest deliberately does not register MainActivity. */
+public final class RawRecoveryActivity extends Activity {
+    private TextView status;
+    private Button export;
+    private volatile boolean exporting;
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        LinearLayout layout = new LinearLayout(this);
+        layout.setOrientation(LinearLayout.VERTICAL);
+        int padding = (int) (24 * getResources().getDisplayMetrics().density);
+        layout.setPadding(padding, padding, padding, padding);
+        status = new TextView(this);
+        status.setTextSize(20);
+        status.setText("Math Reader 本机数据抢救\n\n保持设备断网。点击下方按钮后，请留在此页面，等待提示完成。\n\n本页面直接复制本机原始文件，不加载阅读器，不修改原始数据。");
+        layout.addView(status);
+        export = new Button(this);
+        export.setText("导出本机原始数据");
+        export.setOnClickListener(v -> startExport());
+        layout.addView(export);
+        setContentView(layout);
+    }
+
+    private void startExport() {
+        if (exporting) return;
+        exporting = true;
+        export.setEnabled(false);
+        getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        status.setText("正在复制本机原始数据，请保持此页面打开…");
+        new Thread(() -> {
+            Uri uri = null;
+            File partial = null;
+            String name = "math-reader-raw-recovery-" +
+                    new SimpleDateFormat("yyyyMMdd-HHmmss", Locale.US).format(new Date()) +
+                    "-" + UUID.randomUUID().toString().substring(0, 8) + ".zip";
+            try {
+                OutputStream output;
+                String location;
+                if (Build.VERSION.SDK_INT >= 29) {
+                    ContentValues values = new ContentValues();
+                    values.put(MediaStore.Downloads.DISPLAY_NAME, name);
+                    values.put(MediaStore.Downloads.MIME_TYPE, "application/zip");
+                    values.put(MediaStore.Downloads.RELATIVE_PATH, Environment.DIRECTORY_DOWNLOADS);
+                    values.put(MediaStore.Downloads.IS_PENDING, 1);
+                    uri = getContentResolver().insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values);
+                    if (uri == null) throw new IOException("无法创建下载文件");
+                    output = getContentResolver().openOutputStream(uri);
+                    location = "Download/" + name;
+                } else {
+                    File dir = getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS);
+                    if (dir == null || !(dir.isDirectory() || dir.mkdirs())) {
+                        throw new IOException("无法创建下载目录");
+                    }
+                    partial = File.createTempFile(".recovery-", ".part", dir);
+                    output = new FileOutputStream(partial);
+                    location = new File(dir, name).getAbsolutePath();
+                }
+                if (output == null) throw new IOException("无法写入下载文件");
+                long[] lastUpdate = {0};
+                long[] totals;
+                try (OutputStream buffered = new BufferedOutputStream(output, 256 * 1024)) {
+                    totals = RawDataBackup.write(new File(getApplicationInfo().dataDir).toPath(), buffered,
+                            (files, bytes) -> {
+                        long now = SystemClock.elapsedRealtime();
+                        if (now - lastUpdate[0] < 500) return;
+                        lastUpdate[0] = now;
+                        runOnUiThread(() -> status.setText("正在复制：" + files + " 个文件，" +
+                                (bytes / 1024 / 1024) + " MB\n请保持此页面打开…"));
+                    });
+                }
+                if (uri != null) {
+                    ContentValues values = new ContentValues();
+                    values.put(MediaStore.Downloads.IS_PENDING, 0);
+                    if (getContentResolver().update(uri, values, null, null) != 1) {
+                        throw new IOException("无法完成下载文件");
+                    }
+                } else {
+                    java.nio.file.Files.move(partial.toPath(), new File(location).toPath());
+                }
+                String message = (totals[2] == 0 ? "原始数据复制完成\n" : "可读取部分已复制，存在 " + totals[2] + " 项读取异常（详见 ZIP 内清单）\n") + totals[0] + " 个文件，" +
+                        (totals[1] / 1024 / 1024) + " MB\n\n" + location +
+                        "\n\n保持断网，通过 USB 复制到电脑后校验。这个原始快照不能直接用于应用内导入。";
+                runOnUiThread(() -> status.setText(message));
+            } catch (Exception e) {
+                try {
+                    if (uri != null) getContentResolver().delete(uri, null, null);
+                    if (partial != null) partial.delete();
+                } catch (Exception ignored) { /* never touch source files */ }
+                runOnUiThread(() -> status.setText("导出未完成：" + e.getMessage() + "\n原始数据未修改。"));
+            } finally {
+                exporting = false;
+                runOnUiThread(() -> {
+                    export.setEnabled(true);
+                    getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+                });
+            }
+        }, "raw-local-recovery").start();
+    }
+
+    @Override
+    public void onBackPressed() {
+        if (!exporting) super.onBackPressed();
+    }
+}

--- a/tests/RawDataBackupCheck.java
+++ b/tests/RawDataBackupCheck.java
@@ -1,0 +1,74 @@
+import com.mathreader.boox.RawDataBackup;
+import java.io.*;
+import java.nio.file.*;
+import java.security.*;
+import java.util.*;
+import java.util.zip.*;
+
+public class RawDataBackupCheck {
+    private static byte[] hash(InputStream in) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        byte[] buffer = new byte[64 * 1024];
+        int count;
+        while ((count = in.read(buffer)) != -1) digest.update(buffer, 0, count);
+        return digest.digest();
+    }
+    public static void main(String[] args) throws Exception {
+        Path tmp = Files.createTempDirectory("raw-data-check-");
+        try {
+            Path root = Files.createDirectories(tmp.resolve("private"));
+            Path db = Files.createDirectories(root.resolve("app_webview/Default/IndexedDB"));
+            Files.writeString(db.resolve("CURRENT"), "MANIFEST-000001\n");
+            Files.writeString(db.resolve("MANIFEST-000001"), "raw database manifest");
+            Files.writeString(Files.createDirectories(root.resolve("shared_prefs")).resolve("设置.xml"), "本地设置");
+            Files.writeString(Files.createDirectories(root.resolve("cache")).resolve("recoverable"), "preserved");
+            Files.createDirectories(root.resolve("lib"));
+            Files.writeString(root.resolve("lib/generated"), "not user data");
+            Path recording = Files.createDirectories(root.resolve("no_backup/recordings/id")).resolve("data.bin");
+            try (OutputStream out = Files.newOutputStream(recording)) {
+                byte[] chunk = new byte[128 * 1024];
+                new Random(3).nextBytes(chunk);
+                for (int i = 0; i < 512; i++) out.write(chunk);
+            }
+            Path zipPath = tmp.resolve("snapshot.zip");
+            long[] totals;
+            try (OutputStream out = Files.newOutputStream(zipPath)) {
+                totals = RawDataBackup.write(root, out, (files, bytes) -> {});
+            }
+            assert totals[0] == 5 && totals[1] > 64L * 1024 * 1024 && totals[2] == 0;
+            int entries = 0;
+            try (ZipInputStream zip = new ZipInputStream(Files.newInputStream(zipPath))) {
+                ZipEntry entry;
+                while ((entry = zip.getNextEntry()) != null) {
+                    entries++;
+                    if (entry.getName().startsWith("private/")) {
+                        try (InputStream in = Files.newInputStream(root.resolve(entry.getName().substring(8)))) {
+                            assert Arrays.equals(hash(in), hash(zip)) : entry.getName();
+                        }
+                    } else {
+                        assert entry.getName().equals("recovery-info.txt");
+                        assert new String(zip.readAllBytes()).contains("errors=0");
+                    }
+                    zip.closeEntry();
+                }
+            }
+            assert entries == 6;
+            assert Files.readString(db.resolve("CURRENT")).equals("MANIFEST-000001\n");
+            Files.createSymbolicLink(root.resolve("outside"), tmp);
+            long[] partial = RawDataBackup.write(root, OutputStream.nullOutputStream(), (files, bytes) -> {});
+            assert partial[2] == 1 : "special sources must be explicitly reported";
+            boolean failed = false;
+            try {
+                RawDataBackup.write(root, new OutputStream() {
+                    public void write(int value) throws IOException { throw new IOException("disk full"); }
+                }, (files, bytes) -> {});
+            } catch (IOException expected) { failed = true; }
+            assert failed : "destination failure must never report success";
+            System.out.println("Raw recovery: 64 MiB source under 32 MiB heap, source hashes, CRC, error reporting and write failures passed");
+        } finally {
+            try (var paths = Files.walk(tmp)) {
+                for (Path p : paths.sorted(Comparator.reverseOrder()).toArray(Path[]::new)) Files.delete(p);
+            }
+        }
+    }
+}


### PR DESCRIPTION
仅用于当前 BOOX 数据抢救，不作为正常阅读版本合并。包名和正式签名保持一致；入口替换为原生导出界面，默认 Application 不初始化阅读器或 SDK，避免 WebView 启动及整库打包导致进程退出。以 128 KiB 缓冲流式复制本机应用私有目录到 Download 中单个 ZIP，包含数据库、Blob 文件、录音、设置及缓存；源文件只读。读取异常逐项写入清单并保留其余可读数据；输出写入失败不报告成功。这个 ZIP 是原始数据快照，不能直接用于现有应用内导入。全部网页、云同步代码、云调用和原有保存触发相对 PR97 逐字不变。已通过 32 MiB JVM 堆下复制并逐文件 SHA256 校验 64 MiB 测试源、ZIP CRC、读取异常报告、输出失败检查以及 Android assembleRelease。真实 BOOX 快照仍待设备执行。