### PR TITLE
仅恢复 PR73 前的笔记云同步逻辑

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Check handwriting input and shared page
         run: |
           node tests/cloud-sync-restore.test.js
+          node tests/notebook-cloud-sync.test.js
           node tests/zip-import.test.js
           node tests/notebook-input.test.js
           node tests/native-selection.test.js

--- a/app/src/main/assets/www/index.html
+++ b/app/src/main/assets/www/index.html
@@ -14226,33 +14226,7 @@
                     }
                 }
 
-                // 同步笔记本页面和媒体（本地有云端没有 → 上传，本地没有云端有 → 拉取）
-                for (const nb of (appData.notebooks?.items || [])) {
-                    for (const page of (nb.pages || [])) {
-                        if (!page || !page.id) continue;
-                        let pgData = await getFileData('nbpage_' + page.id).catch(() => null);
-                        if (pgData) {
-                            try { await r2PutObject('notebooks/pages/nbpage_' + page.id, pgData, 'application/json'); } catch(e) {}
-                        } else {
-                            try {
-                                const cd = await r2GetObject('notebooks/pages/nbpage_' + page.id);
-                                if (cd) { pgData = cd; await saveFileData('nbpage_' + page.id, cd); }
-                            } catch(e) {}
-                        }
-                        const mediaIds = r2NotebookMediaIdsFromPage(page, pgData);
-                        for (const mid of mediaIds) {
-                            const localMedia = await getFileData('nbmedia_' + mid).catch(() => null);
-                            if (localMedia) {
-                                try { await r2PutObject('notebooks/media/nbmedia_' + mid, localMedia, 'application/octet-stream'); } catch(e) {}
-                            } else {
-                                try {
-                                    const cd = await r2GetObject('notebooks/media/nbmedia_' + mid);
-                                    if (cd) await saveFileData('nbmedia_' + mid, cd);
-                                } catch(e) {}
-                            }
-                        }
-                    }
-                }
+                // 笔记本页面与媒体已在 metadata 发布前由 r2SyncAllNotebookPages() 合并。
 
                 // 更新上次同步时间
                 config.lastSyncTime = new Date().toISOString();
@@ -14911,34 +14885,103 @@
             return e;
         }
 
