### PR TITLE
修复旧 ZIP 导入后的启动与定时同步覆盖，保留离线评分恢复

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -17,6 +17,7 @@ jobs:
 
       - name: Check handwriting input and shared page
         run: |
+          node tests/cloud-sync-restore.test.js
           node tests/zip-import.test.js
           node tests/notebook-input.test.js
           node tests/native-selection.test.js

--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -14416,6 +14416,8 @@
         }
 
         async function r2PublishMetadataWithCas(localMetadata, classroomIntent, options = {}) {
+            // 导入的离线评分也必须先有完整图片，不能先发布只有分数的索引。
+            await exEnsureImportedGradedPages();
             // 这是 metadata.json 所有发布路径的最后一道门（包括手动全量同步和
             // 云端尚无 metadata 时的课堂首传）。刷新 exercises 快照，确保刚上传
             // 完成的持久标记也进入本次 CAS。
@@ -16740,6 +16742,10 @@
                     if (exPreserveActiveExercisePageCount()) repairMetadataAfterStartup = true;
                 }
                 if (!appData.exercises) appData.exercises = { folders: [], wrongByFolder: {}, archivedWrong: {} };
+                if (exCollectUncommittedGradedCloudEntries(appData.exercises, true)
+                    .some(entry => entry.records.some(record => record.gradedDrawingCloudCommitted === 'imported'))) {
+                    repairMetadataAfterStartup = true;
+                }
                 appData.settings = { ...metadata.settings, ...localApiSettings, r2Config: localR2Config };
                 appDataLoaded = true;
                 saveData();
@@ -17883,10 +17889,9 @@
                     _callNativeRecording('deleteRecording', id);
                     await deleteFileData('classroom_' + id).catch(() => {});
                 }
-                // 备份中的待上传标记属于导出时的旧状态；导入后按 PR88 从云端恢复。
-                // 保留评分和图片，以及正常本机新评分的断点补传。
-                for (const entry of exCollectUncommittedGradedCloudEntries(appData.exercises)) {
-                    for (const record of entry.records) delete record.gradedDrawingCloudCommitted;
+                // 导入来源单独标记：不压过云端已有评分，但独有评分必须先补齐图片再发布。
+                for (const entry of exCollectUncommittedGradedCloudEntries(appData.exercises, true)) {
+                    for (const record of entry.records) record.gradedDrawingCloudCommitted = 'imported';
                 }
                 if (typeof saveExercisesToIDB === 'function') await saveExercisesToIDB();
                 const metadataSaved = saveData();
@@ -25694,6 +25699,30 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     }
                 }
                 return { exercisesForPublish, uploadedSignatures };
+            }
+        }
+
+        async function exEnsureImportedGradedPages() {
+            for (const entry of exCollectUncommittedGradedCloudEntries(appData.exercises, true)) {
+                const imported = entry.records.filter(record => record.gradedDrawingCloudCommitted === 'imported');
+                if (!imported.length) continue;
+                for (let p = 0; p < entry.pageCount; p++) {
+                    for (const baseKey of entry.baseKeys) {
+                        const key = exPageKey(baseKey, p);
+                        if (await r2GetObject('exercises/drawings/' + key)) continue;
+                        const data = await exReadRedoPageFromLocal(entry.baseKeys, null, p);
+                        if (!data) throw new Error('Imported exercise drawing is missing: ' + key);
+                        try {
+                            await r2PutObject('exercises/drawings/' + key, data,
+                                'image/png', { ifNoneMatch: '*' });
+                        } catch (error) {
+                            if (error?.status !== 412) throw error;
+                        }
+                    }
+                }
+                for (const record of imported) {
+                    if (record.gradedDrawingCloudCommitted === 'imported') record.gradedDrawingCloudCommitted = true;
+                }
             }
         }
 

