### PR TITLE
单独提交旧备份云同步修复，保留 PR89–95 功能

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -17,6 +17,7 @@ jobs:
 
       - name: Check handwriting input and shared page
         run: |
+          node tests/cloud-sync-restore.test.js
           node tests/zip-import.test.js
           node tests/notebook-input.test.js
           node tests/native-selection.test.js

--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -16720,6 +16720,8 @@
                     JSON.stringify(metadata.notebooks || { items: [], reviews: [] })) {
                     repairMetadataAfterStartup = true;
                 }
+                // 沿用 PR88 的讲义/笔记修复范围；习题元数据补传不上传笔记正文。
+                const repairNotebookPagesAfterStartup = repairMetadataAfterStartup;
                 if (metadata.exercises) {
                     const cloudEx = metadata.exercises;
                     const localEx = appData.exercises || { folders: [], wrongByFolder: {}, archivedWrong: {} };
@@ -16801,7 +16803,7 @@
                 if (repairMetadataAfterStartup) {
                     // 修复只补齐云端缺的那部分：正文按版本增量上传，不把本机旧正文回传。
                     await r2SyncChangedLectureContents();
-                    await r2SyncAllNotebookPages();
+                    if (repairNotebookPagesAfterStartup) await r2SyncAllNotebookPages();
                     await r2SyncMetadataOnly();
                 }
                 if (config.lastSyncTime || metadata.syncedAt) {
@@ -17993,8 +17995,15 @@
                     _callNativeRecording('deleteRecording', id);
                     await deleteFileData('classroom_' + id).catch(() => {});
                 }
+                // 备份中的待上传标记属于导出时的旧状态；导入后按 PR88 从云端恢复。
+                // 保留评分和图片，以及正常本机新评分的断点补传。
+                for (const entry of exCollectUncommittedGradedCloudEntries(appData.exercises)) {
+                    for (const record of entry.records) delete record.gradedDrawingCloudCommitted;
+                }
                 if (typeof saveExercisesToIDB === 'function') await saveExercisesToIDB();
-                saveData();
+                const metadataSaved = saveData();
+                const exercisesSaved = await exWaitForExercisesDataSaves();
+                if (!metadataSaved || !exercisesSaved) throw new Error(i18n('storage_save_failed'));
                 await restoreBlobsFromIDB();
                 applySettings();
                 renderLibrary();
@@ -26090,7 +26099,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             currentExerciseFolder = null;
             currentExerciseTask = null;
             // 旧版本同一题每次评分都会并列新增一条错题，这里按题号去重只留最近一条
-            if (exDedupeWrongQuestions()) { saveData(); debouncedChatSync(); }
+            if (exDedupeWrongQuestions()) saveData();
             document.body.classList.remove('exercise-folder-active');
             document.getElementById('exercisesGrid').style.display = '';
             document.getElementById('exerciseFolderView').style.display = 'none';

--- a/docs/index.html
+++ b/docs/index.html
@@ -16720,6 +16720,8 @@
                     JSON.stringify(metadata.notebooks || { items: [], reviews: [] })) {
                     repairMetadataAfterStartup = true;
                 }