+        function r2ParseNotebookPageContent(raw) {
+            if (!raw || typeof raw !== 'string') return null;
+            try {
+                const content = JSON.parse(raw);
+                if (!content || typeof content !== 'object' || Array.isArray(content)) return null;
+                if (!Array.isArray(content.strokes)) content.strokes = [];
+                if (!Array.isArray(content.texts)) content.texts = [];
+                if (!Array.isArray(content.media)) content.media = [];
+                if (!Object.prototype.hasOwnProperty.call(content, 'recognized')) content.recognized = null;
+                return content;
+            } catch (e) {
+                return null;
+            }
+        }
+
+        function r2NotebookPageContentScore(content) {
+            if (!content) return 0;
+            return (content.strokes || []).length + (content.texts || []).length +
+                (content.media || []).length + (content.recognized ? 1 : 0);
+        }
+
+        function r2ChooseNotebookPageSource(localContent, cloudContent) {
+            if (!localContent) return 'cloud';
+            if (!cloudContent) return 'local';
+            const localTs = syncTimestamp(localContent.updatedAt);
+            const cloudTs = syncTimestamp(cloudContent.updatedAt);
+            const localScore = r2NotebookPageContentScore(localContent);
+            const cloudScore = r2NotebookPageContentScore(cloudContent);
+
+            // PR58 可能用页面 metadata 的时间戳生成一个空正文。旧版真实笔迹没有
+            // content.updatedAt 时，不能让这个“较新空页”覆盖它。
+            if (localScore > 0 && cloudScore === 0 && localTs === 0) return 'local';
+            if (cloudScore > 0 && localScore === 0 && cloudTs === 0) return 'cloud';
+            if (localTs !== cloudTs) return localTs > cloudTs ? 'local' : 'cloud';
+            if (localScore !== cloudScore) return localScore > cloudScore ? 'local' : 'cloud';
+            return 'local';
+        }
+
         async function r2SyncNotebookPageBundle(pageId) {
             if (!pageId) return;
             const page = (appData.notebooks?.items || [])
                 .flatMap(nb => nb.pages || [])
                 .find(pg => pg && pg.id === pageId);
-            const mediaIds = new Set();
-            let pgData = await getFileData('nbpage_' + pageId).catch(() => null);
-            let pageContent = null;
-            try { pageContent = pgData ? JSON.parse(pgData) : null; } catch (e) {}
-            if (!pageContent && page) pageContent = { strokes: [], texts: [], media: [], recognized: null };
-            if (pageContent) {
-                if (!pageContent.updatedAt) {
-                    pageContent.updatedAt = page?.updatedAt || page?.createdAt || new Date().toISOString();
-                }
-                if (page && (!page.updatedAt || syncTimestamp(pageContent.updatedAt) >
-                    syncTimestamp(page.updatedAt || page.createdAt))) {
-                    page.updatedAt = pageContent.updatedAt;
-                    saveData();
-                }
-                pgData = JSON.stringify(pageContent);
-                await saveFileData('nbpage_' + pageId, pgData);
-                await r2PutObject('notebooks/pages/nbpage_' + pageId, pgData, 'application/json');
-                (pageContent.media || []).forEach(m => { if (m.mediaId) mediaIds.add(m.mediaId); });
+            const pageKey = 'nbpage_' + pageId;
+            const cloudKey = 'notebooks/pages/' + pageKey;
+            const localRaw = await getFileData(pageKey).catch(() => null);
+            let localContent = r2ParseNotebookPageContent(localRaw);
+            const cloudRaw = await r2GetObjectWithTimeout(cloudKey, 5000);
+            let cloudContent = r2ParseNotebookPageContent(cloudRaw);
+
+            if (localRaw && !localContent) {
+                console.warn('[nb-sync] 本地笔记页正文损坏:', pageId);
             }
+            if (cloudRaw && !cloudContent) {
+                if (!localContent || r2NotebookPageContentScore(localContent) === 0) {
+                    throw new Error('[nb-sync] 云端笔记页正文损坏: ' + pageId);
+                }
+                console.warn('[nb-sync] 使用有效的本地正文修复云端损坏页:', pageId);
+            }
+
+            if (!localContent && !cloudContent) {
+                if (!page) return;
+                localContent = { strokes: [], texts: [], media: [], recognized: null };
+            }
+
+            const source = r2ChooseNotebookPageSource(localContent, cloudContent);
+            const pageContent = source === 'cloud' ? cloudContent : localContent;
+            if (!pageContent) return;
+            if (!pageContent.updatedAt && source === 'local') {
+                pageContent.updatedAt = page?.updatedAt || page?.createdAt || new Date().toISOString();
+            }
+            const pageJson = JSON.stringify(pageContent);
+            await saveFileData(pageKey, pageJson);
+
+            const contentTs = syncTimestamp(pageContent.updatedAt);
+            if (page && contentTs > syncTimestamp(page.updatedAt || page.createdAt)) {
+                page.updatedAt = pageContent.updatedAt;
+                saveData();
+            }
+
+            const cloudJson = cloudContent ? JSON.stringify(cloudContent) : null;
+            if (source === 'local' && pageJson !== cloudJson) {
+                await r2PutObject(cloudKey, pageJson, 'application/json');
+            }
+
+            const mediaIds = new Set();
+            (pageContent.media || []).forEach(m => { if (m.mediaId) mediaIds.add(m.mediaId); });
             if (page && page.bgImage) mediaIds.add(page.bgImage);
             for (const mid of mediaIds) {
-                const mData = await getFileData('nbmedia_' + mid).catch(() => null);
-                if (mData) await r2PutObject('notebooks/media/nbmedia_' + mid, mData, 'application/octet-stream');
+                const mediaKey = 'nbmedia_' + mid;
+                const mData = await getFileData(mediaKey).catch(() => null);
+                if (mData) {
+                    await r2PutObject('notebooks/media/' + mediaKey, mData, 'application/octet-stream');
+                } else {
+                    const cloudMedia = await r2GetObjectWithTimeout('notebooks/media/' + mediaKey, 5000);
+                    if (cloudMedia) await saveFileData(mediaKey, cloudMedia);
+                }
             }
         }
 
@@ -14980,9 +15023,16 @@
                         try {
                             const cloudPage = await r2GetObject('notebooks/pages/nbpage_' + page.id);
                             if (cloudPage) {
-                                pageJson = cloudPage;
-                                await saveFileData('nbpage_' + page.id, cloudPage);
-                                pages++;
+                                const localContent = r2ParseNotebookPageContent(pageJson);
+                                const cloudContent = r2ParseNotebookPageContent(cloudPage);
+                                if (cloudContent &&
+                                    r2ChooseNotebookPageSource(localContent, cloudContent) === 'cloud') {
+                                    pageJson = JSON.stringify(cloudContent);
+                                    await saveFileData('nbpage_' + page.id, pageJson);
+                                    pages++;
+                                } else if (!cloudContent) {
+                                    console.warn('[startup-sync] 云端笔记页正文损坏，保留本地:', page.id);
+                                }
                             }
                         } catch (e) { console.warn('[startup-sync] 拉取笔记页失败:', page.id, e); }
                     }