--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -14416,16 +14416,15 @@
         }
 
         async function r2PublishMetadataWithCas(localMetadata, classroomIntent, options = {}) {
-            // 导入的离线评分也必须先有完整图片，不能先发布只有分数的索引。
-            await exEnsureImportedGradedPages();
-            // 这是 metadata.json 所有发布路径的最后一道门（包括手动全量同步和
-            // 云端尚无 metadata 时的课堂首传）。刷新 exercises 快照，确保刚上传
-            // 完成的持久标记也进入本次 CAS。
-            const gradingFlush = await exFlushGradedDrawingCloudCommits();
-            localMetadata = {
-                ...localMetadata,
-                exercises: gradingFlush.exercisesForPublish
-            };
+            if (!options.classroomOnly) {
+                // 发布本地评分前必须先有完整图片；课堂专用请求不携带本地习题。
+                await exEnsureImportedGradedPages();
+                const gradingFlush = await exFlushGradedDrawingCloudCommits();
+                localMetadata = {
+                    ...localMetadata,
+                    exercises: gradingFlush.exercisesForPublish
+                };
+            }
             const frozenClassroom = classroomIntent || stripClassroomData(appData.classroom, false);
             let lastConflict = null;
             for (let attempt = 0; attempt < 5; attempt++) {
@@ -14456,8 +14455,9 @@
                 const mergedIntent = remoteClassroomCount === 0 && localClassroomCount > 0
                     ? localClassroom
                     : mergeClassroomData(remoteClassroom, localClassroom, remoteBaseline);
-                let candidateBase = options.classroomOnly && remoteMetadata
-                    ? remoteMetadata
+                // 课堂首传也只创建课堂索引，不能顺带发布未校验的本地习题和笔记。
+                let candidateBase = options.classroomOnly
+                    ? (remoteMetadata || {})
                     : localMetadata;
                 if (!options.classroomOnly) {
                     // 文件变更同步不会先跑完整的 pull。提交前把远端同一条习题的版本化
@@ -14532,11 +14532,11 @@
                         Date.parse(candidate.syncedAt) || 0);
                     await cleanupClassroomEntriesRemovedByMerge(liveBefore, applied);
                     appData.classroom = applied;
-                    appData.lectures = mergeLecturesData(candidate.lectures, appData.lectures,
-                        Date.parse(candidate.syncedAt) || 0);
-                    appData.notebooks = mergeNotebooksData(candidate.notebooks, appData.notebooks,
-                        Date.parse(candidate.syncedAt) || 0);
                     if (!options.classroomOnly) {
+                        appData.lectures = mergeLecturesData(candidate.lectures, appData.lectures,
+                            Date.parse(candidate.syncedAt) || 0);
+                        appData.notebooks = mergeNotebooksData(candidate.notebooks, appData.notebooks,
+                            Date.parse(candidate.syncedAt) || 0);
                         // 网络等待期间本机可能又产生了更新；仍用同一套版本规则合回活对象，
                         // 既接收远端较新的清空，也不会压掉刚发生的本机重做。
                         exMergeMatchingExerciseHistories(appData.exercises, candidate.exercises, true);

--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -16720,6 +16720,8 @@
                     JSON.stringify(metadata.notebooks || { items: [], reviews: [] })) {
                     repairMetadataAfterStartup = true;
                 }
+                // 沿用 PR88 的讲义/笔记修复范围；习题元数据补传不上传笔记正文。
+                const repairNotebookPagesAfterStartup = repairMetadataAfterStartup;
                 if (metadata.exercises) {
                     const cloudEx = metadata.exercises;
                     const localEx = appData.exercises || { folders: [], wrongByFolder: {}, archivedWrong: {} };
@@ -16801,7 +16803,7 @@
                 if (repairMetadataAfterStartup) {
                     // 修复只补齐云端缺的那部分：正文按版本增量上传，不把本机旧正文回传。
                     await r2SyncChangedLectureContents();
-                    await r2SyncAllNotebookPages();
+                    if (repairNotebookPagesAfterStartup) await r2SyncAllNotebookPages();
                     await r2SyncMetadataOnly();
                 }
                 if (config.lastSyncTime || metadata.syncedAt) {
@@ -17993,8 +17995,15 @@
                     _callNativeRecording('deleteRecording', id);
                     await deleteFileData('classroom_' + id).catch(() => {});
                 }
+                // 备份中的待上传标记属于导出时的旧状态；导入后按 PR88 从云端恢复。
+                // 保留评分和图片，以及正常本机新评分的断点补传。
+                for (const entry of exCollectUncommittedGradedCloudEntries(appData.exercises)) {
+                    for (const record of entry.records) delete record.gradedDrawingCloudCommitted;
+                }
                 if (typeof saveExercisesToIDB === 'function') await saveExercisesToIDB();
-                saveData();
+                const metadataSaved = saveData();
+                const exercisesSaved = await exWaitForExercisesDataSaves();
+                if (!metadataSaved || !exercisesSaved) throw new Error(i18n('storage_save_failed'));
                 await restoreBlobsFromIDB();
                 applySettings();
                 renderLibrary();
@@ -26090,7 +26099,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             currentExerciseFolder = null;
             currentExerciseTask = null;
             // 旧版本同一题每次评分都会并列新增一条错题，这里按题号去重只留最近一条
-            if (exDedupeWrongQuestions()) { saveData(); debouncedChatSync(); }
+            if (exDedupeWrongQuestions()) saveData();
             document.body.classList.remove('exercise-folder-active');
             document.getElementById('exercisesGrid').style.display = '';
             document.getElementById('exerciseFolderView').style.display = 'none';

--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -14849,20 +14849,28 @@
                 .flatMap(nb => nb.pages || [])
                 .find(pg => pg && pg.id === pageId);
             const mediaIds = new Set();
-            let pgData = await getFileData('nbpage_' + pageId).catch(() => null);
+            const localPageJson = await getFileData('nbpage_' + pageId);
+            let pgData = localPageJson;
             let pageContent = null;
             if (pgData) pageContent = JSON.parse(pgData);
             // 目录刚从云端合并，正文可能仍是旧备份；不能把旧正文当成本机新编辑。
-            if (pageContent && syncTimestamp(pageContent.updatedAt) <
+            if (pageContent && syncTimestamp(pageContent.updatedAt) > 0 && syncTimestamp(pageContent.updatedAt) <
                 syncTimestamp(page?.updatedAt || page?.createdAt)) return;
             let conditions = {};
-            if (!pageContent && page) {
-                // 云端独有页尚未下载时必须保留；真正的新空白页只允许创建，不覆盖。
-                if (await r2GetObject('notebooks/pages/nbpage_' + pageId)) return;
-                pageContent = { strokes: [], texts: [], media: [], recognized: null };
-                conditions = { ifNoneMatch: '*' };
+            let uploadBody = !!pageContent;
+            if ((!pageContent && page) || (pageContent && !syncTimestamp(pageContent.updatedAt))) {
+                // 无时间戳的旧正文不能判断新旧；云端存在时保留，缺失时只允许条件创建。
+                const cloudPage = await r2GetObject('notebooks/pages/nbpage_' + pageId);
+                if (cloudPage) {
+                    pageContent = JSON.parse(cloudPage);
+                    uploadBody = false;
+                } else {
+                    pageContent = pageContent || { strokes: [], texts: [], media: [], recognized: null };
+                    conditions = { ifNoneMatch: '*' };
+                    uploadBody = true;
+                }
             }
-            if (pageContent) {
+            if (uploadBody) {
                 if (!pageContent.updatedAt) {
                     pageContent.updatedAt = page?.updatedAt || page?.createdAt || new Date().toISOString();
                 }
@@ -14872,15 +14880,20 @@
                     saveData();
                 }
                 pgData = JSON.stringify(pageContent);
-                if (!conditions.ifNoneMatch) await saveFileData('nbpage_' + pageId, pgData);
                 try {
                     await r2PutObject('notebooks/pages/nbpage_' + pageId, pgData, 'application/json', conditions);
+                    if (localPageJson && pgData !== localPageJson) {
+                        await saveCloudFileIfUnchanged('nbpage_' + pageId, pgData, { expected: localPageJson });
+                    }
                 } catch (error) {
                     if (!conditions.ifNoneMatch || error?.status !== 412) throw error;
-                    return; // 另一设备已创建正文，后续 pull 会下载，不能重发空白。
+                    // 另一设备创建成功后不重发正文，但仍需补齐它引用的本地媒体。
+                    const cloudPage = await r2GetObject('notebooks/pages/nbpage_' + pageId);
+                    if (!cloudPage) throw error;
+                    pageContent = JSON.parse(cloudPage);
                 }
-                (pageContent.media || []).forEach(m => { if (m.mediaId) mediaIds.add(m.mediaId); });
             }
+            (pageContent?.media || []).forEach(m => { if (m.mediaId) mediaIds.add(m.mediaId); });
             if (page && page.bgImage) mediaIds.add(page.bgImage);
             for (const mid of mediaIds) {
                 const mData = await getFileData('nbmedia_' + mid).catch(() => null);
@@ -14910,8 +14923,9 @@
 
         async function r2PullNotebookAssetsFromCloud(options = {}) {
             const missingOnly = options.missingOnly !== false;
+            const notebooks = appData.notebooks;
             let pages = 0, media = 0;
-            for (const nb of (appData.notebooks?.items || [])) {
+            for (const nb of (notebooks?.items || [])) {
                 for (const page of (nb.pages || [])) {
                     if (!page || !page.id) continue;
                     let pageJson = await getFileData('nbpage_' + page.id).catch(() => null);
@@ -14923,12 +14937,18 @@
                     const shouldPullPage = !missingOnly || !pageJson ||
                         (cloudPageUpdatedAt > 0 && cloudPageUpdatedAt > localPageUpdatedAt);
                     if (shouldPullPage) {
+                        const pageVersion = page.updatedAt;
                         try {
                             const cloudPage = await r2GetObject('notebooks/pages/nbpage_' + page.id);
                             if (cloudPage) {
-                                pageJson = cloudPage;
-                                await saveFileData('nbpage_' + page.id, cloudPage);
-                                pages++;
+                                const saved = await saveCloudFileIfUnchanged('nbpage_' + page.id, cloudPage, {
+                                    expected: pageJson,
+                                    guard: () => appData.notebooks === notebooks &&
+                                        (notebooks.items || []).includes(nb) && (nb.pages || []).includes(page) &&
+                                        page.updatedAt === pageVersion
+                                });
+                                if (saved) pages++;
+                                pageJson = saved ? cloudPage : await getFileData('nbpage_' + page.id);
                             }
                         } catch (e) { console.warn('[startup-sync] 拉取笔记页失败:', page.id, e); }
                     }
@@ -16587,30 +16607,27 @@
                 const cloudPapers = metadata.papers || [];
                 const cloudSyncedAtMs = metadata.syncedAt ? Date.parse(metadata.syncedAt) : 0;
                 let repairMetadataAfterStartup = false;
-                if ((cloudBooks.length + cloudPapers.length) === 0 && (localBooks.length + localPapers.length) > 0) {
+                const repairBooksAfterStartup = (cloudBooks.length + cloudPapers.length) === 0 &&
+                    (localBooks.length + localPapers.length) > 0;
+                if (repairBooksAfterStartup) {
                     console.warn('[startup-sync] 云端书籍索引为空但本地有 ' + (localBooks.length + localPapers.length) + ' 条，保留本地数据并回传云端');
-                    try {
-                        await r2SyncMetadataOnly();
-                        showToast(i18n('cloud_index_repaired'));
-                    } catch (e) { console.warn('[startup-sync] 回传修复失败:', e); }
-                    finishR2StartupMetadataSync();
-                    return;
+                } else {
+                    const cloudIds = new Set([...cloudBooks, ...cloudPapers].map(d => d && d.id).filter(Boolean));
+                    const removedIds = [...localBooks, ...localPapers]
+                        .filter(d => {
+                            if (!d || !d.id) return false;
+                            if (cloudIds.has(d.id)) return false;
+                            const addedAtMs = d.addedAt ? Date.parse(d.addedAt) : NaN;
+                            if (!isNaN(addedAtMs) && addedAtMs > cloudSyncedAtMs) return false;
+                            return true;
+                        })
+                        .map(d => d.id);
+                    for (const id of removedIds) {
+                        try { await deleteFileData(id); } catch (e) { console.warn('deleteFileData failed for', id, e); }
+                    }
+                    appData.books = mergeDocsPreferringLocalProgress(cloudBooks, localBooks, cloudSyncedAtMs);
+                    appData.papers = mergeDocsPreferringLocalProgress(cloudPapers, localPapers, cloudSyncedAtMs);
                 }
-                const cloudIds = new Set([...cloudBooks, ...cloudPapers].map(d => d && d.id).filter(Boolean));
-                const removedIds = [...localBooks, ...localPapers]
-                    .filter(d => {
-                        if (!d || !d.id) return false;
-                        if (cloudIds.has(d.id)) return false;
-                        const addedAtMs = d.addedAt ? Date.parse(d.addedAt) : NaN;
-                        if (!isNaN(addedAtMs) && addedAtMs > cloudSyncedAtMs) return false;
-                        return true;
-                    })
-                    .map(d => d.id);
-                for (const id of removedIds) {
-                    try { await deleteFileData(id); } catch (e) { console.warn('deleteFileData failed for', id, e); }
-                }
-                appData.books = mergeDocsPreferringLocalProgress(cloudBooks, localBooks, cloudSyncedAtMs);
-                appData.papers = mergeDocsPreferringLocalProgress(cloudPapers, localPapers, cloudSyncedAtMs);
                 appData.notes = mergePreferNonEmpty(metadata.notes, appData.notes);
                 appData.archived = (metadata.archived && metadata.archived.length > 0) ? metadata.archived : (appData.archived || []);
                 const mergedLectures = mergeLecturesData(
@@ -16750,11 +16767,12 @@
                 appDataLoaded = true;
                 saveData();
                 refreshAllUIFromAppData();
-                if (repairMetadataAfterStartup) {
+                if (repairMetadataAfterStartup || repairBooksAfterStartup) {
                     // 修复只补齐云端缺的那部分：正文按版本增量上传，不把本机旧正文回传。
                     await r2SyncChangedLectureContents();
                     if (repairNotebookPagesAfterStartup) await r2SyncAllNotebookPages();
                     await r2SyncMetadataOnly();
+                    if (repairBooksAfterStartup) showToast(i18n('cloud_index_repaired'));
                 }
                 if (config.lastSyncTime || metadata.syncedAt) {
                     r2LastSyncTime = metadata.syncedAt || config.lastSyncTime;
@@ -17891,7 +17909,17 @@
                 }
                 // 导入来源单独标记：不压过云端已有评分，但独有评分必须先补齐图片再发布。
                 for (const entry of exCollectUncommittedGradedCloudEntries(appData.exercises, true)) {
-                    for (const record of entry.records) record.gradedDrawingCloudCommitted = 'imported';
+                    // 旧包的内嵌图片必须先落盘，随后 saveData 才能安全剔除大字段。
+                    for (let p = 0; p < entry.pageCount; p++) {
+                        const image = entry.records.map(record => exPageImageOf(
+                            record.userDrawing || record.drawing, record.userDrawingExtra || record.extra, p)).find(Boolean);
+                        if (image) await exWriteRedoPageAliases(entry.baseKeys, p, image);
+                    }
+                    for (const record of entry.records) {
+                        if (record.userDrawing) record.userDrawingPages = entry.pageCount;
+                        else if (record.drawing) record.pages = entry.pageCount;
+                        record.gradedDrawingCloudCommitted = 'imported';
+                    }
                 }
                 if (typeof saveExercisesToIDB === 'function') await saveExercisesToIDB();
                 const metadataSaved = saveData();
@@ -25406,7 +25434,9 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                         entry.baseKeys.push(mirrorBaseKey);
                     }
                 }
-                entry.pageCount = Math.max(entry.pageCount, Number(pageCount) || 1);
+                entry.pageCount = Math.max(entry.pageCount, Number(pageCount) || 1,
+                    record.userDrawing ? 1 + (record.userDrawingExtra || []).length : 0,
+                    record.drawing ? 1 + (record.extra || []).length : 0);
                 if (!entry.records.includes(record)) entry.records.push(record);
             };
 
@@ -25545,7 +25575,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     // 原子覆盖它。主 key 只在从 legacy 恢复且仍为空时补齐。
                     if (targetBaseKey === aliases[0]) {
                         if (readBaseKey !== targetBaseKey) {
-                            await exSaveCloudDrawingIfMissing(key, drawData);
+                            await saveCloudFileIfUnchanged(key, drawData);
                         }
                     } else {
                         await saveFileData(key, drawData);
@@ -25710,7 +25740,9 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     for (const baseKey of entry.baseKeys) {
                         const key = exPageKey(baseKey, p);
                         if (await r2GetObject('exercises/drawings/' + key)) continue;
-                        const data = await exReadRedoPageFromLocal(entry.baseKeys, null, p);
+                        const embedded = entry.records.map(record => exPageImageOf(
+                            record.userDrawing || record.drawing, record.userDrawingExtra || record.extra, p)).find(Boolean);
+                        const data = embedded || await exReadRedoPageFromLocal(entry.baseKeys, null, p);
                         if (!data) throw new Error('Imported exercise drawing is missing: ' + key);
                         try {
                             await r2PutObject('exercises/drawings/' + key, data,
@@ -25768,7 +25800,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                         }
                         for (let i = 0; i < keys.length; i++) {
                             if (!unchanged()) return;
-                            if (local[i] !== data) await exSaveCloudDrawingIfMissing(keys[i], data,
+                            if (local[i] !== data) await saveCloudFileIfUnchanged(keys[i], data,
                                 { expected: local[i], guard: unchanged });
                         }
                     } catch (error) {
@@ -25778,9 +25810,9 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             }
         }
 
-        // missing-only 云下载必须在同一个读写事务里重新判空：若新评分 B 先提交，
-        // 旧云快照 A 会看到 key 已存在并跳过；若 A 事务先创建，B 随后的事务仍会最后覆盖。
-        async function exSaveCloudDrawingIfMissing(key, data, options = {}) {
+        // 云下载在同一个读写事务内检查原值，不能覆盖等待下载期间的新编辑或新评分。
+        // 不传 expected 时只补本地缺失的文件。
+        async function saveCloudFileIfUnchanged(key, data, options = {}) {
             if (!data) return false;
             if (!await ensureFileDB()) throw new Error(i18n('indexeddb_unavailable'));
             return new Promise((resolve, reject) => {
@@ -28669,7 +28701,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     try { cloudGradedImage = await r2GetObject('exercises/drawings/' + gradedKey); } catch (e) {}
                     if (cloudGradedImage && restoreGradingGuard()) {
                         try {
-                            const inserted = await exSaveCloudDrawingIfMissing(gradedKey, cloudGradedImage);
+                            const inserted = await saveCloudFileIfUnchanged(gradedKey, cloudGradedImage);
                             if (restoreGradingGuard()) {
                                 if (inserted) {
                                     gradedImage = cloudGradedImage;

--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -14133,9 +14133,13 @@
                 await r2SyncAllNotebookPages();
 
                 // 再把合并后的结果推回云端
-                const metadataPublishResult = await r2SyncMetadataOnly();
-                if (metadataPublishResult.casCommitted) {
-                    await flushClassroomDeletionOutboxAfterMetadata();
+                let metadataPublishError = null;
+                try {
+                    const metadataPublishResult = await r2SyncMetadataOnly();
+                    if (metadataPublishResult.casCommitted) await flushClassroomDeletionOutboxAfterMetadata();
+                } catch (error) {
+                    // 补传失败不能跳过后续资源下载；恢复完成后仍向调用方报告发布失败。
+                    metadataPublishError = error;
                 }
 
                 // 把本地新加、云端还没有的 PDF 文件一起上传
@@ -14185,6 +14189,7 @@
                 await r2PullNotebookAssetsFromCloud({ missingOnly: true });
 
                 // 更新上次同步时间
+                if (metadataPublishError) throw metadataPublishError;
                 config.lastSyncTime = new Date().toISOString();
                 r2LastSyncTime = config.lastSyncTime;
                 saveData();
@@ -14416,15 +14421,18 @@
         }
 
         async function r2PublishMetadataWithCas(localMetadata, classroomIntent, options = {}) {
+            const hadImportedGrading = !options.classroomOnly &&
+                exCollectUncommittedGradedCloudEntries(appData.exercises, true)
+                    .some(entry => entry.records.some(record => record.gradedDrawingCloudCommitted === 'imported'));
             if (!options.classroomOnly) {
-                // 发布本地评分前必须先有完整图片；课堂专用请求不携带本地习题。
-                await exEnsureImportedGradedPages();
                 const gradingFlush = await exFlushGradedDrawingCloudCommits();
                 localMetadata = {
                     ...localMetadata,
                     exercises: gradingFlush.exercisesForPublish
                 };
             }
+            const gradingSource = appData.exercises;
+            const gradingGeneration = _exGradedCloudCommitCounter;
             const frozenClassroom = classroomIntent || stripClassroomData(appData.classroom, false);
             let lastConflict = null;
             for (let attempt = 0; attempt < 5; attempt++) {
@@ -14455,16 +14463,20 @@
                 const mergedIntent = remoteClassroomCount === 0 && localClassroomCount > 0
                     ? localClassroom
                     : mergeClassroomData(remoteClassroom, localClassroom, remoteBaseline);
-                // 课堂首传也只创建课堂索引，不能顺带发布未校验的本地习题和笔记。
+                // 首次建索引保留已有目录，否则新的 syncedAt 会把离线笔记误判为已删除。
+                // 未经图片校验的习题仍不能随课堂首传发布。
                 let candidateBase = options.classroomOnly
-                    ? (remoteMetadata || {})
+                    ? (remoteMetadata || { ...localMetadata, exercises: undefined })
                     : localMetadata;
                 if (!options.classroomOnly) {
+                    // 每次 CAS 重试都从原快照重建，保留导入来源，重新核对最新云端评分。
+                    candidateBase = { ...candidateBase, exercises: stripExercisesData(localMetadata.exercises) };
                     // 文件变更同步不会先跑完整的 pull。提交前把远端同一条习题的版本化
                     // redo 历史合进本次快照，避免长时间在线的旧设备覆盖另一端的清空。
                     exMergeMatchingExerciseHistories(
                         candidateBase?.exercises,
                         remoteMetadata?.exercises,
+                        true,
                         true
                     );
                     candidateBase = {
@@ -14504,6 +14516,8 @@
                     classroomTombstones: tombstones,
                     syncedAt: new Date().toISOString()
                 };
+                // 只验证合并后确实要发布的导入评分；不能拿旧分数配上已存在的云端图片。
+                if (!options.classroomOnly) await exEnsureImportedGradedPages(candidate.exercises);
 
                 if (!options.allowEmpty &&
                     !await r2ProtectMetadataOverwrite(candidate, remoteResult?.data || null, remoteMetadata)) {
@@ -14518,6 +14532,10 @@
                     : remoteResult?.etag
                         ? { ifMatch: remoteResult.etag }
                         : {};
+                if (hadImportedGrading && (appData.exercises !== gradingSource ||
+                    _exGradedCloudCommitCounter !== gradingGeneration)) {
+                    throw new Error('Exercise grading changed during import recovery; retry publication');
+                }
                 try {
                     await r2PutObject('metadata.json', JSON.stringify(candidate), 'application/json', conditions);
 
@@ -14539,7 +14557,7 @@
                             Date.parse(candidate.syncedAt) || 0);
                         // 网络等待期间本机可能又产生了更新；仍用同一套版本规则合回活对象，
                         // 既接收远端较新的清空，也不会压掉刚发生的本机重做。
-                        exMergeMatchingExerciseHistories(appData.exercises, candidate.exercises, true);
+                        exMergeMatchingExerciseHistories(appData.exercises, candidate.exercises, true, true);
                     }
                     const gradingCommitStateChanged = exMarkPublishedGradingCommits(
                         appData.exercises,
@@ -14550,6 +14568,7 @@
                         // 云端已提交成功；保留本地 false 的旧持久副本只会触发安全重试。
                         console.warn('[sync] 评分快照提交状态本地保存失败，将在下次同步重试');
                     }
+                    if (hadImportedGrading) await exSyncCachedGradedPages();
                     return { metadata: candidate, casCommitted: true };
                 } catch (e) {
                     if (e?.status !== 412) throw e;
@@ -16768,11 +16787,15 @@
                 saveData();
                 refreshAllUIFromAppData();
                 if (repairMetadataAfterStartup || repairBooksAfterStartup) {
-                    // 修复只补齐云端缺的那部分：正文按版本增量上传，不把本机旧正文回传。
-                    await r2SyncChangedLectureContents();
-                    if (repairNotebookPagesAfterStartup) await r2SyncAllNotebookPages();
-                    await r2SyncMetadataOnly();
-                    if (repairBooksAfterStartup) showToast(i18n('cloud_index_repaired'));
+                    try {
+                        // 发布失败也继续下载云端资源，不让缺图习题阻断 PDF 和笔记恢复。
+                        await r2SyncChangedLectureContents();
+                        if (repairNotebookPagesAfterStartup) await r2SyncAllNotebookPages();
+                        await r2SyncMetadataOnly();
+                        if (repairBooksAfterStartup) showToast(i18n('cloud_index_repaired'));
+                    } catch (error) {
+                        console.warn('[startup-sync] 索引补传失败，继续恢复云端资源:', error);
+                    }
                 }
                 if (config.lastSyncTime || metadata.syncedAt) {
                     r2LastSyncTime = metadata.syncedAt || config.lastSyncTime;
@@ -17910,13 +17933,18 @@
                 // 导入来源单独标记：不压过云端已有评分，但独有评分必须先补齐图片再发布。
                 for (const entry of exCollectUncommittedGradedCloudEntries(appData.exercises, true)) {
                     // 旧包的内嵌图片必须先落盘，随后 saveData 才能安全剔除大字段。
+                    // 错题的 userDrawing 是最近重做的显示缓存，不是原答图片。
+                    const embeddedRecords = entry.records.filter(record => !(record.redoDrawings || []).length);
+                    entry.pageCount = Math.max(entry.pageCount, ...embeddedRecords.map(record =>
+                        record.userDrawing ? 1 + (record.userDrawingExtra || []).length :
+                        record.drawing ? 1 + (record.extra || []).length : 0));
                     for (let p = 0; p < entry.pageCount; p++) {
-                        const image = entry.records.map(record => exPageImageOf(
+                        const image = embeddedRecords.map(record => exPageImageOf(
                             record.userDrawing || record.drawing, record.userDrawingExtra || record.extra, p)).find(Boolean);
                         if (image) await exWriteRedoPageAliases(entry.baseKeys, p, image);
                     }
                     for (const record of entry.records) {
-                        if (record.userDrawing) record.userDrawingPages = entry.pageCount;
+                        if (record.userDrawing && !(record.redoDrawings || []).length) record.userDrawingPages = entry.pageCount;
                         else if (record.drawing) record.pages = entry.pageCount;
                         record.gradedDrawingCloudCommitted = 'imported';
                     }
@@ -24958,17 +24986,26 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
         // 启动/周期 pull 会先以云端对象为骨架。若本地存在“metadata 已落盘、图片尚未
         // 上传”的评分事务，必须把这份结果一起保住，否则进程重启恰好会抹掉补传标记。
-        function exPreserveUncommittedGrading(targetQ, localQ) {
-            if (!targetQ || !localQ || localQ.gradedDrawingCloudCommitted !== false) return false;
+        function exPreserveUncommittedGrading(targetQ, localQ, restoreImported = false) {
+            if (!targetQ || !localQ) return false;
+            const restoring = restoreImported && targetQ.gradedDrawingCloudCommitted === 'imported';
+            if (!restoring && localQ.gradedDrawingCloudCommitted !== false) return false;
             const fields = [
                 'status', 'score', 'userDrawing', 'userDrawingExtra',
                 'userDrawingPages', 'pageCount', 'aiComment',
                 'timeUsedSeconds', 'remainingSeconds', 'gradedDrawingCommitId',
-                'gradedDrawingCloudCommitted'
+                'gradedDrawingCloudCommitted',
+                ...(restoring ? ['drawing', 'extra', 'pages', 'comment'] : [])
             ];
             let changed = false;
             for (const field of fields) {
-                if (!Object.prototype.hasOwnProperty.call(localQ, field)) continue;
+                if (!Object.prototype.hasOwnProperty.call(localQ, field)) {
+                    if (restoring && Object.prototype.hasOwnProperty.call(targetQ, field)) {
+                        delete targetQ[field];
+                        changed = true;
+                    }
+                    continue;
+                }
                 const value = Array.isArray(localQ[field])
                     ? localQ[field].slice()
                     : localQ[field];
@@ -24984,7 +25021,9 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         // 习题目前只能加页、不能删页，因此页数合并始终取两端较大值。
         function exMergeExerciseQuestionPageCounts(targetQ, localQ, options = {}) {
             if (!targetQ || !localQ) return false;
-            let changed = options.preserveSourceUncommitted === false
+            let changed = options.restoreImported && targetQ.gradedDrawingCloudCommitted === 'imported'
+                ? exPreserveUncommittedGrading(targetQ, localQ, true)
+                : options.preserveSourceUncommitted === false
                 ? false
                 : exPreserveUncommittedGrading(targetQ, localQ);
             const gradedPages = Math.max(
@@ -25031,6 +25070,8 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     }
                     const targetRedo = targetRedos[targetIndex];
                     if (!targetRedo) return;
+                    if (options.restoreImported && targetRedo.gradedDrawingCloudCommitted === 'imported' &&
+                        exPreserveUncommittedGrading(targetRedo, localRedo, true)) changed = true;
                     const redoPages = Math.max(
                         1,
                         Number(targetRedo.pages) || 0,
@@ -25081,6 +25122,8 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     winningRedos, losingRedo, losingIndex);
                 if (winningIndex < 0) return;
                 const winningRedo = winningRedos[winningIndex];
+                if (options.restoreImported && !localWins && winningRedo.gradedDrawingCloudCommitted === 'imported' &&
+                    exPreserveUncommittedGrading(winningRedo, losingRedo, true)) changed = true;
                 const redoPages = Math.max(
                     1,
                     Number(winningRedo.pages) || 0,
@@ -25128,7 +25171,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
         // 只合并两份 metadata 中本来就是同一实体的题目；不补 folder/task/question，
         // 避免在没有实体 tombstone 的情况下顺手复活整道已删除错题。
-        function exMergeMatchingExerciseHistories(targetExercises, sourceExercises, preferSourceRedoOnTie = false) {
+        function exMergeMatchingExerciseHistories(targetExercises, sourceExercises, preferSourceRedoOnTie = false, restoreImported = false) {
             if (!targetExercises || !sourceExercises) return false;
             let changed = false;
 
@@ -25150,7 +25193,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                             targetQ = (targetTask.questions || [])[sourceIndex];
                         }
                         if (targetQ && exMergeExerciseQuestionPageCounts(targetQ, sourceQ,
-                            { preferSourceRedoOnTie, preserveSourceUncommitted: false })) {
+                            { preferSourceRedoOnTie, preserveSourceUncommitted: false, restoreImported })) {
                             changed = true;
                         }
                     });
@@ -25167,7 +25210,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                         const targetQ = (targetTask.questions || [])
                             .find(q => q && q.questionIndex === sourceQ?.questionIndex);
                         if (targetQ && exMergeExerciseQuestionPageCounts(targetQ, sourceQ,
-                            { preferSourceRedoOnTie, preserveSourceUncommitted: false })) {
+                            { preferSourceRedoOnTie, preserveSourceUncommitted: false, restoreImported })) {
                             changed = true;
                         }
                     }
@@ -25182,7 +25225,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                         item.questionIndex === sourceItem?.questionIndex &&
                         item.archivedAt === sourceItem?.archivedAt);
                     if (targetItem && exMergeExerciseQuestionPageCounts(targetItem, sourceItem,
-                        { preferSourceRedoOnTie, preserveSourceUncommitted: false })) {
+                        { preferSourceRedoOnTie, preserveSourceUncommitted: false, restoreImported })) {
                         changed = true;
                     }
                 }
@@ -25434,9 +25477,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                         entry.baseKeys.push(mirrorBaseKey);
                     }
                 }
-                entry.pageCount = Math.max(entry.pageCount, Number(pageCount) || 1,
-                    record.userDrawing ? 1 + (record.userDrawingExtra || []).length : 0,
-                    record.drawing ? 1 + (record.extra || []).length : 0);
+                entry.pageCount = Math.max(entry.pageCount, Number(pageCount) || 1);
                 if (!entry.records.includes(record)) entry.records.push(record);
             };
 
@@ -25732,23 +25773,28 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             }
         }
 
-        async function exEnsureImportedGradedPages() {
-            for (const entry of exCollectUncommittedGradedCloudEntries(appData.exercises, true)) {
+        async function exEnsureImportedGradedPages(exercises) {
+            for (const entry of exCollectUncommittedGradedCloudEntries(exercises, true)) {
                 const imported = entry.records.filter(record => record.gradedDrawingCloudCommitted === 'imported');
                 if (!imported.length) continue;
                 for (let p = 0; p < entry.pageCount; p++) {
                     for (const baseKey of entry.baseKeys) {
                         const key = exPageKey(baseKey, p);
-                        if (await r2GetObject('exercises/drawings/' + key)) continue;
-                        const embedded = entry.records.map(record => exPageImageOf(
+                        const cloudDrawing = await r2GetObject('exercises/drawings/' + key);
+                        const embedded = entry.records.filter(record => !(record.redoDrawings || []).length).map(record => exPageImageOf(
                             record.userDrawing || record.drawing, record.userDrawingExtra || record.extra, p)).find(Boolean);
                         const data = embedded || await exReadRedoPageFromLocal(entry.baseKeys, null, p);
                         if (!data) throw new Error('Imported exercise drawing is missing: ' + key);
+                        if (cloudDrawing) {
+                            if (cloudDrawing !== data) throw new Error('Imported exercise drawing conflicts with cloud: ' + key);
+                            continue;
+                        }
                         try {
                             await r2PutObject('exercises/drawings/' + key, data,
                                 'image/png', { ifNoneMatch: '*' });
                         } catch (error) {
                             if (error?.status !== 412) throw error;
+                            if (await r2GetObject('exercises/drawings/' + key) !== data) throw error;
                         }
                     }
                 }
@@ -25768,6 +25814,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 !exHasPendingGradedPagesCloudCommit() &&
                 exCollectUncommittedGradedCloudEntries(appData.exercises).length === 0;
             for (const entry of exCollectUncommittedGradedCloudEntries(appData.exercises, true)) {
+                if (entry.records.some(record => record.gradedDrawingCloudCommitted === 'imported')) continue;
                 for (let p = 0; p < entry.pageCount; p++) {
                     if (!unchanged()) return;
                     const keys = entry.baseKeys.map(base => exPageKey(base, p));

--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -14177,82 +14177,12 @@
                                 }
                             }
                         }
-                        // 同步用户作答drawings（本地有云端没有 → 上传，本地没有云端有 → 拉取），多页作答逐页同步
-                        for (const q of (task.questions || [])) {
-                            if (q.status === 'done') {
-                                for (const drawKey of exGradedPageKeys(`exercise_drawing_${task.id}_${q.index}`, q.userDrawingPages)) {
-                                    const localDraw = await getFileData(drawKey).catch(() => null);
-                                    if (localDraw) {
-                                        try { await r2PutObject('exercises/drawings/' + drawKey, localDraw, 'image/png'); } catch(e) {}
-                                    } else {
-                                        try {
-                                            const cd = await r2GetObject('exercises/drawings/' + drawKey);
-                                            if (cd) await exSaveCloudDrawingIfMissing(drawKey, cd);
-                                        } catch(e) {}
-                                    }
-                                }
-                            }
-                        }
                     }
                 }
-                // 同步错题和重做drawings（多页作答逐页同步）
-                for (const fId of Object.keys(appData.exercises?.wrongByFolder || {})) {
-                    for (const wt of (appData.exercises.wrongByFolder[fId] || [])) {
-                        for (const q of (wt.questions || [])) {
-                            for (const wrongDrawKey of exGradedPageKeys(`exercise_drawing_${wt.taskId}_${q.questionIndex}`, q.userDrawingPages)) {
-                                const localWD = await getFileData(wrongDrawKey).catch(() => null);
-                                if (localWD) {
-                                    try { await r2PutObject('exercises/drawings/' + wrongDrawKey, localWD, 'image/png'); } catch(e) {}
-                                } else {
-                                    try { const cd = await r2GetObject('exercises/drawings/' + wrongDrawKey); if (cd) await exSaveCloudDrawingIfMissing(wrongDrawKey, cd); } catch(e) {}
-                                }
-                            }
-                            for (let ri = 0; ri < (q.redoDrawings || []).length; ri++) {
-                                const rd = q.redoDrawings[ri];
-                                const redoBaseKeys = exRedoDrawingBaseKeys(
-                                    wt.taskId, q.questionIndex, rd, ri);
-                                const redoPageCount = Math.max(1, Number(rd && rd.pages) || 0);
-                                for (let p = 0; p < redoPageCount; p++) {
-                                    const localRD = await exReadRedoPageFromLocal(redoBaseKeys, rd, p);
-                                    if (localRD) {
-                                        try { await exUploadRedoPageAliases(redoBaseKeys, p, localRD); } catch(e) {}
-                                    } else {
-                                        const cloudRD = await exReadRedoPageFromCloud(redoBaseKeys, p);
-                                        if (cloudRD) await exWriteRedoPageAliases(redoBaseKeys, p, cloudRD);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                await exSyncCachedGradedPages();
 
-                // 同步笔记本页面和媒体（本地有云端没有 → 上传，本地没有云端有 → 拉取）
-                for (const nb of (appData.notebooks?.items || [])) {
-                    for (const page of (nb.pages || [])) {
-                        if (!page || !page.id) continue;
-                        let pgData = await getFileData('nbpage_' + page.id).catch(() => null);
-                        if (pgData) {
-                            try { await r2PutObject('notebooks/pages/nbpage_' + page.id, pgData, 'application/json'); } catch(e) {}
-                        } else {
-                            try {
-                                const cd = await r2GetObject('notebooks/pages/nbpage_' + page.id);
-                                if (cd) { pgData = cd; await saveFileData('nbpage_' + page.id, cd); }
-                            } catch(e) {}
-                        }
-                        const mediaIds = r2NotebookMediaIdsFromPage(page, pgData);
-                        for (const mid of mediaIds) {
-                            const localMedia = await getFileData('nbmedia_' + mid).catch(() => null);
-                            if (localMedia) {
-                                try { await r2PutObject('notebooks/media/nbmedia_' + mid, localMedia, 'application/octet-stream'); } catch(e) {}
-                            } else {
-                                try {
-                                    const cd = await r2GetObject('notebooks/media/nbmedia_' + mid);
-                                    if (cd) await saveFileData('nbmedia_' + mid, cd);
-                                } catch(e) {}
-                            }
-                        }
-                    }
-                }
+                // 正文上传已走统一版本检查；下载较新或缺失的正文和媒体。
+                await r2PullNotebookAssetsFromCloud({ missingOnly: true });
 
                 // 更新上次同步时间
                 config.lastSyncTime = new Date().toISOString();
@@ -14919,8 +14849,17 @@
             const mediaIds = new Set();
             let pgData = await getFileData('nbpage_' + pageId).catch(() => null);
             let pageContent = null;
-            try { pageContent = pgData ? JSON.parse(pgData) : null; } catch (e) {}
-            if (!pageContent && page) pageContent = { strokes: [], texts: [], media: [], recognized: null };
+            if (pgData) pageContent = JSON.parse(pgData);
+            // 目录刚从云端合并，正文可能仍是旧备份；不能把旧正文当成本机新编辑。
+            if (pageContent && syncTimestamp(pageContent.updatedAt) <
+                syncTimestamp(page?.updatedAt || page?.createdAt)) return;
+            let conditions = {};
+            if (!pageContent && page) {
+                // 云端独有页尚未下载时必须保留；真正的新空白页只允许创建，不覆盖。
+                if (await r2GetObject('notebooks/pages/nbpage_' + pageId)) return;
+                pageContent = { strokes: [], texts: [], media: [], recognized: null };
+                conditions = { ifNoneMatch: '*' };
+            }
             if (pageContent) {
                 if (!pageContent.updatedAt) {
                     pageContent.updatedAt = page?.updatedAt || page?.createdAt || new Date().toISOString();
@@ -14931,8 +14870,13 @@
                     saveData();
                 }
                 pgData = JSON.stringify(pageContent);
-                await saveFileData('nbpage_' + pageId, pgData);
-                await r2PutObject('notebooks/pages/nbpage_' + pageId, pgData, 'application/json');
+                if (!conditions.ifNoneMatch) await saveFileData('nbpage_' + pageId, pgData);
+                try {
+                    await r2PutObject('notebooks/pages/nbpage_' + pageId, pgData, 'application/json', conditions);
+                } catch (error) {
+                    if (!conditions.ifNoneMatch || error?.status !== 412) throw error;
+                    return; // 另一设备已创建正文，后续 pull 会下载，不能重发空白。
+                }
                 (pageContent.media || []).forEach(m => { if (m.mediaId) mediaIds.add(m.mediaId); });
             }
             if (page && page.bgImage) mediaIds.add(page.bgImage);
@@ -16941,65 +16885,9 @@
                                 } catch(e) { console.warn('启动拉取习题文件失败:', sf.id, e); }
                             }
                         }
-                        for (const q of (task.questions || [])) {
-                            if (q.status === 'done') {
-                                for (const drawKey of exGradedPageKeys(`exercise_drawing_${task.id}_${q.index}`, q.userDrawingPages)) {
-                                    const localDraw = await getFileData(drawKey).catch(() => null);
-                                    if (!localDraw) {
-                                        try {
-                                            const cloudDraw = await r2GetObject('exercises/drawings/' + drawKey);
-                                            if (cloudDraw) await exSaveCloudDrawingIfMissing(drawKey, cloudDraw);
-                                        } catch(e) {}
-                                    }
-                                }
-                            }
-                        }
                     }
                 }
-                for (const fId of Object.keys(appData.exercises?.wrongByFolder || {})) {
-                    for (const wt of (appData.exercises.wrongByFolder[fId] || [])) {
-                        for (const q of (wt.questions || [])) {
-                            for (const wrongDrawKey of exGradedPageKeys(`exercise_drawing_${wt.taskId}_${q.questionIndex}`, q.userDrawingPages)) {
-                                const localWD = await getFileData(wrongDrawKey).catch(() => null);
-                                if (!localWD) {
-                                    try { const cd = await r2GetObject('exercises/drawings/' + wrongDrawKey); if (cd) await exSaveCloudDrawingIfMissing(wrongDrawKey, cd); } catch(e) {}
-                                }
-                            }
-                            for (let ri = 0; ri < (q.redoDrawings || []).length; ri++) {
-                                const rd = q.redoDrawings[ri];
-                                const redoBaseKeys = exRedoDrawingBaseKeys(
-                                    wt.taskId, q.questionIndex, rd, ri);
-                                const redoPageCount = Math.max(1, Number(rd && rd.pages) || 0);
-                                for (let p = 0; p < redoPageCount; p++) {
-                                    let redoData = await exReadRedoPageFromLocal(redoBaseKeys, rd, p);
-                                    if (!redoData) redoData = await exReadRedoPageFromCloud(redoBaseKeys, p);
-                                    if (redoData) await exWriteRedoPageAliases(redoBaseKeys, p, redoData);
-                                }
-                            }
-                        }
-                    }
-                }
-                for (const fId of Object.keys(appData.exercises?.archivedWrong || {})) {
-                    for (const item of (appData.exercises.archivedWrong[fId] || [])) {
-                        for (const archDrawKey of exGradedPageKeys(`exercise_drawing_${item.taskId}_${item.questionIndex}`, item.userDrawingPages)) {
-                            const localAD = await getFileData(archDrawKey).catch(() => null);
-                            if (!localAD) {
-                                try { const cd = await r2GetObject('exercises/drawings/' + archDrawKey); if (cd) await exSaveCloudDrawingIfMissing(archDrawKey, cd); } catch(e) {}
-                            }
-                        }
-                        for (let ri = 0; ri < (item.redoDrawings || []).length; ri++) {
-                            const rd = item.redoDrawings[ri];
-                            const redoBaseKeys = exRedoDrawingBaseKeys(
-                                item.taskId, item.questionIndex, rd, ri);
-                            const redoPageCount = Math.max(1, Number(rd && rd.pages) || 0);
-                            for (let p = 0; p < redoPageCount; p++) {
-                                let redoData = await exReadRedoPageFromLocal(redoBaseKeys, rd, p);
-                                if (!redoData) redoData = await exReadRedoPageFromCloud(redoBaseKeys, p);
-                                if (redoData) await exWriteRedoPageAliases(redoBaseKeys, p, redoData);
-                            }
-                        }
-                    }
-                }
+                await exSyncCachedGradedPages();
 
                 // 拉取本地缺失的笔记本页面和媒体（与习题同样的模式）
                 const pulledNotebooks = await r2PullNotebookAssetsFromCloud({ missingOnly: true });
@@ -25499,10 +25387,10 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             return 'g' + Date.now().toString(36) + Math.random().toString(36).slice(2, 10);
         }
 
-        function exCollectUncommittedGradedCloudEntries(exercises) {
+        function exCollectUncommittedGradedCloudEntries(exercises, includeCommitted = false) {
             const byBaseKey = new Map();
             const add = (baseKey, pageCount, record, mirrorBaseKeys = []) => {
-                if (!record || record.gradedDrawingCloudCommitted !== false) return;
+                if (!record || (!includeCommitted && record.gradedDrawingCloudCommitted !== false)) return;
                 let entry = byBaseKey.get(baseKey);
                 if (!entry) {
                     entry = { baseKey, baseKeys: [baseKey], pageCount: 1, records: [] };
@@ -25809,9 +25697,61 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             }
         }
 
+        // 正常新评分由持久化待上传标记负责提交。启动/定时同步中的已评分图片是缓存，
+        // 只能读取云端或条件创建缺失对象，不能凭“本地有图片”覆盖云端。
+        async function exSyncCachedGradedPages() {
+            const generation = _exGradedCloudCommitCounter;
+            const exercises = appData.exercises;
+            const unchanged = () => exercises === appData.exercises &&
+                generation === _exGradedCloudCommitCounter &&
+                !exHasPendingGradedPagesCloudCommit() &&
+                exCollectUncommittedGradedCloudEntries(appData.exercises).length === 0;
+            for (const entry of exCollectUncommittedGradedCloudEntries(appData.exercises, true)) {
+                for (let p = 0; p < entry.pageCount; p++) {
+                    if (!unchanged()) return;
+                    const keys = entry.baseKeys.map(base => exPageKey(base, p));
+                    const local = await Promise.all(keys.map(key => getFileData(key)));
+                    try {
+                        let data = null;
+                        for (const key of keys) {
+                            data = await r2GetObject('exercises/drawings/' + key);
+                            if (data) break;
+                        }
+                        if (!unchanged()) return;
+                        if (!data) {
+                            data = local.find(Boolean);
+                            if (!data) continue;
+                            for (let i = 0; i < keys.length; i++) {
+                                if (!unchanged()) return;
+                                const key = keys[i];
+                                try {
+                                    await r2PutObject('exercises/drawings/' + key, data,
+                                        'image/png', { ifNoneMatch: '*' });
+                                } catch (error) {
+                                    if (error?.status !== 412) throw error;
+                                    // 稳定 key 始终优先，旧数组下标 alias 不能反向覆盖它。
+                                    if (i === 0) {
+                                        data = await r2GetObject('exercises/drawings/' + key);
+                                        if (!data) throw error;
+                                    }
+                                }
+                            }
+                        }
+                        for (let i = 0; i < keys.length; i++) {
+                            if (!unchanged()) return;
+                            if (local[i] !== data) await exSaveCloudDrawingIfMissing(keys[i], data,
+                                { expected: local[i], guard: unchanged });
+                        }
+                    } catch (error) {
+                        console.warn('[sync] 习题图片恢复失败，保留本地缓存:', keys[0], error);
+                    }
+                }
+            }
+        }
+
         // missing-only 云下载必须在同一个读写事务里重新判空：若新评分 B 先提交，
         // 旧云快照 A 会看到 key 已存在并跳过；若 A 事务先创建，B 随后的事务仍会最后覆盖。
-        async function exSaveCloudDrawingIfMissing(key, data) {
+        async function exSaveCloudDrawingIfMissing(key, data, options = {}) {
             if (!data) return false;
             if (!await ensureFileDB()) throw new Error(i18n('indexeddb_unavailable'));
             return new Promise((resolve, reject) => {
@@ -25822,7 +25762,10 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     const request = store.get(key);
                     let inserted = false;
                     request.onsuccess = () => {
-                        if (request.result !== undefined) return;
+                        if (options.guard && !options.guard()) return;
+                        if ('expected' in options) {
+                            if ((request.result?.data ?? null) !== options.expected) return;
+                        } else if (request.result !== undefined) return;
                         inserted = true;
                         store.put({ id: key, data });
                     };

--- a/docs/index.html
+++ b/docs/index.html
@@ -14416,6 +14416,8 @@
         }
 
         async function r2PublishMetadataWithCas(localMetadata, classroomIntent, options = {}) {
+            // 导入的离线评分也必须先有完整图片，不能先发布只有分数的索引。
+            await exEnsureImportedGradedPages();
             // 这是 metadata.json 所有发布路径的最后一道门（包括手动全量同步和
             // 云端尚无 metadata 时的课堂首传）。刷新 exercises 快照，确保刚上传
             // 完成的持久标记也进入本次 CAS。
@@ -16740,6 +16742,10 @@
                     if (exPreserveActiveExercisePageCount()) repairMetadataAfterStartup = true;
                 }
                 if (!appData.exercises) appData.exercises = { folders: [], wrongByFolder: {}, archivedWrong: {} };
+                if (exCollectUncommittedGradedCloudEntries(appData.exercises, true)
+                    .some(entry => entry.records.some(record => record.gradedDrawingCloudCommitted === 'imported'))) {
+                    repairMetadataAfterStartup = true;
+                }
                 appData.settings = { ...metadata.settings, ...localApiSettings, r2Config: localR2Config };
                 appDataLoaded = true;
                 saveData();
@@ -17883,10 +17889,9 @@
                     _callNativeRecording('deleteRecording', id);
                     await deleteFileData('classroom_' + id).catch(() => {});
                 }
-                // 备份中的待上传标记属于导出时的旧状态；导入后按 PR88 从云端恢复。
-                // 保留评分和图片，以及正常本机新评分的断点补传。
-                for (const entry of exCollectUncommittedGradedCloudEntries(appData.exercises)) {
-                    for (const record of entry.records) delete record.gradedDrawingCloudCommitted;
+                // 导入来源单独标记：不压过云端已有评分，但独有评分必须先补齐图片再发布。
+                for (const entry of exCollectUncommittedGradedCloudEntries(appData.exercises, true)) {
+                    for (const record of entry.records) record.gradedDrawingCloudCommitted = 'imported';
                 }
                 if (typeof saveExercisesToIDB === 'function') await saveExercisesToIDB();
                 const metadataSaved = saveData();
@@ -25694,6 +25699,30 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     }
                 }
                 return { exercisesForPublish, uploadedSignatures };
+            }
+        }
+
+        async function exEnsureImportedGradedPages() {
+            for (const entry of exCollectUncommittedGradedCloudEntries(appData.exercises, true)) {
+                const imported = entry.records.filter(record => record.gradedDrawingCloudCommitted === 'imported');
+                if (!imported.length) continue;
+                for (let p = 0; p < entry.pageCount; p++) {
+                    for (const baseKey of entry.baseKeys) {
+                        const key = exPageKey(baseKey, p);
+                        if (await r2GetObject('exercises/drawings/' + key)) continue;
+                        const data = await exReadRedoPageFromLocal(entry.baseKeys, null, p);
+                        if (!data) throw new Error('Imported exercise drawing is missing: ' + key);
+                        try {
+                            await r2PutObject('exercises/drawings/' + key, data,
+                                'image/png', { ifNoneMatch: '*' });
+                        } catch (error) {
+                            if (error?.status !== 412) throw error;
+                        }
+                    }
+                }
+                for (const record of imported) {
+                    if (record.gradedDrawingCloudCommitted === 'imported') record.gradedDrawingCloudCommitted = true;
+                }
             }
         }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -14416,16 +14416,15 @@
         }
 
         async function r2PublishMetadataWithCas(localMetadata, classroomIntent, options = {}) {
-            // 导入的离线评分也必须先有完整图片，不能先发布只有分数的索引。
-            await exEnsureImportedGradedPages();
-            // 这是 metadata.json 所有发布路径的最后一道门（包括手动全量同步和
-            // 云端尚无 metadata 时的课堂首传）。刷新 exercises 快照，确保刚上传
-            // 完成的持久标记也进入本次 CAS。
-            const gradingFlush = await exFlushGradedDrawingCloudCommits();
-            localMetadata = {
-                ...localMetadata,
-                exercises: gradingFlush.exercisesForPublish
-            };
+            if (!options.classroomOnly) {
+                // 发布本地评分前必须先有完整图片；课堂专用请求不携带本地习题。
+                await exEnsureImportedGradedPages();
+                const gradingFlush = await exFlushGradedDrawingCloudCommits();
+                localMetadata = {
+                    ...localMetadata,
+                    exercises: gradingFlush.exercisesForPublish
+                };
+            }
             const frozenClassroom = classroomIntent || stripClassroomData(appData.classroom, false);
             let lastConflict = null;
             for (let attempt = 0; attempt < 5; attempt++) {
@@ -14456,8 +14455,9 @@
                 const mergedIntent = remoteClassroomCount === 0 && localClassroomCount > 0
                     ? localClassroom
                     : mergeClassroomData(remoteClassroom, localClassroom, remoteBaseline);
-                let candidateBase = options.classroomOnly && remoteMetadata
-                    ? remoteMetadata
+                // 课堂首传也只创建课堂索引，不能顺带发布未校验的本地习题和笔记。
+                let candidateBase = options.classroomOnly
+                    ? (remoteMetadata || {})
                     : localMetadata;
                 if (!options.classroomOnly) {
                     // 文件变更同步不会先跑完整的 pull。提交前把远端同一条习题的版本化
@@ -14532,11 +14532,11 @@
                         Date.parse(candidate.syncedAt) || 0);
                     await cleanupClassroomEntriesRemovedByMerge(liveBefore, applied);
                     appData.classroom = applied;
-                    appData.lectures = mergeLecturesData(candidate.lectures, appData.lectures,
-                        Date.parse(candidate.syncedAt) || 0);
-                    appData.notebooks = mergeNotebooksData(candidate.notebooks, appData.notebooks,
-                        Date.parse(candidate.syncedAt) || 0);
                     if (!options.classroomOnly) {
+                        appData.lectures = mergeLecturesData(candidate.lectures, appData.lectures,
+                            Date.parse(candidate.syncedAt) || 0);
+                        appData.notebooks = mergeNotebooksData(candidate.notebooks, appData.notebooks,
+                            Date.parse(candidate.syncedAt) || 0);
                         // 网络等待期间本机可能又产生了更新；仍用同一套版本规则合回活对象，
                         // 既接收远端较新的清空，也不会压掉刚发生的本机重做。
                         exMergeMatchingExerciseHistories(appData.exercises, candidate.exercises, true);

--- a/docs/index.html
+++ b/docs/index.html
@@ -16720,6 +16720,8 @@
                     JSON.stringify(metadata.notebooks || { items: [], reviews: [] })) {
                     repairMetadataAfterStartup = true;
                 }
+                // 沿用 PR88 的讲义/笔记修复范围；习题元数据补传不上传笔记正文。
+                const repairNotebookPagesAfterStartup = repairMetadataAfterStartup;
                 if (metadata.exercises) {
                     const cloudEx = metadata.exercises;
                     const localEx = appData.exercises || { folders: [], wrongByFolder: {}, archivedWrong: {} };
@@ -16801,7 +16803,7 @@
                 if (repairMetadataAfterStartup) {
                     // 修复只补齐云端缺的那部分：正文按版本增量上传，不把本机旧正文回传。
                     await r2SyncChangedLectureContents();
-                    await r2SyncAllNotebookPages();
+                    if (repairNotebookPagesAfterStartup) await r2SyncAllNotebookPages();
                     await r2SyncMetadataOnly();
                 }
                 if (config.lastSyncTime || metadata.syncedAt) {
@@ -17993,8 +17995,15 @@
                     _callNativeRecording('deleteRecording', id);
                     await deleteFileData('classroom_' + id).catch(() => {});
                 }
+                // 备份中的待上传标记属于导出时的旧状态；导入后按 PR88 从云端恢复。
+                // 保留评分和图片，以及正常本机新评分的断点补传。
+                for (const entry of exCollectUncommittedGradedCloudEntries(appData.exercises)) {
+                    for (const record of entry.records) delete record.gradedDrawingCloudCommitted;
+                }
                 if (typeof saveExercisesToIDB === 'function') await saveExercisesToIDB();
-                saveData();
+                const metadataSaved = saveData();
+                const exercisesSaved = await exWaitForExercisesDataSaves();
+                if (!metadataSaved || !exercisesSaved) throw new Error(i18n('storage_save_failed'));
                 await restoreBlobsFromIDB();
                 applySettings();
                 renderLibrary();
@@ -26090,7 +26099,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             currentExerciseFolder = null;
             currentExerciseTask = null;
             // 旧版本同一题每次评分都会并列新增一条错题，这里按题号去重只留最近一条
-            if (exDedupeWrongQuestions()) { saveData(); debouncedChatSync(); }
+            if (exDedupeWrongQuestions()) saveData();
             document.body.classList.remove('exercise-folder-active');
             document.getElementById('exercisesGrid').style.display = '';
             document.getElementById('exerciseFolderView').style.display = 'none';

--- a/docs/index.html
+++ b/docs/index.html
@@ -14849,20 +14849,28 @@
                 .flatMap(nb => nb.pages || [])
                 .find(pg => pg && pg.id === pageId);
             const mediaIds = new Set();
-            let pgData = await getFileData('nbpage_' + pageId).catch(() => null);
+            const localPageJson = await getFileData('nbpage_' + pageId);
+            let pgData = localPageJson;
             let pageContent = null;
             if (pgData) pageContent = JSON.parse(pgData);
             // 目录刚从云端合并，正文可能仍是旧备份；不能把旧正文当成本机新编辑。
-            if (pageContent && syncTimestamp(pageContent.updatedAt) <
+            if (pageContent && syncTimestamp(pageContent.updatedAt) > 0 && syncTimestamp(pageContent.updatedAt) <
                 syncTimestamp(page?.updatedAt || page?.createdAt)) return;
             let conditions = {};
-            if (!pageContent && page) {
-                // 云端独有页尚未下载时必须保留；真正的新空白页只允许创建，不覆盖。
-                if (await r2GetObject('notebooks/pages/nbpage_' + pageId)) return;
-                pageContent = { strokes: [], texts: [], media: [], recognized: null };
-                conditions = { ifNoneMatch: '*' };
+            let uploadBody = !!pageContent;
+            if ((!pageContent && page) || (pageContent && !syncTimestamp(pageContent.updatedAt))) {
+                // 无时间戳的旧正文不能判断新旧；云端存在时保留，缺失时只允许条件创建。
+                const cloudPage = await r2GetObject('notebooks/pages/nbpage_' + pageId);
+                if (cloudPage) {
+                    pageContent = JSON.parse(cloudPage);
+                    uploadBody = false;
+                } else {
+                    pageContent = pageContent || { strokes: [], texts: [], media: [], recognized: null };
+                    conditions = { ifNoneMatch: '*' };
+                    uploadBody = true;
+                }
             }
-            if (pageContent) {
+            if (uploadBody) {
                 if (!pageContent.updatedAt) {
                     pageContent.updatedAt = page?.updatedAt || page?.createdAt || new Date().toISOString();
                 }
@@ -14872,15 +14880,20 @@
                     saveData();
                 }
                 pgData = JSON.stringify(pageContent);
-                if (!conditions.ifNoneMatch) await saveFileData('nbpage_' + pageId, pgData);
                 try {
                     await r2PutObject('notebooks/pages/nbpage_' + pageId, pgData, 'application/json', conditions);
+                    if (localPageJson && pgData !== localPageJson) {
+                        await saveCloudFileIfUnchanged('nbpage_' + pageId, pgData, { expected: localPageJson });
+                    }
                 } catch (error) {
                     if (!conditions.ifNoneMatch || error?.status !== 412) throw error;
-                    return; // 另一设备已创建正文，后续 pull 会下载，不能重发空白。
+                    // 另一设备创建成功后不重发正文，但仍需补齐它引用的本地媒体。
+                    const cloudPage = await r2GetObject('notebooks/pages/nbpage_' + pageId);
+                    if (!cloudPage) throw error;
+                    pageContent = JSON.parse(cloudPage);
                 }
-                (pageContent.media || []).forEach(m => { if (m.mediaId) mediaIds.add(m.mediaId); });
             }
+            (pageContent?.media || []).forEach(m => { if (m.mediaId) mediaIds.add(m.mediaId); });
             if (page && page.bgImage) mediaIds.add(page.bgImage);
             for (const mid of mediaIds) {
                 const mData = await getFileData('nbmedia_' + mid).catch(() => null);
@@ -14910,8 +14923,9 @@
 
         async function r2PullNotebookAssetsFromCloud(options = {}) {
             const missingOnly = options.missingOnly !== false;
+            const notebooks = appData.notebooks;
             let pages = 0, media = 0;
-            for (const nb of (appData.notebooks?.items || [])) {
+            for (const nb of (notebooks?.items || [])) {
                 for (const page of (nb.pages || [])) {
                     if (!page || !page.id) continue;
                     let pageJson = await getFileData('nbpage_' + page.id).catch(() => null);
@@ -14923,12 +14937,18 @@
                     const shouldPullPage = !missingOnly || !pageJson ||
                         (cloudPageUpdatedAt > 0 && cloudPageUpdatedAt > localPageUpdatedAt);
                     if (shouldPullPage) {
+                        const pageVersion = page.updatedAt;
                         try {
                             const cloudPage = await r2GetObject('notebooks/pages/nbpage_' + page.id);
                             if (cloudPage) {
-                                pageJson = cloudPage;
-                                await saveFileData('nbpage_' + page.id, cloudPage);
-                                pages++;
+                                const saved = await saveCloudFileIfUnchanged('nbpage_' + page.id, cloudPage, {
+                                    expected: pageJson,
+                                    guard: () => appData.notebooks === notebooks &&
+                                        (notebooks.items || []).includes(nb) && (nb.pages || []).includes(page) &&
+                                        page.updatedAt === pageVersion
+                                });
+                                if (saved) pages++;
+                                pageJson = saved ? cloudPage : await getFileData('nbpage_' + page.id);
                             }
                         } catch (e) { console.warn('[startup-sync] 拉取笔记页失败:', page.id, e); }
                     }
@@ -16587,30 +16607,27 @@
                 const cloudPapers = metadata.papers || [];
                 const cloudSyncedAtMs = metadata.syncedAt ? Date.parse(metadata.syncedAt) : 0;
                 let repairMetadataAfterStartup = false;
-                if ((cloudBooks.length + cloudPapers.length) === 0 && (localBooks.length + localPapers.length) > 0) {
+                const repairBooksAfterStartup = (cloudBooks.length + cloudPapers.length) === 0 &&
+                    (localBooks.length + localPapers.length) > 0;
+                if (repairBooksAfterStartup) {
                     console.warn('[startup-sync] 云端书籍索引为空但本地有 ' + (localBooks.length + localPapers.length) + ' 条，保留本地数据并回传云端');
-                    try {
-                        await r2SyncMetadataOnly();
-                        showToast(i18n('cloud_index_repaired'));
-                    } catch (e) { console.warn('[startup-sync] 回传修复失败:', e); }
-                    finishR2StartupMetadataSync();
-                    return;
+                } else {
+                    const cloudIds = new Set([...cloudBooks, ...cloudPapers].map(d => d && d.id).filter(Boolean));
+                    const removedIds = [...localBooks, ...localPapers]
+                        .filter(d => {
+                            if (!d || !d.id) return false;
+                            if (cloudIds.has(d.id)) return false;
+                            const addedAtMs = d.addedAt ? Date.parse(d.addedAt) : NaN;
+                            if (!isNaN(addedAtMs) && addedAtMs > cloudSyncedAtMs) return false;
+                            return true;
+                        })
+                        .map(d => d.id);
+                    for (const id of removedIds) {
+                        try { await deleteFileData(id); } catch (e) { console.warn('deleteFileData failed for', id, e); }
+                    }
+                    appData.books = mergeDocsPreferringLocalProgress(cloudBooks, localBooks, cloudSyncedAtMs);
+                    appData.papers = mergeDocsPreferringLocalProgress(cloudPapers, localPapers, cloudSyncedAtMs);
                 }
-                const cloudIds = new Set([...cloudBooks, ...cloudPapers].map(d => d && d.id).filter(Boolean));
-                const removedIds = [...localBooks, ...localPapers]
-                    .filter(d => {
-                        if (!d || !d.id) return false;
-                        if (cloudIds.has(d.id)) return false;
-                        const addedAtMs = d.addedAt ? Date.parse(d.addedAt) : NaN;
-                        if (!isNaN(addedAtMs) && addedAtMs > cloudSyncedAtMs) return false;
-                        return true;
-                    })
-                    .map(d => d.id);
-                for (const id of removedIds) {
-                    try { await deleteFileData(id); } catch (e) { console.warn('deleteFileData failed for', id, e); }
-                }
-                appData.books = mergeDocsPreferringLocalProgress(cloudBooks, localBooks, cloudSyncedAtMs);
-                appData.papers = mergeDocsPreferringLocalProgress(cloudPapers, localPapers, cloudSyncedAtMs);
                 appData.notes = mergePreferNonEmpty(metadata.notes, appData.notes);
                 appData.archived = (metadata.archived && metadata.archived.length > 0) ? metadata.archived : (appData.archived || []);
                 const mergedLectures = mergeLecturesData(
@@ -16750,11 +16767,12 @@
                 appDataLoaded = true;
                 saveData();
                 refreshAllUIFromAppData();
-                if (repairMetadataAfterStartup) {
+                if (repairMetadataAfterStartup || repairBooksAfterStartup) {
                     // 修复只补齐云端缺的那部分：正文按版本增量上传，不把本机旧正文回传。
                     await r2SyncChangedLectureContents();
                     if (repairNotebookPagesAfterStartup) await r2SyncAllNotebookPages();
                     await r2SyncMetadataOnly();
+                    if (repairBooksAfterStartup) showToast(i18n('cloud_index_repaired'));
                 }
                 if (config.lastSyncTime || metadata.syncedAt) {
                     r2LastSyncTime = metadata.syncedAt || config.lastSyncTime;
@@ -17891,7 +17909,17 @@
                 }
                 // 导入来源单独标记：不压过云端已有评分，但独有评分必须先补齐图片再发布。
                 for (const entry of exCollectUncommittedGradedCloudEntries(appData.exercises, true)) {
-                    for (const record of entry.records) record.gradedDrawingCloudCommitted = 'imported';
+                    // 旧包的内嵌图片必须先落盘，随后 saveData 才能安全剔除大字段。
+                    for (let p = 0; p < entry.pageCount; p++) {
+                        const image = entry.records.map(record => exPageImageOf(
+                            record.userDrawing || record.drawing, record.userDrawingExtra || record.extra, p)).find(Boolean);
+                        if (image) await exWriteRedoPageAliases(entry.baseKeys, p, image);
+                    }
+                    for (const record of entry.records) {
+                        if (record.userDrawing) record.userDrawingPages = entry.pageCount;
+                        else if (record.drawing) record.pages = entry.pageCount;
+                        record.gradedDrawingCloudCommitted = 'imported';
+                    }
                 }
                 if (typeof saveExercisesToIDB === 'function') await saveExercisesToIDB();
                 const metadataSaved = saveData();
@@ -25406,7 +25434,9 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                         entry.baseKeys.push(mirrorBaseKey);
                     }
                 }
-                entry.pageCount = Math.max(entry.pageCount, Number(pageCount) || 1);
+                entry.pageCount = Math.max(entry.pageCount, Number(pageCount) || 1,
+                    record.userDrawing ? 1 + (record.userDrawingExtra || []).length : 0,
+                    record.drawing ? 1 + (record.extra || []).length : 0);
                 if (!entry.records.includes(record)) entry.records.push(record);
             };
 
@@ -25545,7 +25575,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     // 原子覆盖它。主 key 只在从 legacy 恢复且仍为空时补齐。
                     if (targetBaseKey === aliases[0]) {
                         if (readBaseKey !== targetBaseKey) {
-                            await exSaveCloudDrawingIfMissing(key, drawData);
+                            await saveCloudFileIfUnchanged(key, drawData);
                         }
                     } else {
                         await saveFileData(key, drawData);
@@ -25710,7 +25740,9 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     for (const baseKey of entry.baseKeys) {
                         const key = exPageKey(baseKey, p);
                         if (await r2GetObject('exercises/drawings/' + key)) continue;
-                        const data = await exReadRedoPageFromLocal(entry.baseKeys, null, p);
+                        const embedded = entry.records.map(record => exPageImageOf(
+                            record.userDrawing || record.drawing, record.userDrawingExtra || record.extra, p)).find(Boolean);
+                        const data = embedded || await exReadRedoPageFromLocal(entry.baseKeys, null, p);
                         if (!data) throw new Error('Imported exercise drawing is missing: ' + key);
                         try {
                             await r2PutObject('exercises/drawings/' + key, data,
@@ -25768,7 +25800,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                         }
                         for (let i = 0; i < keys.length; i++) {
                             if (!unchanged()) return;
-                            if (local[i] !== data) await exSaveCloudDrawingIfMissing(keys[i], data,
+                            if (local[i] !== data) await saveCloudFileIfUnchanged(keys[i], data,
                                 { expected: local[i], guard: unchanged });
                         }
                     } catch (error) {
@@ -25778,9 +25810,9 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             }
         }
 
-        // missing-only 云下载必须在同一个读写事务里重新判空：若新评分 B 先提交，
-        // 旧云快照 A 会看到 key 已存在并跳过；若 A 事务先创建，B 随后的事务仍会最后覆盖。
-        async function exSaveCloudDrawingIfMissing(key, data, options = {}) {
+        // 云下载在同一个读写事务内检查原值，不能覆盖等待下载期间的新编辑或新评分。
+        // 不传 expected 时只补本地缺失的文件。
+        async function saveCloudFileIfUnchanged(key, data, options = {}) {
             if (!data) return false;
             if (!await ensureFileDB()) throw new Error(i18n('indexeddb_unavailable'));
             return new Promise((resolve, reject) => {
@@ -28669,7 +28701,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     try { cloudGradedImage = await r2GetObject('exercises/drawings/' + gradedKey); } catch (e) {}
                     if (cloudGradedImage && restoreGradingGuard()) {
                         try {
-                            const inserted = await exSaveCloudDrawingIfMissing(gradedKey, cloudGradedImage);
+                            const inserted = await saveCloudFileIfUnchanged(gradedKey, cloudGradedImage);
                             if (restoreGradingGuard()) {
                                 if (inserted) {
                                     gradedImage = cloudGradedImage;

--- a/docs/index.html
+++ b/docs/index.html
@@ -14133,9 +14133,13 @@
                 await r2SyncAllNotebookPages();
 
                 // 再把合并后的结果推回云端
-                const metadataPublishResult = await r2SyncMetadataOnly();
-                if (metadataPublishResult.casCommitted) {
-                    await flushClassroomDeletionOutboxAfterMetadata();
+                let metadataPublishError = null;
+                try {
+                    const metadataPublishResult = await r2SyncMetadataOnly();
+                    if (metadataPublishResult.casCommitted) await flushClassroomDeletionOutboxAfterMetadata();
+                } catch (error) {
+                    // 补传失败不能跳过后续资源下载；恢复完成后仍向调用方报告发布失败。
+                    metadataPublishError = error;
                 }
 
                 // 把本地新加、云端还没有的 PDF 文件一起上传
@@ -14185,6 +14189,7 @@
                 await r2PullNotebookAssetsFromCloud({ missingOnly: true });
 
                 // 更新上次同步时间
+                if (metadataPublishError) throw metadataPublishError;
                 config.lastSyncTime = new Date().toISOString();
                 r2LastSyncTime = config.lastSyncTime;
                 saveData();
@@ -14416,15 +14421,18 @@
         }
 
         async function r2PublishMetadataWithCas(localMetadata, classroomIntent, options = {}) {
+            const hadImportedGrading = !options.classroomOnly &&
+                exCollectUncommittedGradedCloudEntries(appData.exercises, true)
+                    .some(entry => entry.records.some(record => record.gradedDrawingCloudCommitted === 'imported'));
             if (!options.classroomOnly) {
-                // 发布本地评分前必须先有完整图片；课堂专用请求不携带本地习题。
-                await exEnsureImportedGradedPages();
                 const gradingFlush = await exFlushGradedDrawingCloudCommits();
                 localMetadata = {
                     ...localMetadata,
                     exercises: gradingFlush.exercisesForPublish
                 };
             }
+            const gradingSource = appData.exercises;
+            const gradingGeneration = _exGradedCloudCommitCounter;
             const frozenClassroom = classroomIntent || stripClassroomData(appData.classroom, false);
             let lastConflict = null;
             for (let attempt = 0; attempt < 5; attempt++) {
@@ -14455,16 +14463,20 @@
                 const mergedIntent = remoteClassroomCount === 0 && localClassroomCount > 0
                     ? localClassroom
                     : mergeClassroomData(remoteClassroom, localClassroom, remoteBaseline);
-                // 课堂首传也只创建课堂索引，不能顺带发布未校验的本地习题和笔记。
+                // 首次建索引保留已有目录，否则新的 syncedAt 会把离线笔记误判为已删除。
+                // 未经图片校验的习题仍不能随课堂首传发布。
                 let candidateBase = options.classroomOnly
-                    ? (remoteMetadata || {})
+                    ? (remoteMetadata || { ...localMetadata, exercises: undefined })
                     : localMetadata;
                 if (!options.classroomOnly) {
+                    // 每次 CAS 重试都从原快照重建，保留导入来源，重新核对最新云端评分。
+                    candidateBase = { ...candidateBase, exercises: stripExercisesData(localMetadata.exercises) };
                     // 文件变更同步不会先跑完整的 pull。提交前把远端同一条习题的版本化
                     // redo 历史合进本次快照，避免长时间在线的旧设备覆盖另一端的清空。
                     exMergeMatchingExerciseHistories(
                         candidateBase?.exercises,
                         remoteMetadata?.exercises,
+                        true,
                         true
                     );
                     candidateBase = {
@@ -14504,6 +14516,8 @@
                     classroomTombstones: tombstones,
                     syncedAt: new Date().toISOString()
                 };
+                // 只验证合并后确实要发布的导入评分；不能拿旧分数配上已存在的云端图片。
+                if (!options.classroomOnly) await exEnsureImportedGradedPages(candidate.exercises);
 
                 if (!options.allowEmpty &&
                     !await r2ProtectMetadataOverwrite(candidate, remoteResult?.data || null, remoteMetadata)) {
@@ -14518,6 +14532,10 @@
                     : remoteResult?.etag
                         ? { ifMatch: remoteResult.etag }
                         : {};
+                if (hadImportedGrading && (appData.exercises !== gradingSource ||
+                    _exGradedCloudCommitCounter !== gradingGeneration)) {
+                    throw new Error('Exercise grading changed during import recovery; retry publication');
+                }
                 try {
                     await r2PutObject('metadata.json', JSON.stringify(candidate), 'application/json', conditions);
 
@@ -14539,7 +14557,7 @@
                             Date.parse(candidate.syncedAt) || 0);
                         // 网络等待期间本机可能又产生了更新；仍用同一套版本规则合回活对象，
                         // 既接收远端较新的清空，也不会压掉刚发生的本机重做。
-                        exMergeMatchingExerciseHistories(appData.exercises, candidate.exercises, true);
+                        exMergeMatchingExerciseHistories(appData.exercises, candidate.exercises, true, true);
                     }
                     const gradingCommitStateChanged = exMarkPublishedGradingCommits(
                         appData.exercises,
@@ -14550,6 +14568,7 @@
                         // 云端已提交成功；保留本地 false 的旧持久副本只会触发安全重试。
                         console.warn('[sync] 评分快照提交状态本地保存失败，将在下次同步重试');
                     }
+                    if (hadImportedGrading) await exSyncCachedGradedPages();
                     return { metadata: candidate, casCommitted: true };
                 } catch (e) {
                     if (e?.status !== 412) throw e;
@@ -16768,11 +16787,15 @@
                 saveData();
                 refreshAllUIFromAppData();
                 if (repairMetadataAfterStartup || repairBooksAfterStartup) {
-                    // 修复只补齐云端缺的那部分：正文按版本增量上传，不把本机旧正文回传。
-                    await r2SyncChangedLectureContents();
-                    if (repairNotebookPagesAfterStartup) await r2SyncAllNotebookPages();
-                    await r2SyncMetadataOnly();
-                    if (repairBooksAfterStartup) showToast(i18n('cloud_index_repaired'));
+                    try {
+                        // 发布失败也继续下载云端资源，不让缺图习题阻断 PDF 和笔记恢复。
+                        await r2SyncChangedLectureContents();
+                        if (repairNotebookPagesAfterStartup) await r2SyncAllNotebookPages();
+                        await r2SyncMetadataOnly();
+                        if (repairBooksAfterStartup) showToast(i18n('cloud_index_repaired'));
+                    } catch (error) {
+                        console.warn('[startup-sync] 索引补传失败，继续恢复云端资源:', error);
+                    }
                 }
                 if (config.lastSyncTime || metadata.syncedAt) {
                     r2LastSyncTime = metadata.syncedAt || config.lastSyncTime;
@@ -17910,13 +17933,18 @@
                 // 导入来源单独标记：不压过云端已有评分，但独有评分必须先补齐图片再发布。
                 for (const entry of exCollectUncommittedGradedCloudEntries(appData.exercises, true)) {
                     // 旧包的内嵌图片必须先落盘，随后 saveData 才能安全剔除大字段。
+                    // 错题的 userDrawing 是最近重做的显示缓存，不是原答图片。
+                    const embeddedRecords = entry.records.filter(record => !(record.redoDrawings || []).length);
+                    entry.pageCount = Math.max(entry.pageCount, ...embeddedRecords.map(record =>
+                        record.userDrawing ? 1 + (record.userDrawingExtra || []).length :
+                        record.drawing ? 1 + (record.extra || []).length : 0));
                     for (let p = 0; p < entry.pageCount; p++) {
-                        const image = entry.records.map(record => exPageImageOf(
+                        const image = embeddedRecords.map(record => exPageImageOf(
                             record.userDrawing || record.drawing, record.userDrawingExtra || record.extra, p)).find(Boolean);
                         if (image) await exWriteRedoPageAliases(entry.baseKeys, p, image);
                     }
                     for (const record of entry.records) {
-                        if (record.userDrawing) record.userDrawingPages = entry.pageCount;
+                        if (record.userDrawing && !(record.redoDrawings || []).length) record.userDrawingPages = entry.pageCount;
                         else if (record.drawing) record.pages = entry.pageCount;
                         record.gradedDrawingCloudCommitted = 'imported';
                     }
@@ -24958,17 +24986,26 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
         // 启动/周期 pull 会先以云端对象为骨架。若本地存在“metadata 已落盘、图片尚未
         // 上传”的评分事务，必须把这份结果一起保住，否则进程重启恰好会抹掉补传标记。
-        function exPreserveUncommittedGrading(targetQ, localQ) {
-            if (!targetQ || !localQ || localQ.gradedDrawingCloudCommitted !== false) return false;
+        function exPreserveUncommittedGrading(targetQ, localQ, restoreImported = false) {
+            if (!targetQ || !localQ) return false;
+            const restoring = restoreImported && targetQ.gradedDrawingCloudCommitted === 'imported';
+            if (!restoring && localQ.gradedDrawingCloudCommitted !== false) return false;
             const fields = [
                 'status', 'score', 'userDrawing', 'userDrawingExtra',
                 'userDrawingPages', 'pageCount', 'aiComment',
                 'timeUsedSeconds', 'remainingSeconds', 'gradedDrawingCommitId',
-                'gradedDrawingCloudCommitted'
+                'gradedDrawingCloudCommitted',
+                ...(restoring ? ['drawing', 'extra', 'pages', 'comment'] : [])
             ];
             let changed = false;
             for (const field of fields) {
-                if (!Object.prototype.hasOwnProperty.call(localQ, field)) continue;
+                if (!Object.prototype.hasOwnProperty.call(localQ, field)) {
+                    if (restoring && Object.prototype.hasOwnProperty.call(targetQ, field)) {
+                        delete targetQ[field];
+                        changed = true;
+                    }
+                    continue;
+                }
                 const value = Array.isArray(localQ[field])
                     ? localQ[field].slice()
                     : localQ[field];
@@ -24984,7 +25021,9 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
         // 习题目前只能加页、不能删页，因此页数合并始终取两端较大值。
         function exMergeExerciseQuestionPageCounts(targetQ, localQ, options = {}) {
             if (!targetQ || !localQ) return false;
-            let changed = options.preserveSourceUncommitted === false
+            let changed = options.restoreImported && targetQ.gradedDrawingCloudCommitted === 'imported'
+                ? exPreserveUncommittedGrading(targetQ, localQ, true)
+                : options.preserveSourceUncommitted === false
                 ? false
                 : exPreserveUncommittedGrading(targetQ, localQ);
             const gradedPages = Math.max(
@@ -25031,6 +25070,8 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     }
                     const targetRedo = targetRedos[targetIndex];
                     if (!targetRedo) return;
+                    if (options.restoreImported && targetRedo.gradedDrawingCloudCommitted === 'imported' &&
+                        exPreserveUncommittedGrading(targetRedo, localRedo, true)) changed = true;
                     const redoPages = Math.max(
                         1,
                         Number(targetRedo.pages) || 0,
@@ -25081,6 +25122,8 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     winningRedos, losingRedo, losingIndex);
                 if (winningIndex < 0) return;
                 const winningRedo = winningRedos[winningIndex];
+                if (options.restoreImported && !localWins && winningRedo.gradedDrawingCloudCommitted === 'imported' &&
+                    exPreserveUncommittedGrading(winningRedo, losingRedo, true)) changed = true;
                 const redoPages = Math.max(
                     1,
                     Number(winningRedo.pages) || 0,
@@ -25128,7 +25171,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
 
         // 只合并两份 metadata 中本来就是同一实体的题目；不补 folder/task/question，
         // 避免在没有实体 tombstone 的情况下顺手复活整道已删除错题。
-        function exMergeMatchingExerciseHistories(targetExercises, sourceExercises, preferSourceRedoOnTie = false) {
+        function exMergeMatchingExerciseHistories(targetExercises, sourceExercises, preferSourceRedoOnTie = false, restoreImported = false) {
             if (!targetExercises || !sourceExercises) return false;
             let changed = false;
 
@@ -25150,7 +25193,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                             targetQ = (targetTask.questions || [])[sourceIndex];
                         }
                         if (targetQ && exMergeExerciseQuestionPageCounts(targetQ, sourceQ,
-                            { preferSourceRedoOnTie, preserveSourceUncommitted: false })) {
+                            { preferSourceRedoOnTie, preserveSourceUncommitted: false, restoreImported })) {
                             changed = true;
                         }
                     });
@@ -25167,7 +25210,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                         const targetQ = (targetTask.questions || [])
                             .find(q => q && q.questionIndex === sourceQ?.questionIndex);
                         if (targetQ && exMergeExerciseQuestionPageCounts(targetQ, sourceQ,
-                            { preferSourceRedoOnTie, preserveSourceUncommitted: false })) {
+                            { preferSourceRedoOnTie, preserveSourceUncommitted: false, restoreImported })) {
                             changed = true;
                         }
                     }
@@ -25182,7 +25225,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                         item.questionIndex === sourceItem?.questionIndex &&
                         item.archivedAt === sourceItem?.archivedAt);
                     if (targetItem && exMergeExerciseQuestionPageCounts(targetItem, sourceItem,
-                        { preferSourceRedoOnTie, preserveSourceUncommitted: false })) {
+                        { preferSourceRedoOnTie, preserveSourceUncommitted: false, restoreImported })) {
                         changed = true;
                     }
                 }
@@ -25434,9 +25477,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                         entry.baseKeys.push(mirrorBaseKey);
                     }
                 }
-                entry.pageCount = Math.max(entry.pageCount, Number(pageCount) || 1,
-                    record.userDrawing ? 1 + (record.userDrawingExtra || []).length : 0,
-                    record.drawing ? 1 + (record.extra || []).length : 0);
+                entry.pageCount = Math.max(entry.pageCount, Number(pageCount) || 1);
                 if (!entry.records.includes(record)) entry.records.push(record);
             };
 
@@ -25732,23 +25773,28 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             }
         }
 
-        async function exEnsureImportedGradedPages() {
-            for (const entry of exCollectUncommittedGradedCloudEntries(appData.exercises, true)) {
+        async function exEnsureImportedGradedPages(exercises) {
+            for (const entry of exCollectUncommittedGradedCloudEntries(exercises, true)) {
                 const imported = entry.records.filter(record => record.gradedDrawingCloudCommitted === 'imported');
                 if (!imported.length) continue;
                 for (let p = 0; p < entry.pageCount; p++) {
                     for (const baseKey of entry.baseKeys) {
                         const key = exPageKey(baseKey, p);
-                        if (await r2GetObject('exercises/drawings/' + key)) continue;
-                        const embedded = entry.records.map(record => exPageImageOf(
+                        const cloudDrawing = await r2GetObject('exercises/drawings/' + key);
+                        const embedded = entry.records.filter(record => !(record.redoDrawings || []).length).map(record => exPageImageOf(
                             record.userDrawing || record.drawing, record.userDrawingExtra || record.extra, p)).find(Boolean);
                         const data = embedded || await exReadRedoPageFromLocal(entry.baseKeys, null, p);
                         if (!data) throw new Error('Imported exercise drawing is missing: ' + key);
+                        if (cloudDrawing) {
+                            if (cloudDrawing !== data) throw new Error('Imported exercise drawing conflicts with cloud: ' + key);
+                            continue;
+                        }
                         try {
                             await r2PutObject('exercises/drawings/' + key, data,
                                 'image/png', { ifNoneMatch: '*' });
                         } catch (error) {
                             if (error?.status !== 412) throw error;
+                            if (await r2GetObject('exercises/drawings/' + key) !== data) throw error;
                         }
                     }
                 }
@@ -25768,6 +25814,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                 !exHasPendingGradedPagesCloudCommit() &&
                 exCollectUncommittedGradedCloudEntries(appData.exercises).length === 0;
             for (const entry of exCollectUncommittedGradedCloudEntries(appData.exercises, true)) {
+                if (entry.records.some(record => record.gradedDrawingCloudCommitted === 'imported')) continue;
                 for (let p = 0; p < entry.pageCount; p++) {
                     if (!unchanged()) return;
                     const keys = entry.baseKeys.map(base => exPageKey(base, p));

--- a/docs/index.html
+++ b/docs/index.html
@@ -14177,82 +14177,12 @@
                                 }
                             }
                         }
-                        // 同步用户作答drawings（本地有云端没有 → 上传，本地没有云端有 → 拉取），多页作答逐页同步
-                        for (const q of (task.questions || [])) {
-                            if (q.status === 'done') {
-                                for (const drawKey of exGradedPageKeys(`exercise_drawing_${task.id}_${q.index}`, q.userDrawingPages)) {
-                                    const localDraw = await getFileData(drawKey).catch(() => null);
-                                    if (localDraw) {
-                                        try { await r2PutObject('exercises/drawings/' + drawKey, localDraw, 'image/png'); } catch(e) {}
-                                    } else {
-                                        try {
-                                            const cd = await r2GetObject('exercises/drawings/' + drawKey);
-                                            if (cd) await exSaveCloudDrawingIfMissing(drawKey, cd);
-                                        } catch(e) {}
-                                    }
-                                }
-                            }
-                        }
                     }
                 }
-                // 同步错题和重做drawings（多页作答逐页同步）
-                for (const fId of Object.keys(appData.exercises?.wrongByFolder || {})) {
-                    for (const wt of (appData.exercises.wrongByFolder[fId] || [])) {
-                        for (const q of (wt.questions || [])) {
-                            for (const wrongDrawKey of exGradedPageKeys(`exercise_drawing_${wt.taskId}_${q.questionIndex}`, q.userDrawingPages)) {
-                                const localWD = await getFileData(wrongDrawKey).catch(() => null);
-                                if (localWD) {
-                                    try { await r2PutObject('exercises/drawings/' + wrongDrawKey, localWD, 'image/png'); } catch(e) {}
-                                } else {
-                                    try { const cd = await r2GetObject('exercises/drawings/' + wrongDrawKey); if (cd) await exSaveCloudDrawingIfMissing(wrongDrawKey, cd); } catch(e) {}
-                                }
-                            }
-                            for (let ri = 0; ri < (q.redoDrawings || []).length; ri++) {
-                                const rd = q.redoDrawings[ri];
-                                const redoBaseKeys = exRedoDrawingBaseKeys(
-                                    wt.taskId, q.questionIndex, rd, ri);
-                                const redoPageCount = Math.max(1, Number(rd && rd.pages) || 0);
-                                for (let p = 0; p < redoPageCount; p++) {
-                                    const localRD = await exReadRedoPageFromLocal(redoBaseKeys, rd, p);
-                                    if (localRD) {
-                                        try { await exUploadRedoPageAliases(redoBaseKeys, p, localRD); } catch(e) {}
-                                    } else {
-                                        const cloudRD = await exReadRedoPageFromCloud(redoBaseKeys, p);
-                                        if (cloudRD) await exWriteRedoPageAliases(redoBaseKeys, p, cloudRD);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
+                await exSyncCachedGradedPages();
 
-                // 同步笔记本页面和媒体（本地有云端没有 → 上传，本地没有云端有 → 拉取）
-                for (const nb of (appData.notebooks?.items || [])) {
-                    for (const page of (nb.pages || [])) {
-                        if (!page || !page.id) continue;
-                        let pgData = await getFileData('nbpage_' + page.id).catch(() => null);
-                        if (pgData) {
-                            try { await r2PutObject('notebooks/pages/nbpage_' + page.id, pgData, 'application/json'); } catch(e) {}
-                        } else {
-                            try {
-                                const cd = await r2GetObject('notebooks/pages/nbpage_' + page.id);
-                                if (cd) { pgData = cd; await saveFileData('nbpage_' + page.id, cd); }
-                            } catch(e) {}
-                        }
-                        const mediaIds = r2NotebookMediaIdsFromPage(page, pgData);
-                        for (const mid of mediaIds) {
-                            const localMedia = await getFileData('nbmedia_' + mid).catch(() => null);
-                            if (localMedia) {
-                                try { await r2PutObject('notebooks/media/nbmedia_' + mid, localMedia, 'application/octet-stream'); } catch(e) {}
-                            } else {
-                                try {
-                                    const cd = await r2GetObject('notebooks/media/nbmedia_' + mid);
-                                    if (cd) await saveFileData('nbmedia_' + mid, cd);
-                                } catch(e) {}
-                            }
-                        }
-                    }
-                }
+                // 正文上传已走统一版本检查；下载较新或缺失的正文和媒体。
+                await r2PullNotebookAssetsFromCloud({ missingOnly: true });
 
                 // 更新上次同步时间
                 config.lastSyncTime = new Date().toISOString();
@@ -14919,8 +14849,17 @@
             const mediaIds = new Set();
             let pgData = await getFileData('nbpage_' + pageId).catch(() => null);
             let pageContent = null;
-            try { pageContent = pgData ? JSON.parse(pgData) : null; } catch (e) {}
-            if (!pageContent && page) pageContent = { strokes: [], texts: [], media: [], recognized: null };
+            if (pgData) pageContent = JSON.parse(pgData);
+            // 目录刚从云端合并，正文可能仍是旧备份；不能把旧正文当成本机新编辑。
+            if (pageContent && syncTimestamp(pageContent.updatedAt) <
+                syncTimestamp(page?.updatedAt || page?.createdAt)) return;
+            let conditions = {};
+            if (!pageContent && page) {
+                // 云端独有页尚未下载时必须保留；真正的新空白页只允许创建，不覆盖。
+                if (await r2GetObject('notebooks/pages/nbpage_' + pageId)) return;
+                pageContent = { strokes: [], texts: [], media: [], recognized: null };
+                conditions = { ifNoneMatch: '*' };
+            }
             if (pageContent) {
                 if (!pageContent.updatedAt) {
                     pageContent.updatedAt = page?.updatedAt || page?.createdAt || new Date().toISOString();
@@ -14931,8 +14870,13 @@
                     saveData();
                 }
                 pgData = JSON.stringify(pageContent);
-                await saveFileData('nbpage_' + pageId, pgData);
-                await r2PutObject('notebooks/pages/nbpage_' + pageId, pgData, 'application/json');
+                if (!conditions.ifNoneMatch) await saveFileData('nbpage_' + pageId, pgData);
+                try {
+                    await r2PutObject('notebooks/pages/nbpage_' + pageId, pgData, 'application/json', conditions);
+                } catch (error) {
+                    if (!conditions.ifNoneMatch || error?.status !== 412) throw error;
+                    return; // 另一设备已创建正文，后续 pull 会下载，不能重发空白。
+                }
                 (pageContent.media || []).forEach(m => { if (m.mediaId) mediaIds.add(m.mediaId); });
             }
             if (page && page.bgImage) mediaIds.add(page.bgImage);
@@ -16941,65 +16885,9 @@
                                 } catch(e) { console.warn('启动拉取习题文件失败:', sf.id, e); }
                             }
                         }
-                        for (const q of (task.questions || [])) {
-                            if (q.status === 'done') {
-                                for (const drawKey of exGradedPageKeys(`exercise_drawing_${task.id}_${q.index}`, q.userDrawingPages)) {
-                                    const localDraw = await getFileData(drawKey).catch(() => null);
-                                    if (!localDraw) {
-                                        try {
-                                            const cloudDraw = await r2GetObject('exercises/drawings/' + drawKey);
-                                            if (cloudDraw) await exSaveCloudDrawingIfMissing(drawKey, cloudDraw);
-                                        } catch(e) {}
-                                    }
-                                }
-                            }
-                        }
                     }
                 }
-                for (const fId of Object.keys(appData.exercises?.wrongByFolder || {})) {
-                    for (const wt of (appData.exercises.wrongByFolder[fId] || [])) {
-                        for (const q of (wt.questions || [])) {
-                            for (const wrongDrawKey of exGradedPageKeys(`exercise_drawing_${wt.taskId}_${q.questionIndex}`, q.userDrawingPages)) {
-                                const localWD = await getFileData(wrongDrawKey).catch(() => null);
-                                if (!localWD) {
-                                    try { const cd = await r2GetObject('exercises/drawings/' + wrongDrawKey); if (cd) await exSaveCloudDrawingIfMissing(wrongDrawKey, cd); } catch(e) {}
-                                }
-                            }
-                            for (let ri = 0; ri < (q.redoDrawings || []).length; ri++) {
-                                const rd = q.redoDrawings[ri];
-                                const redoBaseKeys = exRedoDrawingBaseKeys(
-                                    wt.taskId, q.questionIndex, rd, ri);
-                                const redoPageCount = Math.max(1, Number(rd && rd.pages) || 0);
-                                for (let p = 0; p < redoPageCount; p++) {
-                                    let redoData = await exReadRedoPageFromLocal(redoBaseKeys, rd, p);
-                                    if (!redoData) redoData = await exReadRedoPageFromCloud(redoBaseKeys, p);
-                                    if (redoData) await exWriteRedoPageAliases(redoBaseKeys, p, redoData);
-                                }
-                            }
-                        }
-                    }
-                }
-                for (const fId of Object.keys(appData.exercises?.archivedWrong || {})) {
-                    for (const item of (appData.exercises.archivedWrong[fId] || [])) {
-                        for (const archDrawKey of exGradedPageKeys(`exercise_drawing_${item.taskId}_${item.questionIndex}`, item.userDrawingPages)) {
-                            const localAD = await getFileData(archDrawKey).catch(() => null);
-                            if (!localAD) {
-                                try { const cd = await r2GetObject('exercises/drawings/' + archDrawKey); if (cd) await exSaveCloudDrawingIfMissing(archDrawKey, cd); } catch(e) {}
-                            }
-                        }
-                        for (let ri = 0; ri < (item.redoDrawings || []).length; ri++) {
-                            const rd = item.redoDrawings[ri];
-                            const redoBaseKeys = exRedoDrawingBaseKeys(
-                                item.taskId, item.questionIndex, rd, ri);
-                            const redoPageCount = Math.max(1, Number(rd && rd.pages) || 0);
-                            for (let p = 0; p < redoPageCount; p++) {
-                                let redoData = await exReadRedoPageFromLocal(redoBaseKeys, rd, p);
-                                if (!redoData) redoData = await exReadRedoPageFromCloud(redoBaseKeys, p);
-                                if (redoData) await exWriteRedoPageAliases(redoBaseKeys, p, redoData);
-                            }
-                        }
-                    }
-                }
+                await exSyncCachedGradedPages();
 
                 // 拉取本地缺失的笔记本页面和媒体（与习题同样的模式）
                 const pulledNotebooks = await r2PullNotebookAssetsFromCloud({ missingOnly: true });
@@ -25499,10 +25387,10 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             return 'g' + Date.now().toString(36) + Math.random().toString(36).slice(2, 10);
         }
 
-        function exCollectUncommittedGradedCloudEntries(exercises) {
+        function exCollectUncommittedGradedCloudEntries(exercises, includeCommitted = false) {
             const byBaseKey = new Map();
             const add = (baseKey, pageCount, record, mirrorBaseKeys = []) => {
-                if (!record || record.gradedDrawingCloudCommitted !== false) return;
+                if (!record || (!includeCommitted && record.gradedDrawingCloudCommitted !== false)) return;
                 let entry = byBaseKey.get(baseKey);
                 if (!entry) {
                     entry = { baseKey, baseKeys: [baseKey], pageCount: 1, records: [] };
@@ -25809,9 +25697,61 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             }
         }
 
+        // 正常新评分由持久化待上传标记负责提交。启动/定时同步中的已评分图片是缓存，
+        // 只能读取云端或条件创建缺失对象，不能凭“本地有图片”覆盖云端。
+        async function exSyncCachedGradedPages() {
+            const generation = _exGradedCloudCommitCounter;
+            const exercises = appData.exercises;
+            const unchanged = () => exercises === appData.exercises &&
+                generation === _exGradedCloudCommitCounter &&
+                !exHasPendingGradedPagesCloudCommit() &&
+                exCollectUncommittedGradedCloudEntries(appData.exercises).length === 0;
+            for (const entry of exCollectUncommittedGradedCloudEntries(appData.exercises, true)) {
+                for (let p = 0; p < entry.pageCount; p++) {
+                    if (!unchanged()) return;
+                    const keys = entry.baseKeys.map(base => exPageKey(base, p));
+                    const local = await Promise.all(keys.map(key => getFileData(key)));
+                    try {
+                        let data = null;
+                        for (const key of keys) {
+                            data = await r2GetObject('exercises/drawings/' + key);
+                            if (data) break;
+                        }
+                        if (!unchanged()) return;
+                        if (!data) {
+                            data = local.find(Boolean);
+                            if (!data) continue;
+                            for (let i = 0; i < keys.length; i++) {
+                                if (!unchanged()) return;
+                                const key = keys[i];
+                                try {
+                                    await r2PutObject('exercises/drawings/' + key, data,
+                                        'image/png', { ifNoneMatch: '*' });
+                                } catch (error) {
+                                    if (error?.status !== 412) throw error;
+                                    // 稳定 key 始终优先，旧数组下标 alias 不能反向覆盖它。
+                                    if (i === 0) {
+                                        data = await r2GetObject('exercises/drawings/' + key);
+                                        if (!data) throw error;
+                                    }
+                                }
+                            }
+                        }
+                        for (let i = 0; i < keys.length; i++) {
+                            if (!unchanged()) return;
+                            if (local[i] !== data) await exSaveCloudDrawingIfMissing(keys[i], data,
+                                { expected: local[i], guard: unchanged });
+                        }
+                    } catch (error) {
+                        console.warn('[sync] 习题图片恢复失败，保留本地缓存:', keys[0], error);
+                    }
+                }
+            }
+        }
+
         // missing-only 云下载必须在同一个读写事务里重新判空：若新评分 B 先提交，
         // 旧云快照 A 会看到 key 已存在并跳过；若 A 事务先创建，B 随后的事务仍会最后覆盖。
-        async function exSaveCloudDrawingIfMissing(key, data) {
+        async function exSaveCloudDrawingIfMissing(key, data, options = {}) {
             if (!data) return false;
             if (!await ensureFileDB()) throw new Error(i18n('indexeddb_unavailable'));
             return new Promise((resolve, reject) => {
@@ -25822,7 +25762,10 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     const request = store.get(key);
                     let inserted = false;
                     request.onsuccess = () => {
-                        if (request.result !== undefined) return;
+                        if (options.guard && !options.guard()) return;
+                        if ('expected' in options) {
+                            if ((request.result?.data ?? null) !== options.expected) return;
+                        } else if (request.result !== undefined) return;
                         inserted = true;
                         store.put({ id: key, data });
                     };

--- a/tests/cloud-sync-restore.test.js
+++ b/tests/cloud-sync-restore.test.js
@@ -63,6 +63,23 @@ function harness(html, local, remote) {
         dataZipRead: async () => ({ 'metadata.json': JSON.stringify(local) }), dataZipText: async value => value,
         saveFileData: async (key, value) => idb.set(key, value), getFileData: async key => idb.get(key) ?? null,
         deleteFileData: async key => idb.delete(key), saveBlobsToIDB: asyncNoop,
+        ensureFileDB: async () => true,
+        fileDB: { transaction: () => {
+            const tx = {};
+            tx.objectStore = () => ({
+                get: key => {
+                    const request = {};
+                    queueMicrotask(() => {
+                        request.result = idb.has(key) ? { id: key, data: idb.get(key) } : undefined;
+                        request.onsuccess();
+                        queueMicrotask(() => tx.oncomplete());
+                    });
+                    return request;
+                },
+                put: record => idb.set(record.id, record.data)
+            });
+            return tx;
+        } },
         backupAppDataToIDB: noop, restoreBlobsFromIDB: asyncNoop,
         applySettings: noop, renderLibrary: noop, renderNotesPage: noop, renderClassroomPage: noop,
         renderNotebooksPage: noop, refreshAllUIFromAppData: noop,
@@ -72,7 +89,13 @@ function harness(html, local, remote) {
             const value = cloud.get(key);
             return options?.withMetadata ? { data: value, etag: 'memory-etag', missing: !value } : value;
         },
-        r2PutObject: async (key, value) => { calls.push('PUT ' + key); cloud.set(key, value); }
+        r2PutObject: async (key, value, type, conditions = {}) => {
+            calls.push('PUT ' + key);
+            if (conditions.ifNoneMatch === '*' && cloud.has(key)) {
+                throw Object.assign(new Error('conditional create conflict'), { status: 412 });
+            }
+            cloud.set(key, value);
+        }
     });
     async function drainTimers() {
         for (const [id, timer] of [...timers]) { timers.delete(id); timer.fn(); }
@@ -111,6 +134,11 @@ async function checkStartup(html) {
     const notebook = at => ({ items: [{ id: 'nb', updatedAt: at, pages: [{ id: 'p1', updatedAt: at }] }], reviews: [] });
     local.notebooks = notebook(local.syncedAt);
     remote.notebooks = notebook(remote.syncedAt);
+    // Reading position may be newer in an older backup while the cloud body is newer.
+    Object.assign(local.notebooks.items[0], { lastOpenedPageId: 'p1',
+        lastOpenedPageUpdatedAt: Date.parse(local.syncedAt) });
+    Object.assign(remote.notebooks.items[0], { lastOpenedPageId: 'p1',
+        lastOpenedPageUpdatedAt: Date.parse('2026-08-01') });
     remote.notebooks.items[0].pages.push({ id: 'p2', updatedAt: remote.syncedAt });
     local.exercises.wrongByFolder.folder = [{ taskId: 'old-task', questions: [{ questionIndex: 0, score: 1 }] }];
     const h = harness(html, local, remote);
@@ -175,7 +203,120 @@ async function checkOldGrading(html) {
         assert.equal(h.cloud.get('exercises/drawings/' + key),
             imported ? 'CLOUD COMMITTED IMAGE' : 'LOCAL PENDING IMAGE');
         assert.equal(h.calls.includes('PUT exercises/drawings/' + key), !imported);
+        assert.equal(h.idb.get(key), imported ? 'CLOUD COMMITTED IMAGE' : 'LOCAL PENDING IMAGE',
+            'the restored score and local drawing must belong to the same cloud version');
+        await h.context.performAutoSync();
+        await h.drainTimers();
+        assert.deepEqual(h.errors, []);
+        assert.equal(h.cloud.get('exercises/drawings/' + key),
+            imported ? 'CLOUD COMMITTED IMAGE' : 'LOCAL PENDING IMAGE',
+            'the next periodic sync must not upload an old imported drawing');
     }
+}
+async function checkNotebookUploads(html) {
+    const page = (at, text) => JSON.stringify({ updatedAt: at, strokes: [], texts: [{ text }], media: [] });
+    for (const mode of ['offline-edit', 'new-blank', 'create-race', 'download-failure', 'corrupt-local']) {
+        const local = data(), remote = data(true);
+        local.notebooks = { items: [{ id: 'nb', pages: [{ id: 'p', updatedAt: remote.syncedAt }] }], reviews: [] };
+        const h = harness(html, local, remote), key = 'notebooks/pages/nbpage_p';
+        const fresh = page(remote.syncedAt, 'NEW CONTENT');
+        if (mode === 'offline-edit') {
+            h.idb.set('nbpage_p', fresh);
+            h.cloud.set(key, page(local.syncedAt, 'OLD CLOUD'));
+        }
+        if (mode === 'create-race') {
+            const put = h.context.r2PutObject;
+            h.context.r2PutObject = async (...args) => { h.cloud.set(key, fresh); return put(...args); };
+        }
+        if (mode === 'download-failure') h.context.r2GetObject = async () => { throw new Error('network unavailable'); };
+        if (mode === 'corrupt-local') h.idb.set('nbpage_p', '{broken');
+        if (mode === 'download-failure' || mode === 'corrupt-local') {
+            await assert.rejects(h.context.r2SyncNotebookPageBundle('p'));
+            assert.equal(h.cloud.has(key), false, mode + ' must not create blank content');
+        } else {
+            await h.context.r2SyncNotebookPageBundle('p');
+            const result = JSON.parse(h.cloud.get(key));
+            assert.equal(result.texts.length, mode === 'new-blank' ? 0 : 1, mode);
+            if (mode !== 'new-blank') assert.equal(result.texts[0].text, 'NEW CONTENT', mode);
+            if (mode === 'create-race') assert.equal(h.idb.has('nbpage_p'), false,
+                'a failed blank create must not leave a blank local cache hiding the winning page');
+        }
+    }
+}
+async function checkCacheRecovery(html) {
+    const local = data();
+    local.exercises.folders[0].tasks = [{ id: 'task', questions: [{ index: 0, status: 'done', userDrawingPages: 2 }] }];
+    local.exercises.wrongByFolder.folder = [{ taskId: 'wrong', questions: [{ questionIndex: 0,
+        userDrawingPages: 2, redoDrawings: [{ drawingId: 'r1', pages: 2 }] }] }];
+    local.exercises.archivedWrong.folder = [{ taskId: 'arch', questionIndex: 0,
+        userDrawingPages: 2, redoDrawings: [{ pages: 2 }] }];
+    const groups = [['exercise_drawing_task_0'], ['exercise_drawing_wrong_0'],
+        ['exercise_redo_drawing_wrong_0_id_r1', 'exercise_redo_drawing_wrong_0_0'],
+        ['exercise_drawing_arch_0'], ['exercise_redo_drawing_arch_0_0']];
+    const h = harness(html, local, local);
+    for (const bases of groups) for (let p = 0; p < 2; p++) {
+        const suffix = p ? '_p1' : '';
+        for (const base of bases) h.idb.set(base + suffix, 'OLD');
+        h.cloud.set('exercises/drawings/' + bases[0] + suffix, 'NEW ' + bases[0] + suffix);
+    }
+    await h.context.exSyncCachedGradedPages();
+    assert.deepEqual(h.errors, []);
+    assert.equal(h.calls.some(call => call.startsWith('PUT ')), false);
+    for (const bases of groups) for (let p = 0; p < 2; p++) {
+        const suffix = p ? '_p1' : '';
+        for (const base of bases) assert.equal(h.idb.get(base + suffix), 'NEW ' + bases[0] + suffix);
+    }
+    for (const mode of ['missing-cloud', 'create-race', 'late-edit', 'completed-grading', 'new-import', 'network-failure']) {
+        const fixture = data();
+        fixture.exercises.folders[0].tasks = [{ id: 'task', questions: [{ index: 0, status: 'done', userDrawingPages: 1 }] }];
+        const e = harness(html, fixture, fixture), key = 'exercise_drawing_task_0', cloudKey = 'exercises/drawings/' + key;
+        e.idb.set(key, 'LOCAL');
+        if (!['missing-cloud', 'create-race'].includes(mode)) e.cloud.set(cloudKey, 'CLOUD');
+        const get = e.context.r2GetObject, put = e.context.r2PutObject;
+        e.context.r2GetObject = async (...args) => {
+            if (mode === 'network-failure') throw new Error('network unavailable');
+            const result = await get(...args);
+            if (mode === 'late-edit') e.idb.set(key, 'NEW LOCAL EDIT');
+            if (mode === 'completed-grading') {
+                e.context._exGradedCloudCommitCounter++;
+                e.idb.set(key, 'NEW GRADE');
+                e.cloud.set(cloudKey, 'NEW GRADE');
+            }
+            if (mode === 'new-import') {
+                e.context.appData.exercises = clone(fixture.exercises);
+                e.idb.set(key, 'NEW IMPORT');
+            }
+            return result;
+        };
+        if (mode === 'create-race') e.context.r2PutObject = async (...args) => {
+            e.cloud.set(cloudKey, 'OTHER DEVICE');
+            return put(...args);
+        };
+        await e.context.exSyncCachedGradedPages();
+        const expected = { 'missing-cloud': 'LOCAL', 'create-race': 'OTHER DEVICE',
+            'late-edit': 'NEW LOCAL EDIT', 'completed-grading': 'NEW GRADE',
+            'new-import': 'NEW IMPORT', 'network-failure': 'LOCAL' };
+        assert.equal(e.idb.get(key), expected[mode], mode);
+        assert.equal(e.cloud.get(cloudKey), ['late-edit', 'new-import', 'network-failure'].includes(mode) ? 'CLOUD' : expected[mode], mode);
+        if (mode === 'network-failure') assert.equal(e.errors.length, 1);
+        else assert.deepEqual(e.errors, []);
+    }
+    const aliasFixture = data();
+    aliasFixture.exercises.wrongByFolder.folder = [{ taskId: 'task', questions: [{ questionIndex: 0,
+        redoDrawings: [{ drawingId: 'r1', pages: 1 }] }] }];
+    const a = harness(html, aliasFixture, aliasFixture);
+    const stable = 'exercise_redo_drawing_task_0_id_r1', legacy = 'exercise_redo_drawing_task_0_0';
+    a.idb.set(stable, 'BACKUP'); a.idb.set(legacy, 'BACKUP');
+    const put = a.context.r2PutObject;
+    a.context.r2PutObject = async (...args) => {
+        a.cloud.set('exercises/drawings/' + stable, 'CANONICAL');
+        a.cloud.set('exercises/drawings/' + legacy, 'STALE ALIAS');
+        return put(...args);
+    };
+    await a.context.exSyncCachedGradedPages();
+    assert.deepEqual(a.errors, []);
+    assert.equal(a.idb.get(stable), 'CANONICAL', 'a legacy alias conflict cannot undo the stable-key winner');
+    assert.equal(a.idb.get(legacy), 'CANONICAL');
 }
 (async () => {
     for (const file of ['app/src/main/assets/www/index.html', 'docs/index.html']) {
@@ -183,6 +324,8 @@ async function checkOldGrading(html) {
         await checkImport(html);
         await checkStartup(html);
         await checkOldGrading(html);
-        console.log(file + ': old ZIP import, explicit upload, startup restore and old grading passed');
+        await checkNotebookUploads(html);
+        await checkCacheRecovery(html);
+        console.log(file + ': import/startup/periodic recovery, offline edits, conditional creates and concurrent writes passed');
     }
 })().catch(error => { console.error(error); process.exitCode = 1; });

--- a/tests/cloud-sync-restore.test.js
+++ b/tests/cloud-sync-restore.test.js
@@ -1,0 +1,188 @@
+// Run with: node tests/cloud-sync-restore.test.js
+// Product functions run unchanged; ZIP decoding, DOM, IndexedDB and R2 stay in memory.
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const clone = value => JSON.parse(JSON.stringify(value));
+const noop = () => {};
+const asyncNoop = async () => {};
+function source(html, start) {
+    const lineEnd = html.indexOf('\n', start);
+    const end = html.slice(start, lineEnd).trimEnd().endsWith('}')
+        ? lineEnd : html.indexOf('\n        }', lineEnd) + 10;
+    return html.slice(start, end);
+}
+function data(newer = false) {
+    return {
+        books: [], papers: [], archived: [], notes: { note: newer ? 'new cloud note' : 'old backup note' },
+        drafts: { draft: { html: newer ? 'new cloud draft' : 'old backup draft' } },
+        settings: { r2Config: { accessKeyId: 'memory-only', autoSyncEnabled: true } },
+        lectures: {}, lectureDrafts: {}, classroom: { courses: [], seminars: [] },
+        classroomTombstones: [], classroomSyncOutbox: [], notebooks: { items: [], reviews: [] },
+        exercises: { folders: [{ id: 'folder', name: 'Folder', tasks: [] },
+            ...(newer ? [{ id: 'cloud-only-folder', name: 'New cloud folder', tasks: [] }] : [])],
+            wrongByFolder: {}, archivedWrong: {} },
+        syncedAt: newer ? '2026-09-10T00:00:00.000Z' : '2026-09-01T00:00:00.000Z'
+    };
+}
+function harness(html, local, remote) {
+    const cloud = new Map([['metadata.json', JSON.stringify(remote)]]), idb = new Map(), storage = new Map();
+    const calls = [], errors = [], toasts = [], timers = new Map();
+    let nextTimer = 0;
+    const element = { style: {}, classList: { remove: noop, add: noop, contains: () => false },
+        innerHTML: '', textContent: '', querySelectorAll: () => [] };
+    const context = vm.createContext({ appData: clone(local), appDataLoaded: true, window: {},
+        document: { body: element, createElement: () => ({ ...element }), getElementById: () => element,
+            querySelectorAll: () => [] },
+        console: { log: noop, warn: (...a) => errors.push(a.map(String).join(' ')),
+            error: (...a) => errors.push(a.map(String).join(' ')) },
+        localStorage: { getItem: k => storage.get(k) ?? null, setItem: (k, v) => storage.set(k, v) },
+        setTimeout: (fn, delay) => { const id = ++nextTimer; timers.set(id, { fn, delay }); return id; },
+        clearTimeout: id => timers.delete(id),
+        currentExerciseFolder: null, currentExerciseTask: null, exDoingState: null,
+        _chatSyncTimer: null, activeLectureGenerationCount: 0, r2SyncInProgress: false,
+        r2PendingSyncQueue: [], r2DeferredMetadataPublish: false, r2ClassroomRetryTimers: new Map(),
+        r2LastSyncTime: null, _resolveR2StartupMetadataReady: null, _cloudMetaBackupDay: null,
+        _exercisesDataSavePromise: Promise.resolve(true), _exGradedPagesSavePromise: Promise.resolve(),
+        _exGradedCloudCommitCounter: 0, _exPendingGradedCloudCommits: new Map(),
+        _exPositionSyncGeneration: 0, _exPendingPositionChoices: {}, _exPositionSyncTimer: null,
+        _exPositionSyncTarget: null,
+    });
+    // Load declarations only: no app initialization, listeners, real fetch or credentials.
+    for (const match of html.matchAll(/^        (?:async )?function [\w$]+\(/gm)) {
+        vm.runInContext(source(html, match.index), context);
+    }
+    for (const name of ['API_LOCAL_ONLY_KEYS', 'CLASSROOM_DELETE_ACTIONS']) {
+        const declaration = html.match(new RegExp('        const ' + name + ' = \\[[\\s\\S]*?\\];'));
+        assert.ok(declaration, name + ' exists');
+        vm.runInContext(declaration[0], context);
+    }
+    Object.assign(context, {
+        confirm: () => true, i18n: key => key, showToast: key => toasts.push(key),
+        dataZipRead: async () => ({ 'metadata.json': JSON.stringify(local) }), dataZipText: async value => value,
+        saveFileData: async (key, value) => idb.set(key, value), getFileData: async key => idb.get(key) ?? null,
+        deleteFileData: async key => idb.delete(key), saveBlobsToIDB: asyncNoop,
+        backupAppDataToIDB: noop, restoreBlobsFromIDB: asyncNoop,
+        applySettings: noop, renderLibrary: noop, renderNotesPage: noop, renderClassroomPage: noop,
+        renderNotebooksPage: noop, refreshAllUIFromAppData: noop,
+        cleanupClassroomEntriesRemovedByMerge: asyncNoop,
+        r2GetObject: async (key, options) => {
+            calls.push('GET ' + key);
+            const value = cloud.get(key);
+            return options?.withMetadata ? { data: value, etag: 'memory-etag', missing: !value } : value;
+        },
+        r2PutObject: async (key, value) => { calls.push('PUT ' + key); cloud.set(key, value); }
+    });
+    async function drainTimers() {
+        for (const [id, timer] of [...timers]) { timers.delete(id); timer.fn(); }
+        // Debounced callbacks start async work without returning its promise.
+        for (let i = 0; i < 100; i++) await Promise.resolve();
+        assert.equal(context.r2SyncInProgress, false, 'scheduled sync finished');
+    }
+    return { context, cloud, idb, calls, errors, toasts, drainTimers };
+}
+async function checkImport(html) {
+    const local = data(), remote = data(true);
+    remote.notes.cloudOnly = 'new cloud-only note';
+    local.exercises.wrongByFolder.folder = [{ taskId: 'task', taskName: 'Task', questions: [
+        { questionIndex: 0, score: 1 }, { questionIndex: 0, score: 2 }
+    ] }];
+    const h = harness(html, local, remote);
+    await h.context.importDataZip({ target: { value: 'old.zip', files: [{}] } });
+    await h.drainTimers();
+    assert.ok(h.toasts.includes('import_complete_files'), 'ZIP import completed');
+    assert.deepEqual(h.errors, []);
+    assert.deepEqual(h.calls, [], 'importing an old backup must not read or overwrite cloud metadata');
+    assert.deepEqual(JSON.parse(h.cloud.get('metadata.json')), remote, 'all newer cloud modules survive import');
+    assert.equal(h.context.appData.notes.note, 'old backup note', 'import actually restored the old local data');
+    const wrong = h.context.appData.exercises.wrongByFolder.folder[0].questions;
+    assert.equal(wrong.length, 1, 'import still deduplicates old wrong questions locally');
+    assert.equal(wrong[0].score, 2, 'deduplication keeps the latest wrong answer');
+    // The restore fix must preserve normal user-initiated metadata publication.
+    h.context.appData.notes.note = 'intentional local edit';
+    await h.context.triggerSyncOnFileChange(null, 'metadata_update');
+    assert.deepEqual(h.errors, []);
+    assert.equal(h.calls.filter(call => call === 'PUT metadata.json').length, 1);
+    assert.equal(JSON.parse(h.cloud.get('metadata.json')).notes.note, 'intentional local edit');
+}
+async function checkStartup(html) {
+    const local = data(), remote = data(true);
+    const notebook = at => ({ items: [{ id: 'nb', updatedAt: at, pages: [{ id: 'p1', updatedAt: at }] }], reviews: [] });
+    local.notebooks = notebook(local.syncedAt);
+    remote.notebooks = notebook(remote.syncedAt);
+    remote.notebooks.items[0].pages.push({ id: 'p2', updatedAt: remote.syncedAt });
+    local.exercises.wrongByFolder.folder = [{ taskId: 'old-task', questions: [{ questionIndex: 0, score: 1 }] }];
+    const h = harness(html, local, remote);
+    const page = (updatedAt, text) => JSON.stringify({ updatedAt, strokes: [], texts: [{ text }], media: [] });
+    h.idb.set('nbpage_p1', page(local.syncedAt, 'OLD BACKUP PAGE'));
+    h.idb.set('exercise_drawing_old-task_0', 'old local exercise image');
+    h.cloud.set('notebooks/pages/nbpage_p1', page(remote.syncedAt, 'NEW CLOUD PAGE'));
+    h.cloud.set('notebooks/pages/nbpage_p2', page(remote.syncedAt, 'CLOUD ONLY PAGE'));
+    const before = new Map(h.cloud);
+    await h.context.autoSyncFromR2OnStartup();
+    await h.drainTimers();
+    assert.deepEqual(h.errors, []);
+    assert.deepEqual(h.calls.filter(call => call.startsWith('PUT notebooks/')), [],
+        'exercise metadata repair must not upload old or missing notebook pages');
+    assert.ok(h.calls.includes('PUT metadata.json'), 'merged exercise metadata still uploads');
+    const metadata = JSON.parse(h.cloud.get('metadata.json'));
+    assert.equal(metadata.notes.note, remote.notes.note);
+    assert.equal(metadata.drafts.draft.html, remote.drafts.draft.html);
+    assert.ok(metadata.exercises.folders.some(folder => folder.id === 'cloud-only-folder'));
+    assert.equal(metadata.exercises.wrongByFolder.folder[0].taskId, 'old-task');
+    for (const id of ['p1', 'p2']) {
+        assert.equal(h.cloud.get('notebooks/pages/nbpage_' + id), before.get('notebooks/pages/nbpage_' + id),
+            'newer cloud page remains unchanged: ' + id);
+        assert.ok(h.calls.includes('GET notebooks/pages/nbpage_' + id), 'downloads ' + id);
+        assert.equal(h.idb.get('nbpage_' + id), h.cloud.get('notebooks/pages/nbpage_' + id));
+    }
+    assert.equal(h.context.appData.notes.note, remote.notes.note);
+    assert.equal(h.context.appData.drafts.draft.html, remote.drafts.draft.html);
+    assert.ok(h.context.appData.exercises.folders.some(folder => folder.id === 'cloud-only-folder'));
+}
+async function checkOldGrading(html) {
+    for (const imported of [true, false]) {
+        const local = data(), remote = data(true);
+        const task = (score, id, committed) => ({ id: 'task', questions: [{ index: 0, status: 'done', score,
+            gradedDrawingCommitId: id, gradedDrawingCloudCommitted: committed, userDrawingPages: 1 }] });
+        local.exercises.folders[0].tasks = [task(10, 'local-pending', false)];
+        remote.exercises.folders[0].tasks = [task(99, 'cloud-committed', true)];
+        const h = harness(html, local, remote);
+        const key = 'exercise_drawing_task_0';
+        h.idb.set(key, 'LOCAL PENDING IMAGE');
+        h.cloud.set('exercises/drawings/' + key, 'CLOUD COMMITTED IMAGE');
+        if (imported) {
+            await h.context.importDataZip({ target: { value: 'old.zip', files: [{}] } });
+            await h.drainTimers();
+            assert.ok(h.toasts.includes('import_complete_files'));
+            assert.equal(h.context.appData.exercises.folders[0].tasks[0].questions[0].gradedDrawingCloudCommitted,
+                undefined, 'backup import discards old pending upload intent');
+            const persisted = JSON.parse(h.idb.get('__exercises_data__'));
+            assert.equal(persisted.folders[0].tasks[0].questions[0].gradedDrawingCloudCommitted, undefined,
+                'immediate refresh cannot reload old pending intent from IndexedDB');
+            assert.deepEqual(h.calls, [], 'import does not publish the old pending drawing');
+        }
+        await h.context.autoSyncFromR2OnStartup();
+        await h.drainTimers();
+        assert.deepEqual(h.errors, []);
+        const metadata = JSON.parse(h.cloud.get('metadata.json'));
+        const question = metadata.exercises.folders[0].tasks[0].questions[0];
+        assert.equal(question.score, imported ? 99 : 10,
+            'cloud score wins after import; genuine pending offline grading still recovers');
+        assert.equal(question.gradedDrawingCommitId, imported ? 'cloud-committed' : 'local-pending');
+        assert.equal(question.gradedDrawingCloudCommitted, true);
+        assert.equal(h.cloud.get('exercises/drawings/' + key),
+            imported ? 'CLOUD COMMITTED IMAGE' : 'LOCAL PENDING IMAGE');
+        assert.equal(h.calls.includes('PUT exercises/drawings/' + key), !imported);
+    }
+}
+(async () => {
+    for (const file of ['app/src/main/assets/www/index.html', 'docs/index.html']) {
+        const html = fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+        await checkImport(html);
+        await checkStartup(html);
+        await checkOldGrading(html);
+        console.log(file + ': old ZIP import, explicit upload, startup restore and old grading passed');
+    }
+})().catch(error => { console.error(error); process.exitCode = 1; });

--- a/tests/cloud-sync-restore.test.js
+++ b/tests/cloud-sync-restore.test.js
@@ -478,6 +478,48 @@ async function checkImportedOfflineGrading(html) {
         }
     }
 }
+async function checkClassroomWithoutExerciseImages(html) {
+    for (const mode of ['existing', 'missing', 'conflict']) for (const committed of ['imported', false]) {
+        const local = data(), remote = data(true);
+        local.exercises.folders[0].tasks = [{ id: 'offline', questions: [{ index: 0, status: 'done',
+            score: 10, gradedDrawingCloudCommitted: committed }] }];
+        local.classroom.courses = [{ id: 'new-course', name: 'Classroom edit', sessions: [] }];
+        local.notebooks.items = [{ id: 'offline-notebook', createdAt: local.syncedAt,
+            pages: [{ id: 'offline-page', createdAt: local.syncedAt }] }];
+        local.lectures = { book: { createdAt: local.syncedAt, chapters: [] } };
+        const h = harness(html, local, remote);
+        if (mode === 'missing') h.cloud.delete('metadata.json');
+        const before = clone(h.context.appData);
+        const put = h.context.r2PutObject;
+        let conflict = mode === 'conflict';
+        h.context.setTimeout = fn => { queueMicrotask(fn); return 1; };
+        h.context.r2PutObject = async (key, ...args) => {
+            if (key === 'metadata.json' && conflict) {
+                conflict = false;
+                remote.exercises.folders.push({ id: 'concurrent-cloud-folder', tasks: [] });
+                h.cloud.set(key, JSON.stringify(remote));
+                throw Object.assign(new Error('metadata conflict'), { status: 412 });
+            }
+            return put(key, ...args);
+        };
+        await h.context.r2SyncMetadataOnly({ classroomOnly: true });
+        await h.drainTimers();
+        assert.deepEqual(h.errors, []);
+        const published = JSON.parse(h.cloud.get('metadata.json'));
+        assert.equal(published.classroom.courses[0].id, 'new-course');
+        assert.deepEqual(published.exercises, mode === 'missing' ? undefined : remote.exercises,
+            'classroom-only publication never includes unchecked local exercises, including initial cloud creation');
+        assert.equal(h.calls.some(call => call.includes('exercises/drawings/')), false,
+            'classroom-only publication neither waits for nor accesses unrelated drawings');
+        assert.deepEqual(clone(h.context.appData.exercises), before.exercises);
+        assert.deepEqual(clone(h.context.appData.notebooks), before.notebooks, 'classroom first upload preserves offline notebooks');
+        assert.deepEqual(clone(h.context.appData.lectures), before.lectures);
+        const cloudBeforeFullPublish = h.cloud.get('metadata.json');
+        await assert.rejects(h.context.r2SyncMetadataOnly(), /drawing is missing/,
+            'a full publication still requires every local grading image');
+        assert.equal(h.cloud.get('metadata.json'), cloudBeforeFullPublish);
+    }
+}
 async function checkCacheRecovery(html) {
     const local = data();
     local.exercises.folders[0].tasks = [{ id: 'task', questions: [{ index: 0, status: 'done', userDrawingPages: 2 }] }];
@@ -565,6 +607,7 @@ async function checkCacheRecovery(html) {
         await checkPdfBackgroundRetry(html);
         await checkOldGrading(html);
         await checkImportedOfflineGrading(html);
+        await checkClassroomWithoutExerciseImages(html);
         await checkNotebookUploads(html);
         await checkCacheRecovery(html);
         console.log(file + ': import/startup/periodic recovery, legacy data, concurrent edits and PDF retry passed');

--- a/tests/cloud-sync-restore.test.js
+++ b/tests/cloud-sync-restore.test.js
@@ -262,12 +262,15 @@ async function checkNotebookDownloadRace(html) {
 async function checkLegacyEmbeddedGrading(html) {
     for (const stable of [true, false]) {
         const local = data(), remote = data(true);
-        const question = taskId => ({ taskId, questionIndex: 0, score: 10,
-            userDrawing: 'ANSWER 0', userDrawingExtra: ['ANSWER 1'],
+        const question = taskId => ({ taskId, questionIndex: 0, score: 10, userDrawingPages: 2,
+            userDrawing: 'REDO 0', userDrawingExtra: ['REDO 1'],
             redoDrawings: [{ ...(stable ? { drawingId: 'r1' } : {}), drawing: 'REDO 0', extra: ['REDO 1'] }] });
         local.exercises.wrongByFolder.folder = [{ taskId: 'wrong', questions: [question('wrong')] }];
         local.exercises.archivedWrong.folder = [question('archived')];
         const h = harness(html, local, remote);
+        for (const task of ['wrong', 'archived']) for (let p = 0; p < 2; p++) {
+            h.idb.set('exercise_drawing_' + task + '_0' + (p ? '_p1' : ''), 'ANSWER ' + p);
+        }
         await h.context.importDataZip({ target: { value: 'legacy.zip', files: [{}] } });
         await h.drainTimers();
         assert.deepEqual(h.errors, []);
@@ -478,6 +481,205 @@ async function checkImportedOfflineGrading(html) {
         }
     }
 }
+async function checkImportedGradeOnNotebookEdit(html) {
+    for (const kind of ['normal', 'wrong', 'archived', 'redo']) for (const race of [false, true]) {
+        const local = data(), remote = data(true);
+        local.notebooks = remote.notebooks = { items: [{ id: 'nb', createdAt: local.syncedAt,
+            pages: [{ id: 'np', createdAt: local.syncedAt }] }], reviews: [] };
+        const install = (fixture, score, committed) => {
+            const q = { index: 0, questionIndex: 0, status: 'done', score, userDrawingPages: 1,
+                gradedDrawingCloudCommitted: committed, gradedDrawingCommitId: 'grade-' + score };
+            if (!committed) q.userDrawing = 'BACKUP IMAGE';
+            if (kind === 'normal') fixture.exercises.folders[0].tasks = [{ id: 'task', questions: [q] }];
+            if (kind === 'wrong' || kind === 'redo') fixture.exercises.wrongByFolder.folder = [{ taskId: 'task', questions: [q] }];
+            if (kind === 'archived') fixture.exercises.archivedWrong.folder = [{ ...q, taskId: 'task', archivedAt: local.syncedAt }];
+            if (kind === 'redo') q.redoDrawings = [{ drawingId: 'r1', pages: 1, score,
+                gradedDrawingCloudCommitted: committed, gradedDrawingCommitId: 'redo-' + score,
+                ...(!committed ? { drawing: 'BACKUP IMAGE' } : {}) }];
+        };
+        const question = exercises => kind === 'normal' ? exercises.folders[0].tasks[0].questions[0]
+            : kind === 'archived' ? exercises.archivedWrong.folder[0]
+            : exercises.wrongByFolder.folder[0].questions[0];
+        install(local, 2, false); install(remote, 9, true);
+        const h = harness(html, local, remote), base = 'exercise_drawing_task_0';
+        h.idb.set(base, 'BACKUP IMAGE');
+        h.cloud.set('exercises/drawings/' + base, 'CLOUD 9');
+        if (kind === 'redo') h.cloud.set('exercises/drawings/exercise_redo_drawing_task_0_id_r1', 'CLOUD 9');
+        await h.context.importDataZip({ target: { value: 'old.zip', files: [{}] } });
+        await h.drainTimers();
+        assert.deepEqual(h.calls, []);
+        const put = h.context.r2PutObject;
+        let conflict = race;
+        h.context.setTimeout = fn => { queueMicrotask(fn); return 1; };
+        h.context.r2PutObject = async (key, value, ...args) => {
+            if (key === 'metadata.json') {
+                if (conflict) {
+                    conflict = false;
+                    install(remote, 8, true);
+                    h.cloud.set(key, JSON.stringify(remote));
+                    h.cloud.set('exercises/drawings/' + base, 'CLOUD 8');
+                    if (kind === 'redo') h.cloud.set('exercises/drawings/exercise_redo_drawing_task_0_id_r1', 'CLOUD 8');
+                    throw Object.assign(new Error('another device graded during publication'), { status: 412 });
+                }
+                const q = question(JSON.parse(value).exercises);
+                assert.equal(q.score, race ? 8 : 9, 'first successful publication must use the cloud grading snapshot');
+                if (kind === 'redo') assert.equal(q.redoDrawings[0].score, race ? 8 : 9);
+            }
+            return put(key, value, ...args);
+        };
+        let pending;
+        Object.assign(h.context, { _nbSaveTimer: null, nbSnippetCache: {}, nbThumbCache: {},
+            nbState: { notebookId: 'nb', pageIndex: 0, dirty: true,
+                content: { strokes: [], texts: [{ text: 'NEW NOTE' }], media: [] } },
+            nbSyncNotebookEvent: (action, id) => { pending = h.context.triggerSyncOnFileChange(id, action); } });
+        await h.context.nbSavePageNow();
+        await pending;
+        await h.drainTimers();
+        assert.deepEqual(h.errors, []);
+        assert.equal(question(h.context.appData.exercises).score, race ? 8 : 9);
+        assert.equal(question(h.context.appData.exercises).userDrawing, undefined, 'stale inline display cache is cleared');
+        const imageKey = kind === 'redo' ? 'exercise_redo_drawing_task_0_id_r1' : base;
+        assert.equal(h.idb.get(imageKey), race ? 'CLOUD 8' : 'CLOUD 9');
+        assert.equal(h.calls.some(call => call === 'PUT exercises/drawings/' + imageKey), false);
+        await h.context.performAutoSync();
+        await h.drainTimers();
+        assert.deepEqual(h.errors, []);
+        assert.equal(question(JSON.parse(h.cloud.get('metadata.json')).exercises).score, race ? 8 : 9);
+        assert.equal(h.cloud.get('exercises/drawings/' + imageKey), race ? 'CLOUD 8' : 'CLOUD 9');
+    }
+}
+async function checkImportedPublicationConflicts(html) {
+    for (const mode of ['orphan-image', 'image-create-race', 'new-local-grading']) {
+        const local = data(), remote = data(true);
+        local.exercises.folders[0].tasks = [{ id: 'offline', questions: [{ index: 0, status: 'done',
+            score: 2, userDrawingPages: 1, gradedDrawingCloudCommitted: 'imported' }] }];
+        const h = harness(html, local, remote), key = 'exercises/drawings/exercise_drawing_offline_0';
+        h.idb.set('exercise_drawing_offline_0', 'BACKUP IMAGE');
+        if (mode === 'orphan-image') h.cloud.set(key, 'DIFFERENT CLOUD IMAGE');
+        const get = h.context.r2GetObject, put = h.context.r2PutObject;
+        let changed = false;
+        h.context.r2GetObject = async (...args) => {
+            const value = await get(...args);
+            if (mode === 'new-local-grading' && args[0] === key && !changed) {
+                changed = true;
+                h.context._exGradedCloudCommitCounter++;
+                Object.assign(h.context.appData.exercises.folders[0].tasks[0].questions[0], {
+                    score: 8, gradedDrawingCloudCommitted: false, gradedDrawingCommitId: 'new-grade' });
+                h.idb.set('exercise_drawing_offline_0', 'NEW LOCAL IMAGE');
+            }
+            return value;
+        };
+        h.context.r2PutObject = async (...args) => {
+            if (mode === 'image-create-race' && args[0] === key) h.cloud.set(key, 'DIFFERENT CLOUD IMAGE');
+            return put(...args);
+        };
+        await assert.rejects(h.context.r2SyncMetadataOnly());
+        assert.equal(h.calls.includes('PUT metadata.json'), false, mode + ': no mismatched grading is published');
+        assert.deepEqual(JSON.parse(h.cloud.get('metadata.json')), remote);
+        if (mode === 'new-local-grading') {
+            await h.context.r2SyncMetadataOnly();
+            assert.equal(JSON.parse(h.cloud.get('metadata.json')).exercises.folders[0].tasks[0].questions[0].score, 8);
+            assert.equal(h.cloud.get(key), 'NEW LOCAL IMAGE');
+        } else assert.equal(h.cloud.get(key), 'DIFFERENT CLOUD IMAGE');
+    }
+}
+async function checkRedoPageCountIsolation(html) {
+    const local = data();
+    // State produced by completing a two-page redo while the one-page original is still pending.
+    local.exercises.wrongByFolder.folder = [{ taskId: 'task', questions: [{ questionIndex: 0,
+        score: 9, userDrawingPages: 1, pageCount: 2, gradedDrawingCloudCommitted: false,
+        userDrawing: 'REDO 0', userDrawingExtra: ['REDO 1'], redoDrawings: [{ drawingId: 'r1',
+            pages: 2, drawing: 'REDO 0', extra: ['REDO 1'], gradedDrawingCloudCommitted: false }] }] }];
+    const h = harness(html, local, data());
+    h.idb.set('exercise_drawing_task_0', 'ORIGINAL');
+    h.idb.set('exercise_redo_drawing_task_0_id_r1', 'REDO 0');
+    h.idb.set('exercise_redo_drawing_task_0_id_r1_p1', 'REDO 1');
+    await h.context.r2SyncMetadataOnly();
+    await h.drainTimers();
+    assert.deepEqual(h.errors, []);
+    assert.equal(h.cloud.get('exercises/drawings/exercise_drawing_task_0'), 'ORIGINAL');
+    assert.equal(h.cloud.has('exercises/drawings/exercise_drawing_task_0_p1'), false);
+    for (const base of ['exercise_redo_drawing_task_0_id_r1', 'exercise_redo_drawing_task_0_0']) {
+        for (let p = 0; p < 2; p++) assert.equal(h.cloud.get('exercises/drawings/' + base + (p ? '_p1' : '')), 'REDO ' + p);
+    }
+    await h.context.r2SyncMetadataOnly();
+    assert.deepEqual(h.errors, []);
+}
+async function checkMissingDrawingStillRestores(html) {
+    for (const sync of ['autoSyncFromR2OnStartup', 'performAutoSync']) {
+        const local = data(), remote = data(true);
+        local.exercises.folders[0].tasks = [{ id: 'offline', questions: [{ index: 0, status: 'done',
+            score: 2, userDrawingPages: 1, gradedDrawingCloudCommitted: false }] }];
+        remote.books = [{ id: 'cloud-pdf', addedAt: remote.syncedAt }];
+        local.notebooks = remote.notebooks = { items: [{ id: 'nb', updatedAt: remote.syncedAt,
+            pages: [{ id: 'p', updatedAt: remote.syncedAt }] }], reviews: [] };
+        const h = harness(html, local, remote);
+        await h.context.importDataZip({ target: { value: 'missing.zip', files: [{}] } });
+        await h.drainTimers();
+        const page = JSON.stringify({ updatedAt: remote.syncedAt, texts: [{ text: 'CLOUD PAGE' }] });
+        h.cloud.set('files/cloud-pdf.pdf', 'CLOUD PDF');
+        h.cloud.set('notebooks/pages/nbpage_p', page);
+        const run = h.context[sync]();
+        if (sync === 'performAutoSync') await assert.rejects(run, /drawing is missing/);
+        else await run;
+        await h.drainTimers();
+        assert.equal(h.calls.includes('PUT metadata.json'), false, 'incomplete scores still cannot publish');
+        assert.deepEqual(JSON.parse(h.cloud.get('metadata.json')), remote);
+        assert.equal(h.idb.get('nbpage_p'), page, sync + ': missing grading image does not block notebook download');
+        if (sync === 'autoSyncFromR2OnStartup') assert.equal(h.idb.get('cloud-pdf'), 'CLOUD PDF');
+        assert.equal(h.errors.length, 1, h.errors.join('\n'));
+        // After the missing image is recovered, a normal retry can complete without restarting.
+        h.idb.set('exercise_drawing_offline_0', 'RECOVERED ANSWER');
+        h.errors.length = 0;
+        await h.context.performAutoSync();
+        await h.drainTimers();
+        assert.deepEqual(h.errors, []);
+        assert.ok(h.calls.includes('PUT metadata.json'));
+    }
+}
+async function checkClassroomFirstThenNotebookSync(html) {
+    for (const sync of ['syncToR2', 'performAutoSync', 'autoSyncFromR2OnStartup']) {
+        for (const restart of [false, true]) {
+            const local = data();
+            local.classroom.courses = [{ id: 'course', createdAt: local.syncedAt, sessions: [] }];
+            local.notebooks = { items: [{ id: 'offline-notebook', createdAt: local.syncedAt,
+                pages: ['p1', 'p2'].map(id => ({ id, createdAt: local.syncedAt })) }],
+                reviews: [{ id: 'offline-review', notebookId: 'offline-notebook', createdAt: local.syncedAt }] };
+            let h = harness(html, local, local);
+            h.cloud.delete('metadata.json');
+            const bodies = new Map(['p1', 'p2'].map(id => ['nbpage_' + id,
+                JSON.stringify({ updatedAt: local.syncedAt, strokes: [{ points: [1, 2] }],
+                    texts: [{ text: 'OFFLINE ' + id }], media: [] })]));
+            for (const [key, value] of bodies) h.idb.set(key, value);
+            await h.context.r2SyncMetadataOnly({ classroomOnly: true });
+            await h.drainTimers();
+            if (restart) {
+                const persisted = JSON.parse(h.context.localStorage.getItem('mathReader'));
+                persisted.exercises = JSON.parse(h.idb.get('__exercises_data__'));
+                const reopened = harness(html, persisted, JSON.parse(h.cloud.get('metadata.json')));
+                for (const [key, value] of h.idb) reopened.idb.set(key, value);
+                for (const [key, value] of h.cloud) reopened.cloud.set(key, value);
+                h = reopened;
+            }
+            await h.context[sync]();
+            await h.drainTimers();
+            const label = sync + (restart ? ' after restart' : ' without restart');
+            assert.deepEqual(clone(h.context.appData.notebooks), local.notebooks, label + ': local directory survives');
+            assert.deepEqual(JSON.parse(h.cloud.get('metadata.json')).notebooks, local.notebooks,
+                label + ': cloud directory survives');
+            // Startup may only restore metadata; the next ordinary sync must publish the bodies too.
+            await h.context.performAutoSync();
+            await h.drainTimers();
+            assert.deepEqual(clone(h.context.appData.notebooks), local.notebooks, label + ': next sync stays intact');
+            assert.deepEqual(JSON.parse(h.cloud.get('metadata.json')).notebooks, local.notebooks);
+            for (const [key, value] of bodies) {
+                assert.equal(h.idb.get(key), value, label + ': local page body survives');
+                assert.equal(h.cloud.get('notebooks/pages/' + key), value, label + ': page body uploads');
+            }
+            assert.deepEqual(h.errors, []);
+        }
+    }
+}
 async function checkClassroomWithoutExerciseImages(html) {
     for (const mode of ['existing', 'missing', 'conflict']) for (const committed of ['imported', false]) {
         const local = data(), remote = data(true);
@@ -518,6 +720,15 @@ async function checkClassroomWithoutExerciseImages(html) {
         await assert.rejects(h.context.r2SyncMetadataOnly(), /drawing is missing/,
             'a full publication still requires every local grading image');
         assert.equal(h.cloud.get('metadata.json'), cloudBeforeFullPublish);
+        if (mode === 'missing') {
+            h.idb.set('exercise_drawing_offline_0', 'RECOVERED ANSWER');
+            await h.context.r2SyncMetadataOnly();
+            await h.context.autoSyncFromR2OnStartup();
+            await h.drainTimers();
+            assert.deepEqual(clone(h.context.appData.notebooks), before.notebooks,
+                'repairing the missing image and continuing sync must retain the offline notebook');
+            assert.deepEqual(JSON.parse(h.cloud.get('metadata.json')).notebooks, before.notebooks);
+        }
     }
 }
 async function checkCacheRecovery(html) {
@@ -608,6 +819,11 @@ async function checkCacheRecovery(html) {
         await checkOldGrading(html);
         await checkImportedOfflineGrading(html);
         await checkClassroomWithoutExerciseImages(html);
+        await checkClassroomFirstThenNotebookSync(html);
+        await checkRedoPageCountIsolation(html);
+        await checkImportedGradeOnNotebookEdit(html);
+        await checkImportedPublicationConflicts(html);
+        await checkMissingDrawingStillRestores(html);
         await checkNotebookUploads(html);
         await checkCacheRecovery(html);
         console.log(file + ': import/startup/periodic recovery, legacy data, concurrent edits and PDF retry passed');

--- a/tests/cloud-sync-restore.test.js
+++ b/tests/cloud-sync-restore.test.js
@@ -112,6 +112,7 @@ async function checkImport(html) {
         { questionIndex: 0, score: 1 }, { questionIndex: 0, score: 2 }
     ] }];
     const h = harness(html, local, remote);
+    h.idb.set('exercise_drawing_task_0', 'IMPORTED WRONG ANSWER');
     await h.context.importDataZip({ target: { value: 'old.zip', files: [{}] } });
     await h.drainTimers();
     assert.ok(h.toasts.includes('import_complete_files'), 'ZIP import completed');
@@ -185,10 +186,10 @@ async function checkOldGrading(html) {
             await h.drainTimers();
             assert.ok(h.toasts.includes('import_complete_files'));
             assert.equal(h.context.appData.exercises.folders[0].tasks[0].questions[0].gradedDrawingCloudCommitted,
-                undefined, 'backup import discards old pending upload intent');
+                'imported', 'backup intent remains distinct from a new local grading commit');
             const persisted = JSON.parse(h.idb.get('__exercises_data__'));
-            assert.equal(persisted.folders[0].tasks[0].questions[0].gradedDrawingCloudCommitted, undefined,
-                'immediate refresh cannot reload old pending intent from IndexedDB');
+            assert.equal(persisted.folders[0].tasks[0].questions[0].gradedDrawingCloudCommitted, 'imported',
+                'the import origin survives an immediate restart');
             assert.deepEqual(h.calls, [], 'import does not publish the old pending drawing');
         }
         await h.context.autoSyncFromR2OnStartup();
@@ -240,6 +241,50 @@ async function checkNotebookUploads(html) {
             if (mode !== 'new-blank') assert.equal(result.texts[0].text, 'NEW CONTENT', mode);
             if (mode === 'create-race') assert.equal(h.idb.has('nbpage_p'), false,
                 'a failed blank create must not leave a blank local cache hiding the winning page');
+        }
+    }
+}
+async function checkImportedOfflineGrading(html) {
+    for (const mode of ['complete', 'upload-fails', 'missing-image']) {
+        const local = data(), remote = data(true);
+        local.exercises.folders[0].tasks = [{ id: 'offline', questions: [{ index: 0, status: 'done',
+            score: 10, userDrawingPages: 2, gradedDrawingCloudCommitted: false }] }];
+        local.exercises.wrongByFolder.folder = [{ taskId: 'offline', questions: [{ questionIndex: 0,
+            score: 10, userDrawingPages: 2, gradedDrawingCloudCommitted: false,
+            redoDrawings: [{ drawingId: 'redo1', pages: 2, gradedDrawingCloudCommitted: false }] }] }];
+        const h = harness(html, local, remote);
+        const keys = ['exercise_drawing_offline_0', 'exercise_drawing_offline_0_p1',
+            'exercise_redo_drawing_offline_0_id_redo1', 'exercise_redo_drawing_offline_0_id_redo1_p1',
+            'exercise_redo_drawing_offline_0_0', 'exercise_redo_drawing_offline_0_0_p1'];
+        for (const key of keys) if (mode !== 'missing-image' || !key.endsWith('_p1')) h.idb.set(key, 'ANSWER ' + key);
+        await h.context.importDataZip({ target: { value: 'offline.zip', files: [{}] } });
+        await h.drainTimers();
+        assert.deepEqual(h.calls, [], 'offline import itself does not connect to cloud');
+        const put = h.context.r2PutObject;
+        let completeAtPublication = false;
+        h.context.r2PutObject = async (key, ...args) => {
+            if (mode === 'upload-fails' && key.endsWith('_p1')) throw new Error('upload failed');
+            if (key === 'metadata.json') {
+                completeAtPublication = keys.every(k => h.cloud.has('exercises/drawings/' + k));
+                assert.ok(completeAtPublication, 'all pages and aliases must exist before the first metadata PUT');
+            }
+            return put(key, ...args);
+        };
+        await h.context.autoSyncFromR2OnStartup();
+        await h.drainTimers();
+        if (mode === 'complete') {
+            assert.deepEqual(h.errors, []);
+            assert.equal(completeAtPublication, true);
+            const published = JSON.parse(h.cloud.get('metadata.json'));
+            assert.equal(published.exercises.folders[0].tasks[0].questions[0].score, 10);
+            assert.equal(published.exercises.folders[0].tasks[0].questions[0].gradedDrawingCloudCommitted, true);
+        } else {
+            assert.equal(h.calls.includes('PUT metadata.json'), false, 'incomplete imported answers must not publish');
+            assert.deepEqual(JSON.parse(h.cloud.get('metadata.json')), remote);
+            assert.equal(h.errors.length, 1);
+            const stored = JSON.parse(h.idb.get('__exercises_data__'));
+            assert.equal(stored.folders[0].tasks[0].questions[0].gradedDrawingCloudCommitted, 'imported',
+                'failed restoration remains resumable after restarting');
         }
     }
 }
@@ -324,6 +369,7 @@ async function checkCacheRecovery(html) {
         await checkImport(html);
         await checkStartup(html);
         await checkOldGrading(html);
+        await checkImportedOfflineGrading(html);
         await checkNotebookUploads(html);
         await checkCacheRecovery(html);
         console.log(file + ': import/startup/periodic recovery, offline edits, conditional creates and concurrent writes passed');

--- a/tests/cloud-sync-restore.test.js
+++ b/tests/cloud-sync-restore.test.js
@@ -170,6 +170,196 @@ async function checkStartup(html) {
     assert.equal(h.context.appData.drafts.draft.html, remote.drafts.draft.html);
     assert.ok(h.context.appData.exercises.folders.some(folder => folder.id === 'cloud-only-folder'));
 }
+async function checkEmptyShelf(html) {
+    for (const shelf of ['books', 'papers']) {
+        const local = data(), remote = data(true);
+        local[shelf] = [{ id: 'backup-pdf', addedAt: local.syncedAt }];
+        remote.notes.cloudOnly = 'CLOUD ONLY NOTE';
+        local.notebooks = remote.notebooks = { items: [{ id: 'nb', updatedAt: remote.syncedAt,
+            pages: [{ id: 'p', updatedAt: remote.syncedAt }] }], reviews: [] };
+        const h = harness(html, local, remote);
+        h.idb.set('backup-pdf', 'LOCAL PDF');
+        h.idb.set('nbpage_p', JSON.stringify({ updatedAt: local.syncedAt, texts: [{ text: 'BACKUP PAGE' }] }));
+        const newPage = JSON.stringify({ updatedAt: remote.syncedAt, texts: [{ text: 'CLOUD PAGE' }] });
+        h.cloud.set('notebooks/pages/nbpage_p', newPage);
+        await h.context.importDataZip({ target: { value: 'old.zip', files: [{}] } });
+        await h.drainTimers();
+        assert.deepEqual(h.calls, []);
+        const put = h.context.r2PutObject;
+        let publications = 0;
+        h.context.r2PutObject = async (key, value, ...args) => {
+            if (key === 'metadata.json') {
+                const published = JSON.parse(value);
+                assert.deepEqual(published.notes, remote.notes, 'first shelf repair must keep newer cloud notes');
+                assert.deepEqual(published.drafts, remote.drafts);
+                assert.deepEqual(published.exercises, remote.exercises);
+                assert.equal(published[shelf][0].id, 'backup-pdf');
+                publications++;
+            }
+            return put(key, value, ...args);
+        };
+        await h.context.autoSyncFromR2OnStartup();
+        await h.drainTimers();
+        assert.equal(publications, 1, 'startup repairs the shelf after all cloud modules merge');
+        assert.equal(h.idb.get('backup-pdf'), 'LOCAL PDF');
+        assert.equal(h.calls.some(call => call.startsWith('PUT notebooks/')), false);
+        assert.equal(h.idb.get('nbpage_p'), newPage);
+        await h.context.performAutoSync();
+        await h.drainTimers();
+        assert.equal(publications, 2);
+        assert.equal(h.errors.filter(error => !error.includes('云端书籍索引为空')).length, 0,
+            h.errors.join('\n'));
+    }
+    const local = data(), remote = data(true);
+    local.books = [{ id: 'deleted', addedAt: local.syncedAt }];
+    remote.books = [{ id: 'kept', addedAt: remote.syncedAt }];
+    const h = harness(html, local, remote);
+    h.idb.set('deleted', 'OLD PDF');
+    await h.context.autoSyncFromR2OnStartup();
+    assert.equal(h.idb.has('deleted'), false, 'nonempty cloud shelf still applies deletions');
+    assert.equal(h.context.appData.books[0].id, 'kept');
+    assert.deepEqual(h.errors, []);
+}
+async function checkNotebookDownloadRace(html) {
+    for (const mode of ['periodic', 'manual-pull', 'idb-write', 'reimport']) {
+        const local = data(), remote = data(true);
+        local.notebooks = remote.notebooks = { items: [{ id: 'nb', updatedAt: remote.syncedAt,
+            pages: [{ id: 'p', updatedAt: remote.syncedAt }] }], reviews: [] };
+        const h = harness(html, local, remote), key = 'notebooks/pages/nbpage_p';
+        h.idb.set('nbpage_p', JSON.stringify({ updatedAt: local.syncedAt, texts: [{ text: 'BACKUP' }] }));
+        h.cloud.set(key, JSON.stringify({ updatedAt: remote.syncedAt, texts: [{ text: 'CLOUD' }] }));
+        Object.assign(h.context, { _nbSaveTimer: null, nbSnippetCache: {}, nbThumbCache: {},
+            nbState: { notebookId: 'nb', pageIndex: 0, dirty: true,
+                content: { strokes: [], texts: [{ text: 'JUST SAVED' }], media: [] } } });
+        const get = h.context.r2GetObject;
+        let downloaded = false;
+        h.context.r2GetObject = async (...args) => {
+            const result = await get(...args);
+            if (args[0] === key && !downloaded) {
+                downloaded = true;
+                if (mode === 'reimport' || mode === 'idb-write') {
+                    if (mode === 'reimport') h.context.appData.notebooks = clone(h.context.appData.notebooks);
+                    h.idb.set('nbpage_p', JSON.stringify({ texts: [{ text: 'NEW IMPORT' }] }));
+                } else {
+                    await h.context.nbSavePageNow();
+                    assert.equal(JSON.parse(h.idb.get('nbpage_p')).texts[0].text, 'JUST SAVED');
+                }
+            }
+            return result;
+        };
+        if (mode === 'periodic') await h.context.performAutoSync();
+        else await h.context.r2PullNotebookAssetsFromCloud({ missingOnly: false });
+        await h.drainTimers();
+        assert.equal(downloaded, true);
+        assert.deepEqual(h.errors, []);
+        assert.equal(JSON.parse(h.idb.get('nbpage_p')).texts[0].text,
+            ['reimport', 'idb-write'].includes(mode) ? 'NEW IMPORT' : 'JUST SAVED', 'slow download cannot overwrite a newer local save');
+        if (mode === 'periodic' || mode === 'manual-pull') {
+            assert.equal(JSON.parse(h.cloud.get(key)).texts[0].text, 'JUST SAVED', 'queued edit still uploads');
+        }
+    }
+}
+async function checkLegacyEmbeddedGrading(html) {
+    for (const stable of [true, false]) {
+        const local = data(), remote = data(true);
+        const question = taskId => ({ taskId, questionIndex: 0, score: 10,
+            userDrawing: 'ANSWER 0', userDrawingExtra: ['ANSWER 1'],
+            redoDrawings: [{ ...(stable ? { drawingId: 'r1' } : {}), drawing: 'REDO 0', extra: ['REDO 1'] }] });
+        local.exercises.wrongByFolder.folder = [{ taskId: 'wrong', questions: [question('wrong')] }];
+        local.exercises.archivedWrong.folder = [question('archived')];
+        const h = harness(html, local, remote);
+        await h.context.importDataZip({ target: { value: 'legacy.zip', files: [{}] } });
+        await h.drainTimers();
+        assert.deepEqual(h.errors, []);
+        assert.ok(h.toasts.includes('import_complete_files'));
+        assert.deepEqual(h.calls, [], 'legacy migration is entirely local');
+        const expected = new Map();
+        for (const task of ['wrong', 'archived']) for (let p = 0; p < 2; p++) {
+            const suffix = p ? '_p1' : '';
+            expected.set('exercise_drawing_' + task + '_0' + suffix, 'ANSWER ' + p);
+            expected.set('exercise_redo_drawing_' + task + '_0_0' + suffix, 'REDO ' + p);
+            if (stable) expected.set('exercise_redo_drawing_' + task + '_0_id_r1' + suffix, 'REDO ' + p);
+        }
+        for (const [key, value] of expected) assert.equal(h.idb.get(key), value, 'durable legacy page: ' + key);
+        // Simulate reopening from stripped metadata and the durable image store.
+        h.context.appData.exercises = JSON.parse(h.idb.get('__exercises_data__'));
+        assert.equal(h.context.appData.exercises.wrongByFolder.folder[0].questions[0].redoDrawings[0].drawing, undefined);
+        const put = h.context.r2PutObject;
+        h.context.r2PutObject = async (key, ...args) => {
+            if (key === 'metadata.json') for (const [k, value] of expected) {
+                assert.equal(h.cloud.get('exercises/drawings/' + k), value, 'legacy images precede metadata');
+            }
+            return put(key, ...args);
+        };
+        await h.context.autoSyncFromR2OnStartup();
+        await h.drainTimers();
+        await h.context.performAutoSync();
+        await h.drainTimers();
+        assert.deepEqual(h.errors, []);
+        assert.ok(h.calls.includes('PUT metadata.json'));
+    }
+}
+async function checkLegacyNotebook(html) {
+    for (const mode of ['missing', 'existing', 'create-race', 'get-fails']) {
+        const local = data(), remote = data(true);
+        local.notebooks = { items: [{ id: 'nb', pages: [{ id: 'p', createdAt: local.syncedAt }] }], reviews: [] };
+        const h = harness(html, local, remote), key = 'notebooks/pages/nbpage_p';
+        h.idb.set('nbpage_p', JSON.stringify({ strokes: [{ points: [1, 2] }], texts: [], media: [] }));
+        const cloudPage = JSON.stringify({ updatedAt: remote.syncedAt, texts: [{ text: 'NEW CLOUD' }] });
+        if (mode === 'existing') h.cloud.set(key, cloudPage);
+        if (mode === 'create-race') {
+            const put = h.context.r2PutObject;
+            h.context.r2PutObject = async (...args) => {
+                if (args[0] === key) h.cloud.set(key, cloudPage);
+                return put(...args);
+            };
+        }
+        if (mode === 'get-fails') {
+            const get = h.context.r2GetObject;
+            h.context.r2GetObject = async (...args) => {
+                if (args[0] === key) throw new Error('download unavailable');
+                return get(...args);
+            };
+        }
+        await h.context.syncToR2();
+        await h.drainTimers();
+        if (mode === 'get-fails') {
+            assert.equal(h.calls.includes('PUT metadata.json'), false);
+            assert.equal(h.cloud.has(key), false);
+            assert.equal(h.errors.length, 1);
+        } else {
+            assert.deepEqual(h.errors, []);
+            assert.ok(h.calls.includes('PUT metadata.json'));
+            if (mode === 'missing') {
+                assert.deepEqual(JSON.parse(h.cloud.get(key)).strokes, [{ points: [1, 2] }]);
+                assert.equal(JSON.parse(h.cloud.get(key)).updatedAt, local.syncedAt);
+            } else assert.equal(h.cloud.get(key), cloudPage, 'undated backup must not overwrite an existing cloud body');
+        }
+    }
+}
+async function checkPdfBackgroundRetry(html) {
+    const local = data(), remote = data(true);
+    local.notebooks = { items: [{ id: 'nb', pages: [{ id: 'p', createdAt: local.syncedAt, bgImage: 'bg' }] }], reviews: [] };
+    const h = harness(html, local, remote), key = 'notebooks/pages/nbpage_p', mediaKey = 'notebooks/media/nbmedia_bg';
+    h.idb.set('nbmedia_bg', 'PDF BACKGROUND');
+    const put = h.context.r2PutObject;
+    let fail = true;
+    h.context.r2PutObject = async (k, ...args) => {
+        if (k === mediaKey && fail) { fail = false; throw new Error('background upload failed'); }
+        if (k === 'metadata.json') assert.equal(h.cloud.get(mediaKey), 'PDF BACKGROUND', 'retry sends background before metadata');
+        return put(k, ...args);
+    };
+    await h.context.syncToR2();
+    assert.ok(h.cloud.has(key));
+    assert.equal(h.calls.includes('PUT metadata.json'), false);
+    assert.equal(h.errors.length, 1);
+    h.errors.length = 0;
+    await h.context.syncToR2();
+    await h.drainTimers();
+    assert.deepEqual(h.errors, []);
+    assert.equal(h.cloud.get(mediaKey), 'PDF BACKGROUND');
+    assert.ok(h.calls.includes('PUT metadata.json'));
+}
 async function checkOldGrading(html) {
     for (const imported of [true, false]) {
         const local = data(), remote = data(true);
@@ -368,10 +558,15 @@ async function checkCacheRecovery(html) {
         const html = fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
         await checkImport(html);
         await checkStartup(html);
+        await checkEmptyShelf(html);
+        await checkNotebookDownloadRace(html);
+        await checkLegacyEmbeddedGrading(html);
+        await checkLegacyNotebook(html);
+        await checkPdfBackgroundRetry(html);
         await checkOldGrading(html);
         await checkImportedOfflineGrading(html);
         await checkNotebookUploads(html);
         await checkCacheRecovery(html);
-        console.log(file + ': import/startup/periodic recovery, offline edits, conditional creates and concurrent writes passed');
+        console.log(file + ': import/startup/periodic recovery, legacy data, concurrent edits and PDF retry passed');
     }
 })().catch(error => { console.error(error); process.exitCode = 1; });


### PR DESCRIPTION
导入旧 ZIP 后，页面渲染和启动恢复曾把旧本地内容上传到云端；即使首次刷新成功，下一轮定时同步仍会把旧习题图片覆盖回云端。本 PR 修复这些入口，并保留正常离线评分和笔记编辑的上传。

- 移除重复错题渲染时整包上传的副作用；去重仍保存到本地。
- 云端书架为空时只保留本地书籍和论文，继续合并云端笔记、草稿、课堂及习题，最后才修复索引；书架修复不触发全部笔记正文上传。
- 习题元数据补齐不再连带上传全部笔记。所有笔记正文上传共用检查：正文落后于已合并目录时跳过上传；本地缺页先检查云端，真正的新空白页使用条件创建。条件冲突不重发空白，也不留下遮住云端正文的空白本地缓存。
- 移除定时同步中绕过共用检查、直接上传笔记正文的重复路径。
- 启动和定时同步共用习题图片恢复流程，覆盖普通作答、错题、归档、重做及多页图片。已有云端对象用于恢复缓存；缺失对象只允许条件创建。真正的新评分仍通过原有待上传记录提交。
- 导入时把评分标记为独立的导入来源，并等待元数据持久化完成。它不会压过云端已有评分；备份独有的离线作答在首次发布评分索引前，必须先补齐全部图片和重做 alias。图片缺失或上传失败时停止包含本地习题的完整索引发布，保留可重试状态。
- 课堂专用发布不读取或等待本地习题图片，已有云索引时沿用本轮 CAS 读到的云端习题；首次建索引保留本地已有的其他模块目录，只排除未经图片校验的习题，避免后续全量同步或重启把离线笔记本误判为已删除。
- 导入评分在最终发布前与当前云端同一条记录核对，普通作答、错题、归档及重做一起恢复对应评分字段和图片缓存。每次 CAS 冲突都从原始导入快照重新核对，不把一次尝试的已验证标记带入下一次。期间有新本地评分或导入时停止旧快照发布。
- 缺图或图像冲突仍阻止不完整评分索引发布，但启动恢复继续下载云端 PDF、笔记页等资源；定时同步在完成后续下载后报告发布失败，不虚报同步成功。尚未验证的导入图片不走被动缓存补传。
- 缓存回写在同一个 IndexedDB 事务中检查原值，并检查期间是否发生新评分或导入；旧下载不能覆盖新写入。重做图片始终优先采用稳定 key，旧下标 alias 的冲突不能反向替换它。
- 笔记下载复用事务内原值校验，并检查页面与目录是否已变化；定时恢复和手动下载返回的旧正文不能覆盖刚保存的笔记，排队的新编辑仍正常上传。
- 导入旧版内嵌作答和重做图片时，先将全部页面与 alias 写入 IndexedDB 并补齐页数，再保存剔除图片的元数据；重启后仍能完成图片上传和索引发布。页数推断仅用于旧包导入；错题的最新重做显示缓存不用于推断原答页数，也不覆盖原答图片。
- 无更新时间戳的旧版笔记先检查云端，云端缺页时条件创建，已有云端正文时保留；上传失败或条件冲突不能覆盖较新正文。
- PDF 空白页已有云端正文时仍补传背景和引用媒体，首次背景上传失败后的手动重试必须补图后才能发布目录。

验证：

- 使用实际页面函数和内存存储，连续验证“导入旧包 → 刷新 → 下一轮定时同步”。
- 覆盖阅读位置比云端新但正文比云端旧、云端独有笔记页、正常离线笔记编辑、正常离线评分、新空白页、条件创建冲突、下载失败、损坏正文，以及恢复期间的新编辑、新评分和新导入。
- 覆盖作答／错题／归档／重做的多页图片，以及稳定 key 与旧 alias 的创建冲突。
- 在第一次 metadata PUT 时检查备份独有作答的所有图片已存在；缺图或上传失败时确认云端索引保持原样，导入来源标记仍持久化保留。
- 新增空书架保留本地 PDF 并接收全部云端模块、慢下载期间真实笔记保存和排队上传、下载期间重新导入、旧版两页内嵌图片重启恢复、无时间戳正文及云端创建冲突、PDF 背景上传失败后手动重试的原函数回归。
- 验证本地导入缺图和正常待提交评分缺图均不阻塞课堂专用发布，覆盖已有云索引、首次创建和 ETag 冲突重试；同时确认全量评分发布仍拒绝缺图，云端习题与本地离线笔记保持原样。
- 连续验证“无云索引 → 课堂首传 → 手动全量／定时／启动同步 → 下一轮定时同步”，各覆盖不重启及从持久化数据新建运行环境两种情况，检查笔记本、复习目录和两页正文。此场景已与 PR 基线对比。
- 验证导入后不先启动恢复，直接保存笔记触发发布时，评分、作答和重做图片仍使用同一云端版本，覆盖普通／错题／归档／重做及 CAS 冲突；另覆盖孤立云图、图片条件创建冲突和验证期间的新本地评分。
- 验证一页待上传原答加两页重做仍能连续完整发布；缺图阻断评分发布时资源继续恢复，补齐图片后不重启即可完成重试。
- 本地通过 cloud-sync-restore、zip-import、notebook-input、native-selection、boox-pen 五项检查，PWA/APK HTML 一致性、内联脚本语法和 git diff --check。

未连接真实 R2 或修改用户设备数据；以上是自动化回归验证，不是真机或生产云验证。