+                // 沿用 PR88 的讲义/笔记修复范围；习题元数据补传不上传笔记正文。
+                const repairNotebookPagesAfterStartup = repairMetadataAfterStartup;
                 if (metadata.exercises) {
                     const cloudEx = metadata.exercises;
                     const localEx = appData.exercises || { folders: [], wrongByFolder: {}, archivedWrong: {} };
@@ -16801,7 +16803,7 @@
                 if (repairMetadataAfterStartup) {
                     // 修复只补齐云端缺的那部分：正文按版本增量上传，不把本机旧正文回传。
                     await r2SyncChangedLectureContents();
-                    await r2SyncAllNotebookPages();
+                    if (repairNotebookPagesAfterStartup) await r2SyncAllNotebookPages();
                     await r2SyncMetadataOnly();
                 }
                 if (config.lastSyncTime || metadata.syncedAt) {
@@ -17993,8 +17995,15 @@
                     _callNativeRecording('deleteRecording', id);
                     await deleteFileData('classroom_' + id).catch(() => {});
                 }
+                // 备份中的待上传标记属于导出时的旧状态；导入后按 PR88 从云端恢复。
+                // 保留评分和图片，以及正常本机新评分的断点补传。
+                for (const entry of exCollectUncommittedGradedCloudEntries(appData.exercises)) {
+                    for (const record of entry.records) delete record.gradedDrawingCloudCommitted;
+                }
                 if (typeof saveExercisesToIDB === 'function') await saveExercisesToIDB();
-                saveData();
+                const metadataSaved = saveData();
+                const exercisesSaved = await exWaitForExercisesDataSaves();
+                if (!metadataSaved || !exercisesSaved) throw new Error(i18n('storage_save_failed'));
                 await restoreBlobsFromIDB();
                 applySettings();
                 renderLibrary();
@@ -26090,7 +26099,7 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
             currentExerciseFolder = null;
             currentExerciseTask = null;
             // 旧版本同一题每次评分都会并列新增一条错题，这里按题号去重只留最近一条
-            if (exDedupeWrongQuestions()) { saveData(); debouncedChatSync(); }
+            if (exDedupeWrongQuestions()) saveData();
             document.body.classList.remove('exercise-folder-active');
             document.getElementById('exercisesGrid').style.display = '';
             document.getElementById('exerciseFolderView').style.display = 'none';

--- a/tests/cloud-sync-restore.test.js
+++ b/tests/cloud-sync-restore.test.js
@@ -1,0 +1,188 @@
+// Run with: node tests/cloud-sync-restore.test.js
+// Product functions run unchanged; ZIP decoding, DOM, IndexedDB and R2 stay in memory.
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const clone = value => JSON.parse(JSON.stringify(value));
+const noop = () => {};
+const asyncNoop = async () => {};
+function source(html, start) {
+    const lineEnd = html.indexOf('\n', start);
+    const end = html.slice(start, lineEnd).trimEnd().endsWith('}')
+        ? lineEnd : html.indexOf('\n        }', lineEnd) + 10;
+    return html.slice(start, end);
+}
+function data(newer = false) {
+    return {
+        books: [], papers: [], archived: [], notes: { note: newer ? 'new cloud note' : 'old backup note' },
+        drafts: { draft: { html: newer ? 'new cloud draft' : 'old backup draft' } },
+        settings: { r2Config: { accessKeyId: 'memory-only', autoSyncEnabled: true } },
+        lectures: {}, lectureDrafts: {}, classroom: { courses: [], seminars: [] },
+        classroomTombstones: [], classroomSyncOutbox: [], notebooks: { items: [], reviews: [] },
+        exercises: { folders: [{ id: 'folder', name: 'Folder', tasks: [] },
+            ...(newer ? [{ id: 'cloud-only-folder', name: 'New cloud folder', tasks: [] }] : [])],
+            wrongByFolder: {}, archivedWrong: {} },
+        syncedAt: newer ? '2026-09-10T00:00:00.000Z' : '2026-09-01T00:00:00.000Z'
+    };
+}
+function harness(html, local, remote) {
+    const cloud = new Map([['metadata.json', JSON.stringify(remote)]]), idb = new Map(), storage = new Map();
+    const calls = [], errors = [], toasts = [], timers = new Map();
+    let nextTimer = 0;
+    const element = { style: {}, classList: { remove: noop, add: noop, contains: () => false },
+        innerHTML: '', textContent: '', querySelectorAll: () => [] };
+    const context = vm.createContext({ appData: clone(local), appDataLoaded: true, window: {},
+        document: { body: element, createElement: () => ({ ...element }), getElementById: () => element,
+            querySelectorAll: () => [] },
+        console: { log: noop, warn: (...a) => errors.push(a.map(String).join(' ')),
+            error: (...a) => errors.push(a.map(String).join(' ')) },
+        localStorage: { getItem: k => storage.get(k) ?? null, setItem: (k, v) => storage.set(k, v) },
+        setTimeout: (fn, delay) => { const id = ++nextTimer; timers.set(id, { fn, delay }); return id; },
+        clearTimeout: id => timers.delete(id),
+        currentExerciseFolder: null, currentExerciseTask: null, exDoingState: null,
+        _chatSyncTimer: null, activeLectureGenerationCount: 0, r2SyncInProgress: false,
+        r2PendingSyncQueue: [], r2DeferredMetadataPublish: false, r2ClassroomRetryTimers: new Map(),
+        r2LastSyncTime: null, _resolveR2StartupMetadataReady: null, _cloudMetaBackupDay: null,
+        _exercisesDataSavePromise: Promise.resolve(true), _exGradedPagesSavePromise: Promise.resolve(),
+        _exGradedCloudCommitCounter: 0, _exPendingGradedCloudCommits: new Map(),
+        _exPositionSyncGeneration: 0, _exPendingPositionChoices: {}, _exPositionSyncTimer: null,
+        _exPositionSyncTarget: null,
+    });
+    // Load declarations only: no app initialization, listeners, real fetch or credentials.
+    for (const match of html.matchAll(/^        (?:async )?function [\w$]+\(/gm)) {
+        vm.runInContext(source(html, match.index), context);
+    }
+    for (const name of ['API_LOCAL_ONLY_KEYS', 'CLASSROOM_DELETE_ACTIONS']) {
+        const declaration = html.match(new RegExp('        const ' + name + ' = \\[[\\s\\S]*?\\];'));
+        assert.ok(declaration, name + ' exists');
+        vm.runInContext(declaration[0], context);
+    }
+    Object.assign(context, {
+        confirm: () => true, i18n: key => key, showToast: key => toasts.push(key),
+        dataZipRead: async () => ({ 'metadata.json': JSON.stringify(local) }), dataZipText: async value => value,
+        saveFileData: async (key, value) => idb.set(key, value), getFileData: async key => idb.get(key) ?? null,
+        deleteFileData: async key => idb.delete(key), saveBlobsToIDB: asyncNoop,
+        backupAppDataToIDB: noop, restoreBlobsFromIDB: asyncNoop,
+        applySettings: noop, renderLibrary: noop, renderNotesPage: noop, renderClassroomPage: noop,
+        renderNotebooksPage: noop, refreshAllUIFromAppData: noop,
+        cleanupClassroomEntriesRemovedByMerge: asyncNoop,
+        r2GetObject: async (key, options) => {
+            calls.push('GET ' + key);
+            const value = cloud.get(key);
+            return options?.withMetadata ? { data: value, etag: 'memory-etag', missing: !value } : value;
+        },
+        r2PutObject: async (key, value) => { calls.push('PUT ' + key); cloud.set(key, value); }
+    });
+    async function drainTimers() {
+        for (const [id, timer] of [...timers]) { timers.delete(id); timer.fn(); }
+        // Debounced callbacks start async work without returning its promise.
+        for (let i = 0; i < 100; i++) await Promise.resolve();
+        assert.equal(context.r2SyncInProgress, false, 'scheduled sync finished');
+    }
+    return { context, cloud, idb, calls, errors, toasts, drainTimers };
+}
+async function checkImport(html) {
+    const local = data(), remote = data(true);
+    remote.notes.cloudOnly = 'new cloud-only note';
+    local.exercises.wrongByFolder.folder = [{ taskId: 'task', taskName: 'Task', questions: [
+        { questionIndex: 0, score: 1 }, { questionIndex: 0, score: 2 }
+    ] }];
+    const h = harness(html, local, remote);
+    await h.context.importDataZip({ target: { value: 'old.zip', files: [{}] } });
+    await h.drainTimers();
+    assert.ok(h.toasts.includes('import_complete_files'), 'ZIP import completed');
+    assert.deepEqual(h.errors, []);
+    assert.deepEqual(h.calls, [], 'importing an old backup must not read or overwrite cloud metadata');
+    assert.deepEqual(JSON.parse(h.cloud.get('metadata.json')), remote, 'all newer cloud modules survive import');
+    assert.equal(h.context.appData.notes.note, 'old backup note', 'import actually restored the old local data');
+    const wrong = h.context.appData.exercises.wrongByFolder.folder[0].questions;
+    assert.equal(wrong.length, 1, 'import still deduplicates old wrong questions locally');
+    assert.equal(wrong[0].score, 2, 'deduplication keeps the latest wrong answer');
+    // The restore fix must preserve normal user-initiated metadata publication.
+    h.context.appData.notes.note = 'intentional local edit';
+    await h.context.triggerSyncOnFileChange(null, 'metadata_update');
+    assert.deepEqual(h.errors, []);
+    assert.equal(h.calls.filter(call => call === 'PUT metadata.json').length, 1);
+    assert.equal(JSON.parse(h.cloud.get('metadata.json')).notes.note, 'intentional local edit');
+}
+async function checkStartup(html) {
+    const local = data(), remote = data(true);
+    const notebook = at => ({ items: [{ id: 'nb', updatedAt: at, pages: [{ id: 'p1', updatedAt: at }] }], reviews: [] });
+    local.notebooks = notebook(local.syncedAt);
+    remote.notebooks = notebook(remote.syncedAt);
+    remote.notebooks.items[0].pages.push({ id: 'p2', updatedAt: remote.syncedAt });
+    local.exercises.wrongByFolder.folder = [{ taskId: 'old-task', questions: [{ questionIndex: 0, score: 1 }] }];
+    const h = harness(html, local, remote);
+    const page = (updatedAt, text) => JSON.stringify({ updatedAt, strokes: [], texts: [{ text }], media: [] });
+    h.idb.set('nbpage_p1', page(local.syncedAt, 'OLD BACKUP PAGE'));
+    h.idb.set('exercise_drawing_old-task_0', 'old local exercise image');
+    h.cloud.set('notebooks/pages/nbpage_p1', page(remote.syncedAt, 'NEW CLOUD PAGE'));
+    h.cloud.set('notebooks/pages/nbpage_p2', page(remote.syncedAt, 'CLOUD ONLY PAGE'));
+    const before = new Map(h.cloud);
+    await h.context.autoSyncFromR2OnStartup();
+    await h.drainTimers();
+    assert.deepEqual(h.errors, []);
+    assert.deepEqual(h.calls.filter(call => call.startsWith('PUT notebooks/')), [],
+        'exercise metadata repair must not upload old or missing notebook pages');
+    assert.ok(h.calls.includes('PUT metadata.json'), 'merged exercise metadata still uploads');
+    const metadata = JSON.parse(h.cloud.get('metadata.json'));
+    assert.equal(metadata.notes.note, remote.notes.note);
+    assert.equal(metadata.drafts.draft.html, remote.drafts.draft.html);
+    assert.ok(metadata.exercises.folders.some(folder => folder.id === 'cloud-only-folder'));
+    assert.equal(metadata.exercises.wrongByFolder.folder[0].taskId, 'old-task');
+    for (const id of ['p1', 'p2']) {
+        assert.equal(h.cloud.get('notebooks/pages/nbpage_' + id), before.get('notebooks/pages/nbpage_' + id),
+            'newer cloud page remains unchanged: ' + id);
+        assert.ok(h.calls.includes('GET notebooks/pages/nbpage_' + id), 'downloads ' + id);
+        assert.equal(h.idb.get('nbpage_' + id), h.cloud.get('notebooks/pages/nbpage_' + id));
+    }
+    assert.equal(h.context.appData.notes.note, remote.notes.note);
+    assert.equal(h.context.appData.drafts.draft.html, remote.drafts.draft.html);
+    assert.ok(h.context.appData.exercises.folders.some(folder => folder.id === 'cloud-only-folder'));
+}
+async function checkOldGrading(html) {
+    for (const imported of [true, false]) {
+        const local = data(), remote = data(true);
+        const task = (score, id, committed) => ({ id: 'task', questions: [{ index: 0, status: 'done', score,
+            gradedDrawingCommitId: id, gradedDrawingCloudCommitted: committed, userDrawingPages: 1 }] });
+        local.exercises.folders[0].tasks = [task(10, 'local-pending', false)];
+        remote.exercises.folders[0].tasks = [task(99, 'cloud-committed', true)];
+        const h = harness(html, local, remote);
+        const key = 'exercise_drawing_task_0';
+        h.idb.set(key, 'LOCAL PENDING IMAGE');
+        h.cloud.set('exercises/drawings/' + key, 'CLOUD COMMITTED IMAGE');
+        if (imported) {
+            await h.context.importDataZip({ target: { value: 'old.zip', files: [{}] } });
+            await h.drainTimers();
+            assert.ok(h.toasts.includes('import_complete_files'));
+            assert.equal(h.context.appData.exercises.folders[0].tasks[0].questions[0].gradedDrawingCloudCommitted,
+                undefined, 'backup import discards old pending upload intent');
+            const persisted = JSON.parse(h.idb.get('__exercises_data__'));
+            assert.equal(persisted.folders[0].tasks[0].questions[0].gradedDrawingCloudCommitted, undefined,
+                'immediate refresh cannot reload old pending intent from IndexedDB');
+            assert.deepEqual(h.calls, [], 'import does not publish the old pending drawing');
+        }
+        await h.context.autoSyncFromR2OnStartup();
+        await h.drainTimers();
+        assert.deepEqual(h.errors, []);
+        const metadata = JSON.parse(h.cloud.get('metadata.json'));
+        const question = metadata.exercises.folders[0].tasks[0].questions[0];
+        assert.equal(question.score, imported ? 99 : 10,
+            'cloud score wins after import; genuine pending offline grading still recovers');
+        assert.equal(question.gradedDrawingCommitId, imported ? 'cloud-committed' : 'local-pending');
+        assert.equal(question.gradedDrawingCloudCommitted, true);
+        assert.equal(h.cloud.get('exercises/drawings/' + key),
+            imported ? 'CLOUD COMMITTED IMAGE' : 'LOCAL PENDING IMAGE');
+        assert.equal(h.calls.includes('PUT exercises/drawings/' + key), !imported);
+    }
+}
+(async () => {
+    for (const file of ['app/src/main/assets/www/index.html', 'docs/index.html']) {
+        const html = fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+        await checkImport(html);
+        await checkStartup(html);
+        await checkOldGrading(html);
+        console.log(file + ': old ZIP import, explicit upload, startup restore and old grading passed');
+    }
+})().catch(error => { console.error(error); process.exitCode = 1; });


### PR DESCRIPTION
仅包含原始提交 `297571d18f14390be947c4aa858c606ece8a37ed`，以当前 main 为基线独立提交这次修复。

导入含重复错题的旧 ZIP 备份后，PR89 新增的渲染去重会触发整包元数据上传，覆盖云端较新的笔记、草稿和习题索引。PR92 又让启动时的习题合并连带上传所有笔记正文，可能把新正文覆盖成旧正文，或把云端独有页写成空白。

以 #88 的导入与启动恢复行为为基准，修复 #89、#92 引入的覆盖路径，并保留 PR89–95 的功能：

- 错题去重继续保存本地，去掉渲染时自动上传整包元数据的副作用。
- 习题多页、重做历史、未提交评分的合并与元数据补传保持原有流程；笔记正文上传只由 PR88 原有的讲义/笔记修复条件触发。
- 导入旧备份时清除包内过期的评分待上传标记，保留评分、图片和稳定 ID；等待习题数据持久化成功后再完成导入。正常本机离线评分的恢复补传保留。
- Android 与 PWA 页面同步更新；回归测试加入 CI。

验证使用原页面函数与内存存储，不连接真实 R2：

- 导入重复错题仍完成本地去重，但不访问或覆盖云端；显式同步仍正常。
- 启动合并旧习题后仍补传元数据，同时保留并下载云端新笔记正文和云端独有页。
- 导入旧评分不覆盖云端新评分；普通本机未提交评分仍能恢复上传。
- 现有 ZIP 导入、笔记输入、原生选区、Boox 手写测试，以及 HTML 脚本语法和双端镜像检查。