@@ -15303,7 +15353,11 @@
                 const retryableClassroomAction = ['recording_upload', 'classroom_upload',
                     'classroom_note_upload', 'classroom_delete', 'classroom_note_delete',
                     'recording_delete', 'classroom_folder_delete',
-                    'lecture_upload', 'abstract_upload', 'exercise_grading_commit'].includes(action);
+                    'lecture_upload', 'abstract_upload',
+                    'notebook_close', 'notebook_page_add', 'notebook_page_update',
+                    'notebook_page_delete', 'notebook_page_reorder', 'notebook_metadata_update',
+                    'notebook_review_add', 'notebook_review_update',
+                    'exercise_grading_commit'].includes(action);
                 if (retryableClassroomAction &&
                     (config.autoSyncEnabled || config.autoSyncOnChange) && Number(attempt || 0) < 8) {
                     const key = action + ':' + fileId;
@@ -30945,8 +30999,15 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     try {
                         const cloud = await r2GetObject('notebooks/pages/nbpage_' + pageId);
                         if (cloud) {
-                            raw = cloud;
-                            await saveFileData('nbpage_' + pageId, cloud).catch(() => {});
+                            const localContent = r2ParseNotebookPageContent(raw);
+                            const cloudContent = r2ParseNotebookPageContent(cloud);
+                            if (cloudContent &&
+                                r2ChooseNotebookPageSource(localContent, cloudContent) === 'cloud') {
+                                raw = JSON.stringify(cloudContent);
+                                await saveFileData('nbpage_' + pageId, raw).catch(() => {});
+                            } else if (!cloudContent) {
+                                console.warn('[nb] 云端页面内容损坏，保留本地:', pageId);
+                            }
                         }
                     } catch (e) { /* 云端也没有 */ }
                 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -14226,33 +14226,7 @@
                     }
                 }
 
-                // 同步笔记本页面和媒体（本地有云端没有 → 上传，本地没有云端有 → 拉取）
-                for (const nb of (appData.notebooks?.items || [])) {
-                    for (const page of (nb.pages || [])) {
-                        if (!page || !page.id) continue;
-                        let pgData = await getFileData('nbpage_' + page.id).catch(() => null);
-                        if (pgData) {
-                            try { await r2PutObject('notebooks/pages/nbpage_' + page.id, pgData, 'application/json'); } catch(e) {}
-                        } else {
-                            try {
-                                const cd = await r2GetObject('notebooks/pages/nbpage_' + page.id);
-                                if (cd) { pgData = cd; await saveFileData('nbpage_' + page.id, cd); }
-                            } catch(e) {}
-                        }
-                        const mediaIds = r2NotebookMediaIdsFromPage(page, pgData);
-                        for (const mid of mediaIds) {
-                            const localMedia = await getFileData('nbmedia_' + mid).catch(() => null);
-                            if (localMedia) {
-                                try { await r2PutObject('notebooks/media/nbmedia_' + mid, localMedia, 'application/octet-stream'); } catch(e) {}
-                            } else {
-                                try {
-                                    const cd = await r2GetObject('notebooks/media/nbmedia_' + mid);
-                                    if (cd) await saveFileData('nbmedia_' + mid, cd);
-                                } catch(e) {}
-                            }
-                        }
-                    }
-                }
+                // 笔记本页面与媒体已在 metadata 发布前由 r2SyncAllNotebookPages() 合并。
 
                 // 更新上次同步时间
                 config.lastSyncTime = new Date().toISOString();
@@ -14911,34 +14885,103 @@
             return e;
         }
 
+        function r2ParseNotebookPageContent(raw) {
+            if (!raw || typeof raw !== 'string') return null;
+            try {
+                const content = JSON.parse(raw);
+                if (!content || typeof content !== 'object' || Array.isArray(content)) return null;
+                if (!Array.isArray(content.strokes)) content.strokes = [];
+                if (!Array.isArray(content.texts)) content.texts = [];
+                if (!Array.isArray(content.media)) content.media = [];
+                if (!Object.prototype.hasOwnProperty.call(content, 'recognized')) content.recognized = null;
+                return content;
+            } catch (e) {
+                return null;
+            }
+        }
+
+        function r2NotebookPageContentScore(content) {
+            if (!content) return 0;
+            return (content.strokes || []).length + (content.texts || []).length +
+                (content.media || []).length + (content.recognized ? 1 : 0);
+        }
+
+        function r2ChooseNotebookPageSource(localContent, cloudContent) {
+            if (!localContent) return 'cloud';
+            if (!cloudContent) return 'local';
+            const localTs = syncTimestamp(localContent.updatedAt);
+            const cloudTs = syncTimestamp(cloudContent.updatedAt);
+            const localScore = r2NotebookPageContentScore(localContent);
+            const cloudScore = r2NotebookPageContentScore(cloudContent);
+
+            // PR58 可能用页面 metadata 的时间戳生成一个空正文。旧版真实笔迹没有
+            // content.updatedAt 时，不能让这个“较新空页”覆盖它。
+            if (localScore > 0 && cloudScore === 0 && localTs === 0) return 'local';
+            if (cloudScore > 0 && localScore === 0 && cloudTs === 0) return 'cloud';
+            if (localTs !== cloudTs) return localTs > cloudTs ? 'local' : 'cloud';
+            if (localScore !== cloudScore) return localScore > cloudScore ? 'local' : 'cloud';
+            return 'local';
+        }
+
         async function r2SyncNotebookPageBundle(pageId) {
             if (!pageId) return;
             const page = (appData.notebooks?.items || [])
                 .flatMap(nb => nb.pages || [])
                 .find(pg => pg && pg.id === pageId);
-            const mediaIds = new Set();
-            let pgData = await getFileData('nbpage_' + pageId).catch(() => null);
-            let pageContent = null;
-            try { pageContent = pgData ? JSON.parse(pgData) : null; } catch (e) {}
-            if (!pageContent && page) pageContent = { strokes: [], texts: [], media: [], recognized: null };
-            if (pageContent) {
-                if (!pageContent.updatedAt) {
-                    pageContent.updatedAt = page?.updatedAt || page?.createdAt || new Date().toISOString();
-                }
-                if (page && (!page.updatedAt || syncTimestamp(pageContent.updatedAt) >
-                    syncTimestamp(page.updatedAt || page.createdAt))) {
-                    page.updatedAt = pageContent.updatedAt;
-                    saveData();
-                }
-                pgData = JSON.stringify(pageContent);
-                await saveFileData('nbpage_' + pageId, pgData);
-                await r2PutObject('notebooks/pages/nbpage_' + pageId, pgData, 'application/json');
-                (pageContent.media || []).forEach(m => { if (m.mediaId) mediaIds.add(m.mediaId); });
+            const pageKey = 'nbpage_' + pageId;
+            const cloudKey = 'notebooks/pages/' + pageKey;
+            const localRaw = await getFileData(pageKey).catch(() => null);
+            let localContent = r2ParseNotebookPageContent(localRaw);
+            const cloudRaw = await r2GetObjectWithTimeout(cloudKey, 5000);
+            let cloudContent = r2ParseNotebookPageContent(cloudRaw);
+
+            if (localRaw && !localContent) {
+                console.warn('[nb-sync] 本地笔记页正文损坏:', pageId);
             }
+            if (cloudRaw && !cloudContent) {
+                if (!localContent || r2NotebookPageContentScore(localContent) === 0) {
+                    throw new Error('[nb-sync] 云端笔记页正文损坏: ' + pageId);
+                }
+                console.warn('[nb-sync] 使用有效的本地正文修复云端损坏页:', pageId);
+            }
+
+            if (!localContent && !cloudContent) {
+                if (!page) return;
+                localContent = { strokes: [], texts: [], media: [], recognized: null };
+            }
+
+            const source = r2ChooseNotebookPageSource(localContent, cloudContent);
+            const pageContent = source === 'cloud' ? cloudContent : localContent;
+            if (!pageContent) return;
+            if (!pageContent.updatedAt && source === 'local') {
+                pageContent.updatedAt = page?.updatedAt || page?.createdAt || new Date().toISOString();
+            }
+            const pageJson = JSON.stringify(pageContent);
+            await saveFileData(pageKey, pageJson);
+
+            const contentTs = syncTimestamp(pageContent.updatedAt);
+            if (page && contentTs > syncTimestamp(page.updatedAt || page.createdAt)) {
+                page.updatedAt = pageContent.updatedAt;
+                saveData();
+            }
+
+            const cloudJson = cloudContent ? JSON.stringify(cloudContent) : null;
+            if (source === 'local' && pageJson !== cloudJson) {
+                await r2PutObject(cloudKey, pageJson, 'application/json');
+            }
+
+            const mediaIds = new Set();
+            (pageContent.media || []).forEach(m => { if (m.mediaId) mediaIds.add(m.mediaId); });
             if (page && page.bgImage) mediaIds.add(page.bgImage);
             for (const mid of mediaIds) {
-                const mData = await getFileData('nbmedia_' + mid).catch(() => null);
-                if (mData) await r2PutObject('notebooks/media/nbmedia_' + mid, mData, 'application/octet-stream');
+                const mediaKey = 'nbmedia_' + mid;
+                const mData = await getFileData(mediaKey).catch(() => null);
+                if (mData) {
+                    await r2PutObject('notebooks/media/' + mediaKey, mData, 'application/octet-stream');
+                } else {
+                    const cloudMedia = await r2GetObjectWithTimeout('notebooks/media/' + mediaKey, 5000);
+                    if (cloudMedia) await saveFileData(mediaKey, cloudMedia);
+                }
             }
         }
 
@@ -14980,9 +15023,16 @@
                         try {
                             const cloudPage = await r2GetObject('notebooks/pages/nbpage_' + page.id);
                             if (cloudPage) {
-                                pageJson = cloudPage;
-                                await saveFileData('nbpage_' + page.id, cloudPage);
-                                pages++;
+                                const localContent = r2ParseNotebookPageContent(pageJson);
+                                const cloudContent = r2ParseNotebookPageContent(cloudPage);
+                                if (cloudContent &&
+                                    r2ChooseNotebookPageSource(localContent, cloudContent) === 'cloud') {
+                                    pageJson = JSON.stringify(cloudContent);
+                                    await saveFileData('nbpage_' + page.id, pageJson);
+                                    pages++;
+                                } else if (!cloudContent) {
+                                    console.warn('[startup-sync] 云端笔记页正文损坏，保留本地:', page.id);
+                                }
                             }
                         } catch (e) { console.warn('[startup-sync] 拉取笔记页失败:', page.id, e); }
                     }
@@ -15303,7 +15353,11 @@
                 const retryableClassroomAction = ['recording_upload', 'classroom_upload',
                     'classroom_note_upload', 'classroom_delete', 'classroom_note_delete',
                     'recording_delete', 'classroom_folder_delete',
-                    'lecture_upload', 'abstract_upload', 'exercise_grading_commit'].includes(action);
+                    'lecture_upload', 'abstract_upload',
+                    'notebook_close', 'notebook_page_add', 'notebook_page_update',
+                    'notebook_page_delete', 'notebook_page_reorder', 'notebook_metadata_update',
+                    'notebook_review_add', 'notebook_review_update',
+                    'exercise_grading_commit'].includes(action);
                 if (retryableClassroomAction &&
                     (config.autoSyncEnabled || config.autoSyncOnChange) && Number(attempt || 0) < 8) {
                     const key = action + ':' + fileId;
@@ -30945,8 +30999,15 @@ ${paper.abstract ? i18n('prompt_abstract_original') + paper.abstract : ''}`;
                     try {
                         const cloud = await r2GetObject('notebooks/pages/nbpage_' + pageId);
                         if (cloud) {
-                            raw = cloud;
-                            await saveFileData('nbpage_' + pageId, cloud).catch(() => {});
+                            const localContent = r2ParseNotebookPageContent(raw);
+                            const cloudContent = r2ParseNotebookPageContent(cloud);
+                            if (cloudContent &&
+                                r2ChooseNotebookPageSource(localContent, cloudContent) === 'cloud') {
+                                raw = JSON.stringify(cloudContent);
+                                await saveFileData('nbpage_' + pageId, raw).catch(() => {});
+                            } else if (!cloudContent) {
+                                console.warn('[nb] 云端页面内容损坏，保留本地:', pageId);
+                            }
                         }
                     } catch (e) { /* 云端也没有 */ }
                 }

--- a/tests/cloud-sync-restore.test.js
+++ b/tests/cloud-sync-restore.test.js
@@ -114,7 +114,7 @@ async function checkStartup(html) {
     remote.notebooks.items[0].pages.push({ id: 'p2', updatedAt: remote.syncedAt });
     local.exercises.wrongByFolder.folder = [{ taskId: 'old-task', questions: [{ questionIndex: 0, score: 1 }] }];
     const h = harness(html, local, remote);
-    const page = (updatedAt, text) => JSON.stringify({ updatedAt, strokes: [], texts: [{ text }], media: [] });
+    const page = (updatedAt, text) => JSON.stringify({ updatedAt, strokes: [], texts: [{ text }], media: [], recognized: null });
     h.idb.set('nbpage_p1', page(local.syncedAt, 'OLD BACKUP PAGE'));
     h.idb.set('exercise_drawing_old-task_0', 'old local exercise image');
     h.cloud.set('notebooks/pages/nbpage_p1', page(remote.syncedAt, 'NEW CLOUD PAGE'));

--- a/tests/notebook-cloud-sync.test.js
+++ b/tests/notebook-cloud-sync.test.js
@@ -1,0 +1,146 @@
+// Run with: node tests/notebook-cloud-sync.test.js
+// Execute product declarations unchanged, with storage and R2 only in memory.
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const restoreTest = fs.readFileSync(path.join(__dirname, 'cloud-sync-restore.test.js'), 'utf8');
+const helperEnd = restoreTest.indexOf('async function checkImport');
+assert.ok(helperEnd > 0, 'existing restore harness is available');
+const { data, harness } = vm.runInNewContext(restoreTest.slice(0, helperEnd) + '\n({ data, harness })', { require });
+const OLD = '2026-09-01T00:00:00.000Z', NEW = '2026-09-10T00:00:00.000Z';
+const LOCAL_KEY = 'nbpage_p1', CLOUD_KEY = 'notebooks/pages/' + LOCAL_KEY;
+const ink = (at, id) => JSON.stringify({ updatedAt: at, strokes: [
+    { id, tool: 'pen', color: '#000000', w: 2, paths: [[[10, 20], [30, 40]]] }
+], texts: [], media: [], recognized: null });
+const notebook = (at, ids = ['p1']) => ({ items: [{ id: 'nb', updatedAt: at,
+    pages: ids.map(id => ({ id, createdAt: OLD, updatedAt: at })) }], reviews: [] });
+const pagePuts = h => h.calls.filter(call => call.startsWith('PUT notebooks/pages/'));
+const noErrors = h => assert.equal(h.errors.length, 0, JSON.stringify(h.errors));
+function setup(html, localRaw, cloudRaw, metadataAt = NEW) {
+    const local = data(true), remote = data(true);
+    local.notebooks = notebook(metadataAt);
+    remote.notebooks = notebook(metadataAt);
+    const h = harness(html, local, remote);
+    if (localRaw) h.idb.set(LOCAL_KEY, localRaw);
+    if (cloudRaw) h.cloud.set(CLOUD_KEY, cloudRaw);
+    return h;
+}
+async function checkEntrypoints(html) {
+    for (const [entrypoint, repair] of [['performAutoSync', false],
+        ['autoSyncFromR2OnStartup', false], ['autoSyncFromR2OnStartup', true]]) {
+        const local = data(true), remote = data(true);
+        remote.notebooks = notebook(NEW, ['p1', 'p2']);
+        // Exercise metadata repair triggered the notebook overwrite introduced by PR 92.
+        if (repair) local.exercises.wrongByFolder.folder = [{ taskId: 'old-task',
+            questions: [{ questionIndex: 0, score: 1 }] }];
+        const h = harness(html, local, remote);
+        if (repair) h.idb.set('exercise_drawing_old-task_0', 'existing local answer');
+        for (const id of ['p1', 'p2']) h.cloud.set('notebooks/pages/nbpage_' + id, ink(NEW, id));
+        for (let round = 0; round < 2; round++) {
+            await h.context[entrypoint]();
+            await h.drainTimers();
+            noErrors(h);
+            assert.equal(h.context.appData.notebooks.items[0].pages.length, 2);
+            for (const id of ['p1', 'p2']) {
+                assert.equal(h.cloud.get('notebooks/pages/nbpage_' + id), ink(NEW, id),
+                    entrypoint + ' preserves cloud ink');
+                assert.equal(h.idb.get('nbpage_' + id), ink(NEW, id), entrypoint + ' downloads ink');
+            }
+            assert.equal(pagePuts(h).length, 0, 'downloaded pages are not uploaded again');
+        }
+        if (repair) assert.ok(h.calls.includes('PUT metadata.json'), 'startup metadata repair ran');
+    }
+}
+async function checkBundles(html) {
+    for (const localRaw of [null, ink(OLD, 'old-local')]) {
+        const cloudRaw = ink(NEW, 'cloud');
+        const h = setup(html, localRaw, cloudRaw);
+        await h.context.r2SyncNotebookPageBundle('p1');
+        await h.context.r2SyncNotebookPageBundle('p1');
+        noErrors(h);
+        assert.equal(h.cloud.get(CLOUD_KEY), cloudRaw);
+        assert.equal(h.idb.get(LOCAL_KEY), cloudRaw, 'missing or stale local ink pulls newer cloud ink');
+        assert.equal(pagePuts(h).length, 0);
+    }
+    const localRaw = ink(NEW, 'local');
+    const h = setup(html, localRaw, ink(OLD, 'old-cloud'));
+    await h.context.r2SyncNotebookPageBundle('p1');
+    await h.context.r2SyncNotebookPageBundle('p1');
+    noErrors(h);
+    assert.equal(h.cloud.get(CLOUD_KEY), localRaw, 'newer local ink uploads');
+    assert.equal(pagePuts(h).length, 1, 'unchanged ink uploads only once');
+
+    const blank = setup(html, null, null);
+    await blank.context.r2SyncNotebookPageBundle('p1');
+    await blank.context.r2SyncNotebookPageBundle('p1');
+    noErrors(blank);
+    assert.deepEqual(JSON.parse(blank.cloud.get(CLOUD_KEY)),
+        { strokes: [], texts: [], media: [], recognized: null, updatedAt: NEW },
+        'a newly created empty page still uploads');
+    assert.equal(pagePuts(blank).length, 1);
+
+    const legacyContent = JSON.parse(ink(NEW, 'legacy'));
+    delete legacyContent.recognized;
+    const legacyRaw = JSON.stringify(legacyContent);
+    const legacy = setup(html, null, legacyRaw);
+    await legacy.context.r2SyncNotebookPageBundle('p1');
+    await legacy.context.r2SyncNotebookPageBundle('p1');
+    noErrors(legacy);
+    assert.deepEqual(JSON.parse(legacy.idb.get(LOCAL_KEY)), { ...legacyContent, recognized: null },
+        'old notebook bodies normalize the missing recognized field');
+    assert.equal(legacy.cloud.get(CLOUD_KEY), legacyRaw);
+    assert.equal(pagePuts(legacy).length, 0, 'schema normalization does not trigger repeated uploads');
+}
+async function checkPullAndOpen(html) {
+    for (const read of ['r2PullNotebookAssetsFromCloud', 'nbLoadPageContent']) {
+        for (const newerLocal of [false, true]) {
+            const localRaw = ink(newerLocal ? NEW : OLD, 'local');
+            const cloudRaw = ink(newerLocal ? OLD : NEW, 'cloud');
+            // A newer page index must not make an older cloud body replace newer local ink.
+            const h = setup(html, localRaw, cloudRaw, '2026-09-11T00:00:00.000Z');
+            const result = await h.context[read](...(read === 'nbLoadPageContent' ? ['p1'] : []));
+            noErrors(h);
+            assert.ok(h.calls.includes('GET ' + CLOUD_KEY), read + ' checks cloud content');
+            const expected = newerLocal ? localRaw : cloudRaw;
+            assert.equal(h.idb.get(LOCAL_KEY), expected, read + ' keeps the newer body');
+            assert.equal(h.cloud.get(CLOUD_KEY), cloudRaw);
+            if (read === 'nbLoadPageContent') assert.equal(JSON.stringify(result), expected);
+            assert.equal(pagePuts(h).length, 0);
+        }
+    }
+}
+async function checkRetry(html) {
+    const localRaw = ink(NEW, 'local'), cloudRaw = ink(OLD, 'cloud');
+    const h = setup(html, localRaw, cloudRaw);
+    const get = h.context.r2GetObject, timer = h.context.setTimeout, delays = [];
+    let failed = false;
+    h.context.r2GetObject = async (key, options) => {
+        if (key === CLOUD_KEY && !failed) { failed = true; throw new Error('transient notebook GET failure'); }
+        return get(key, options);
+    };
+    h.context.setTimeout = (fn, delay) => { delays.push(delay); return timer(fn, delay); };
+    await h.context.triggerSyncOnFileChange('p1', 'notebook_page_update');
+    assert.equal(h.cloud.get(CLOUD_KEY), cloudRaw, 'failed cloud read cannot overwrite cloud ink');
+    assert.equal(h.idb.get(LOCAL_KEY), localRaw, 'failed cloud read preserves local ink');
+    assert.equal(pagePuts(h).length, 0);
+    assert.equal(h.errors.length, 1);
+    assert.match(h.errors[0], /transient notebook GET failure/);
+    assert.deepEqual(delays, [750], 'existing retry backoff schedules the notebook update');
+    assert.equal(h.context.r2ClassroomRetryTimers.size, 1);
+    await h.drainTimers();
+    assert.equal(h.errors.length, 1, 'retry succeeds without another error');
+    assert.equal(h.cloud.get(CLOUD_KEY), localRaw, 'retry publishes the newer local ink');
+    assert.equal(pagePuts(h).length, 1);
+    assert.equal(h.context.r2ClassroomRetryTimers.size, 0, 'successful retry clears its timer');
+}
+(async () => {
+    for (const file of ['app/src/main/assets/www/index.html', 'docs/index.html']) {
+        const html = fs.readFileSync(path.join(__dirname, '..', file), 'utf8');
+        await checkEntrypoints(html);
+        await checkBundles(html);
+        await checkPullAndOpen(html);
+        await checkRetry(html);
+        console.log(file + ': notebook startup, periodic sync, conflicts, blank pages and retry passed');
+    }
+})().catch(error => { console.error(error); process.exitCode = 1; });


### PR DESCRIPTION
其他设备拿到笔记页数后，本地尚未下载的页面会被同步为空白正文，覆盖云端笔迹。本 PR 仅恢复 PR #73 合并前 `307a652474d9809cd888fcebae3f2626fbe231a5` 已有的笔记云同步逻辑。

6 个笔记正文解析、比较、同步及读取函数与该历史版本逐字一致；按旧版移除定时同步中绕过正文比较的重复笔记上传，并恢复原有 8 个笔记失败重试动作。讲义、课堂、习题、通用元数据发布、笔记输入和本地保存逻辑保持现状；已通过逐字范围比对。Android 与 PWA 同步更新。

验证：新增笔记同步回归检查在两份 HTML 上通过，覆盖只有目录时恢复云端笔迹、重复同步、新旧正文互传、新建空白页、旧格式正文和失败重试。使用修复前 main 的原始函数做负对照，检查正确失败于云端笔迹被清空。现有备份恢复、ZIP 导入、笔记输入、原生选区、BOOX 回放检查，以及脚本语法、双端一致性和 diff 检查通过。既有备份测试仅给笔记样例补齐 recognized:null 默认字段，断言保持不变。

验证使用实际页面函数与内存存储、网络替身，未访问用户云数据或进行真机同步。新增检查已接入现有 APK CI。
